### PR TITLE
Incorrect parsing when passing string with format at 12 Noon.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -265,9 +265,12 @@
                 break;
             // 24 HOUR
             case 'H' :
-                // fall through to hh
+                // fall through to HH
             case 'HH' :
-                // fall through to hh
+    			isPm = ~~input >= 12 ? true : false;
+				inArray[3] = ~~input;
+				break;
+			// 12 HOUR
             case 'h' :
                 // fall through to hh
             case 'hh' :


### PR DESCRIPTION
moment('2012-01-25T11:00:00', 'YYYY-MM-DDTHH:mm:ss').format('HH') returns '11'
moment('2012-01-25T12:00:00', 'YYYY-MM-DDTHH:mm:ss').format('HH') returns '0'
moment('2012-01-25T13:00:00', 'YYYY-MM-DDTHH:mm:ss').format('HH') returns '13'
