### PR TITLE
Diff shouldn't be rounded.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -543,7 +543,7 @@
                     val === 'weeks' ? diff / 6048e5 : // 1000 * 60 * 60 * 24 * 7
                     val === 'days' ? diff / 3600 : diff;
             }
-            return asFloat ? output : round(output);
+            return asFloat ? output : Math.ceil(output);
         },
 
         from : function (time, withoutSuffix) {


### PR DESCRIPTION
If I compare `_.date("2012-01-13", "YYYY-MM-DD").diff(_.date(), 'days')` and today is `2012-01-13 12:00:01` the diff is above 0.5 so it says that there is one day difference.
