### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "moment",
         "date"
     ],
-    "main": "./moment",
+    "main": "./moment.js",
     "engines": {
         "node": "*"
     },
@@ -24,13 +24,13 @@
             "type" : "MIT"
         }
     ],
-    "dev-dependencies" : [
-        "uglify-js",
-        "jshint",
-        "gzip",
-        "jade",
-        "clean-css",
-        "qunit",
-        "bunker"
-    ]
+    "dev-dependencies" : {
+        "uglify-js" : "latest",
+        "jshint"    : "latest",
+        "gzip"      : "latest",
+        "jade"      : "latest",
+        "clean-css" : "latest",
+        "qunit"     : "latest",
+        "bunker"    : "latest"
+    }
 }


### PR DESCRIPTION
- Added `.js` suffix to `"main" : "./money"` in order to avoid [this](https://github.com/josscrowcroft/money.js/pull/7) type of npm warning
- devDependencies should be hash instead of array since npm throws warning about that. `npm WARN moment@1.4.0 devDependencies field should be hash of <name>:<version-range> pairs`
