### PR TITLE
Fixed weekday returned when isUTC date

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -668,7 +668,7 @@
         },
 
         day : function (input) {
-            var day = this._d.getDay();
+            var day = this._isUTC ? this._d.getUTCDay() : this._d.getDay();
             return input == null ? day :
                 this.add({ d : input - day });
         },


### PR DESCRIPTION
Before:

```
moment(1332291600000).utc().add("minutes", -3 * 60).format("dddd D")
//=> Wednesday 20`
```

After:

```
moment(1332291600000).utc().add("minutes", -3 * 60).format("dddd D")
//=> Tuesday 20`
```

---

Date.prototype.toString = Wed Mar 21 2012 00:22:46 GMT+0530 (IST)
Date.prototype.toLocaleString = Wed Mar 21 2012 00:22:46 GMT+0530 (IST)
Date.prototype.getTimezoneOffset = -330
navigator.userAgent = Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.79 Safari/535.11
