### PR TITLE
fixes format for negative timezone offsets "Z" and "ZZ"

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -175,9 +175,9 @@
             case 'z' :
                 return (date.toString().match(timezoneRegex) || [''])[0].replace(nonuppercaseLetters, '');
             case 'Z' :
-                return (currentZone > 0 ? '+' : '-') + leftZeroFill(~~(currentZone / 60), 2) + ':' + leftZeroFill(~~(currentZone % 60), 2);
+                return (currentZone > 0 ? '+' : '-') + leftZeroFill(~~(Math.abs(currentZone) / 60), 2) + ':' + leftZeroFill(~~(Math.abs(currentZone) % 60), 2);
             case 'ZZ' :
-                return (currentZone > 0 ? '+' : '-') + leftZeroFill(~~(10 * currentZone / 6), 4);
+                return (currentZone > 0 ? '+' : '-') + leftZeroFill(~~(10 * Math.abs(currentZone) / 6), 4);
             // LONG DATES
             case 'L' :
             case 'LL' :


### PR DESCRIPTION
The last two "format timezone" tests were broken here in Switzerland.

E.g. Z returned -1:00 instead of -01:00
