### PR TITLE
Fixed mixin with Underscore.

### DIFF
--- a/underscore.date.js
+++ b/underscore.date.js
@@ -387,7 +387,7 @@
     // Integrate with Underscore.js
     } else {
         if (this._ !== undefined) {
-            this._.mixin(_date);
+            this._.mixin({date: _date});
         }
         this._date = _date;
     }


### PR DESCRIPTION
Underscore's mixin fn wants a hash that also names the mixin.
