### PR TITLE
Fixing french locale Aujourd'hui instead of Ajourd'hui

### DIFF
--- a/lang/fr.js
+++ b/lang/fr.js
@@ -18,7 +18,7 @@
                 pm : 'pm'
             },
             calendar : {
-                sameDay: "[Ajourd'hui à] LT",
+                sameDay: "[Aujourd'hui à] LT",
                 nextDay: '[Demain à] LT',
                 nextWeek: 'dddd [à] LT',
                 lastDay: '[Hier à] LT',

--- a/test/lang/fr.js
+++ b/test/lang/fr.js
@@ -180,11 +180,11 @@ exports["lang:fr"] = {
     
         var a = moment().hours(2).minutes(0).seconds(0);
     
-        test.equal(moment(a).calendar(),                     "Ajourd'hui à 02:00",     "today at the same time");
-        test.equal(moment(a).add({ m: 25 }).calendar(),      "Ajourd'hui à 02:25",     "Now plus 25 min");
-        test.equal(moment(a).add({ h: 1 }).calendar(),       "Ajourd'hui à 03:00",     "Now plus 1 hour");
+        test.equal(moment(a).calendar(),                     "Aujourd'hui à 02:00",    "today at the same time");
+        test.equal(moment(a).add({ m: 25 }).calendar(),      "Aujourd'hui à 02:25",    "Now plus 25 min");
+        test.equal(moment(a).add({ h: 1 }).calendar(),       "Aujourd'hui à 03:00",    "Now plus 1 hour");
         test.equal(moment(a).add({ d: 1 }).calendar(),       "Demain à 02:00",         "tomorrow at the same time");
-        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "Ajourd'hui à 01:00",     "Now minus 1 hour");
+        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "Aujourd'hui à 01:00",    "Now minus 1 hour");
         test.equal(moment(a).subtract({ d: 1 }).calendar(),  "Hier à 02:00",           "yesterday at the same time");
         test.done();
     },


### PR DESCRIPTION
The french word for today is not correct.

http://translate.google.fr/#en|fr|today%0A
