### PR TITLE
Add support for creation with unix timestamp in seconds

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -600,7 +600,7 @@
         },
 
         unixValueOf : function () {
-            return parseInt(this.valueOf() / 1000, 10);
+            return round(this.valueOf() / 1000);
         },
 
         local : function () {


### PR DESCRIPTION
This is something that we wanted to avoid doing *1000 on every single UTC timestamp we receive (in seconds).

Figured I would suggest it as I think it makes a nicer API.

I can look into writing tests/docs for it first if you want.
