### PR TITLE
Fixed 12:00 am bug

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -261,6 +261,10 @@
         if (isPm && inArray[3] < 12) {
             inArray[3] += 12;
         }
+        // if is 12 am, change hours to 0
+        if (! isPm && inArray[3] === 12) {
+            inArray[3] = 0;
+        }
         return dateFromArray(inArray);
     }
 

--- a/sitesrc/js/unit-tests.js
+++ b/sitesrc/js/unit-tests.js
@@ -71,6 +71,8 @@ test("string with format", 13, function() {
             ['DD-MM-YYYY h:m:s',    '12-02-1999 2:45:10'],
             ['DD-MM-YYYY h:m:s a',  '12-02-1999 2:45:10 am'],
             ['DD-MM-YYYY h:m:s a',  '12-02-1999 2:45:10 pm'],
+            ['h:mm a',              '12:00 pm'],
+            ['h:mm a',              '12:00 am'],
             ['YYYY-MM-DDTHH:mm:ss', '2011-11-11T11:11:11'],
             ['MM-DD-YYYY \\M',          '12-02-1999 M']
         ],


### PR DESCRIPTION
The string '12:00 am' was being parsed as 12:00 pm.  I fixed that and
added a test.

This was the bug:

```
moment('12:00 am', 'h:mm a').hours() == moment('12:00 pm', 'h:mm a').hours()
```
