### PR TITLE
Fix for moment not working under browserify

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -10,7 +10,7 @@
     var moment,
         round = Math.round,
         languages = {},
-        isNode = (typeof window === 'undefined' && typeof module !== 'undefined'),
+        isNode = (typeof module !== 'undefined'),
         paramsToParse = 'months|monthsShort|weekdays|weekdaysShort|relativeTime|ordinal'.split('|'),
         i,
         shortcuts = 'Month|Date|Hours|Minutes|Seconds'.split('|');


### PR DESCRIPTION
Small fix to the NodeJS detection to make the module work when run client-side using browserify.

I think the way underscore does its client/server-side check best, but didn't want to make that big a change.
