### PR TITLE
Added a "duration-to-humanized-output" converter

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -556,9 +556,9 @@
             return this;
         },
 
-        formattedDuration : function (input, duration, withoutSuffix) {
-            var start = moment();
-            var end = moment(start).add(input, duration);
+        humanizeDuration : function (input, duration, withoutSuffix) {
+            var start = moment(),
+            end = moment(start).add(input, duration);
             return end.from(start, withoutSuffix);
         },
 

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -1,16 +1,16 @@
 var moment = require("../../moment");
 
-// #formatted_duration translates a given integer into a relative-time format
+// #humanize_duration translates a given integer into a relative-time format
 // examples:
-//   moment().formatted_duration('years',4); // 'in 4 years'
-//   moment().formatted_duration('seconds',59); // 'in a minute'
-//   moment().formatted_duration('seconds',59,true); // 'a minute'
-exports.formatted_duration = {
+//   moment().humanize_duration('years',4); // 'in 4 years'
+//   moment().humanize_duration('seconds',59); // 'in a minute'
+//   moment().humanize_duration('seconds',59,true); // 'a minute'
+exports.humanize_duration = {
     "a relative-time formatted duration" : function(test) {
-        test.expect(2);
-        test.equal(moment().formattedDuration('minutes',2,true), '2 minutes', 'output formatted duration');
-        test.equal(moment().formattedDuration('minutes',2), 'in 2 minutes', 'output formatted duration');
-        test.equal(moment().formattedDuration('minutes',20000), 'in 14 days', 'output formatted duration');
+        test.expect(3);
+        test.equal(moment().humanizeDuration('minutes',2,true), '2 minutes', 'output formatted duration');
+        test.equal(moment().humanizeDuration('minutes',2), 'in 2 minutes', 'output formatted duration');
+        test.equal(moment().humanizeDuration('minutes',20000), 'in 14 days', 'output formatted duration');
         test.done();
     }
 };


### PR DESCRIPTION
Added a relative-time converter, takes in units, a duration, and an optional suffix remover boolean, and returns humanized output, e.g. moment().formatted_duration('minutes',20000,true); // "14 days"
