### PR TITLE
Add `moment.isMoment()`

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -561,6 +561,11 @@
         }
     });
 
+    // compare moment object
+    moment.isMoment = function (obj) {
+        return obj instanceof Moment;
+    };
+
     // shortcut for prototype
     moment.fn = Moment.prototype = {
 

--- a/test/moment/is_moment.js
+++ b/test/moment/is_moment.js
@@ -1,0 +1,27 @@
+var moment = require('../../moment');
+
+exports.is_moment = {
+    "is moment object": function(test) {
+        test.expect(11);
+
+        var MyObj = function() {};
+        MyObj.prototype.native = function() {
+            return new Date();
+        }
+
+        test.ok(moment.isMoment(moment()), 'simple moment object');
+        test.ok(moment.isMoment(moment('invalid date')), 'invalid moment object');
+
+        test.ok(!moment.isMoment(new MyObj()), 'myObj is not moment object');
+        test.ok(!moment.isMoment(moment), 'moment function is not moment object');
+        test.ok(!moment.isMoment(new Date()), 'date object is not moment object');
+        test.ok(!moment.isMoment(Object), 'Object is not moment object');
+        test.ok(!moment.isMoment('foo'), 'string is not moment object');
+        test.ok(!moment.isMoment(1), 'number is not moment object');
+        test.ok(!moment.isMoment(NaN), 'NaN is not moment object');
+        test.ok(!moment.isMoment(null), 'null is not moment object');
+        test.ok(!moment.isMoment(undefined), 'undefined is not moment object');
+
+        test.done();
+    }
+};


### PR DESCRIPTION
The problem is that how to compare with a moment object is not prepared. It is possible if it writes in this way.

```
function isMoment(obj) {
    return obj && typeof obj.native === 'function' && obj.native() instanceof Date;
}
```

However, this function is not exact.

```
var myObj = {
    native: function() { return new Date }
};

isMoment(myObj); //=> true
```

This patch solves this. For example.

```
var m = moment();
moment.isMoment(m); //=> true
moment.isMoment(myObj); //=> false
```

Thanks.
