### PR TITLE
setters - falsey values

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -442,7 +442,7 @@
     // helper for adding shortcuts
     function makeShortcut(name, key) {
         moment.fn[name] = function (input) {
-            if (input) {
+            if (input != null) {
                 this._d['set' + key](input);
                 return this;
             } else {

--- a/test/date.js
+++ b/test/date.js
@@ -12,7 +12,7 @@ if (typeof window === 'undefined') {
 /**************************************************
   Tests
  *************************************************/
- 
+
 
 module("create");
 
@@ -225,6 +225,14 @@ test("setters", 7, function() {
     equal(a.hours(), 6, 'hour');
     equal(a.minutes(), 7, 'minute');
     equal(a.seconds(), 8, 'second');
+});
+
+test("setters - falsey values", 1, function() {
+    var a = moment();
+    // ensure minutes wasn't coincidentally 0 already
+    a.minutes(1);
+    a.minutes(0);
+    equal(a.minutes(), 0, 'falsey value');
 });
 
 test("chaining setters", 7, function() {


### PR DESCRIPTION
When using setters with falsey values (e.g. `0`) the getter is called instead.  This is fixed by a null comparison to use the setter for anything but `null` and `undefined`.
