### PR TITLE
fixed ordering of longDateFormat for traditional and simplified Chinese

### DIFF
--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -5,11 +5,11 @@
             weekdays : "星期日_星期一_星期二_星期三_星期四_星期五_星期六".split("_"),
             weekdaysShort : "周日_周一_周二_周三_周四_周五_周六".split("_"),
             longDateFormat : {
-                LT : "h:mm A",
-                L : "DD/MM/YYYY",
-                LL : "D MMMM YYYY",
-                LLL : "D MMMM YYYY LT",
-                LLLL : "dddd, D MMMM YYYY LT"
+                LT : "Ah点mm",
+                L : "YYYY年MMMMD日",
+                LL : "YYYY年MMMMD日",
+                LLL : "YYYY年MMMMD日LT",
+                LLLL : "YYYY年MMMMD日ddddLT"
             },
             meridiem : {
                 AM : '上午',
@@ -18,11 +18,11 @@
                 pm : '下午'
             },
             calendar : {
-                sameDay : '[今天] LT',
-                nextDay : '[明天] LT',
-                nextWeek : '[下]dddd LT', 
-                lastDay : '[昨天] LT',
-                lastWeek : '[上]dddd LT', 
+                sameDay : '[今天]LT',
+                nextDay : '[明天]LT',
+                nextWeek : '[下]ddddLT', 
+                lastDay : '[昨天]LT',
+                lastWeek : '[上]ddddLT', 
                 sameElse : 'L'
             },
             relativeTime : {

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -5,11 +5,11 @@
             weekdays : "星期日_星期一_星期二_星期三_星期四_星期五_星期六".split("_"),
             weekdaysShort : "週日_週一_週二_週三_週四_週五_週六".split("_"),
             longDateFormat : {
-                LT : "h:mm A",
-                L : "DD/MM/YYYY",
-                LL : "D MMMM YYYY",
-                LLL : "D MMMM YYYY LT",
-                LLLL : "dddd, D MMMM YYYY LT"
+                LT : "Ah點mm",
+                L : "YYYY年MMMMD日",
+                LL : "YYYY年MMMMD日",
+                LLL : "YYYY年MMMMD日LT",
+                LLLL : "YYYY年MMMMD日ddddLT"
             },
             meridiem : {
                 AM : '上午',
@@ -18,11 +18,11 @@
                 pm : '下午'
             },
             calendar : {
-                sameDay : '[今天] LT',
-                nextDay : '[明天] LT',
-                nextWeek : '[下]dddd LT',
-                lastDay : '[昨天] LT',
-                lastWeek : '[上]dddd LT',
+                sameDay : '[今天]LT',
+                nextDay : '[明天]LT',
+                nextWeek : '[下]ddddLT',
+                lastDay : '[昨天]LT',
+                lastWeek : '[上]ddddLT',
                 sameElse : 'L'
             },
             relativeTime : {

--- a/test/lang/zh-cn.js
+++ b/test/lang/zh-cn.js
@@ -46,10 +46,10 @@ exports["lang:zh-cn"] = {
                 ['s ss',                               '50 50'],
                 ['a A',                                '下午 下午'],
                 ['t\\he DDDo \\d\\ay of t\\he ye\\ar', 'the 45 day of the year'],
-                ['L',                                  '14/02/2010'],
-                ['LL',                                 '14 二月 2010'],
-                ['LLL',                                '14 二月 2010 3:25 下午'],
-                ['LLLL',                               '星期日, 14 二月 2010 3:25 下午']
+                ['L',                                  '2010年二月14日'],
+                ['LL',                                 '2010年二月14日'],
+                ['LLL',                                '2010年二月14日下午3点25'],
+                ['LLLL',                               '2010年二月14日星期日下午3点25']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;
@@ -147,12 +147,12 @@ exports["lang:zh-cn"] = {
 
         var a = moment().hours(2).minutes(0).seconds(0);
 
-        test.equal(moment(a).calendar(),                     "今天 2:00 上午",     "today at the same time");
-        test.equal(moment(a).add({ m: 25 }).calendar(),      "今天 2:25 上午",     "Now plus 25 min");
-        test.equal(moment(a).add({ h: 1 }).calendar(),       "今天 3:00 上午",     "Now plus 1 hour");
-        test.equal(moment(a).add({ d: 1 }).calendar(),       "明天 2:00 上午",     "tomorrow at the same time");
-        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "今天 1:00 上午",     "Now minus 1 hour");
-        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "昨天 2:00 上午",     "yesterday at the same time");
+        test.equal(moment(a).calendar(),                     "今天上午2点00",     "today at the same time");
+        test.equal(moment(a).add({ m: 25 }).calendar(),      "今天上午2点25",     "Now plus 25 min");
+        test.equal(moment(a).add({ h: 1 }).calendar(),       "今天上午3点00",     "Now plus 1 hour");
+        test.equal(moment(a).add({ d: 1 }).calendar(),       "明天上午2点00",     "tomorrow at the same time");
+        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "今天上午1点00",     "Now minus 1 hour");
+        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "昨天上午2点00",     "yesterday at the same time");
         test.done();
     },
 
@@ -165,11 +165,11 @@ exports["lang:zh-cn"] = {
 
         for (i = 2; i < 7; i++) {
             m = moment().add({ d: i });
-            test.equal(m.calendar(),       m.format('[下]dddd LT'),  "Today + " + i + " days current time");
+            test.equal(m.calendar(),       m.format('[下]ddddLT'),  "Today + " + i + " days current time");
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[下]dddd LT'),  "Today + " + i + " days beginning of day");
+            test.equal(m.calendar(),       m.format('[下]ddddLT'),  "Today + " + i + " days beginning of day");
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[下]dddd LT'),  "Today + " + i + " days end of day");
+            test.equal(m.calendar(),       m.format('[下]ddddLT'),  "Today + " + i + " days end of day");
         }
         test.done();
     },
@@ -180,11 +180,11 @@ exports["lang:zh-cn"] = {
 
         for (i = 2; i < 7; i++) {
             m = moment().subtract({ d: i });
-            test.equal(m.calendar(),       m.format('[上]dddd LT'),  "Today - " + i + " days current time");
+            test.equal(m.calendar(),       m.format('[上]ddddLT'),  "Today - " + i + " days current time");
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[上]dddd LT'),  "Today - " + i + " days beginning of day");
+            test.equal(m.calendar(),       m.format('[上]ddddLT'),  "Today - " + i + " days beginning of day");
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[上]dddd LT'),  "Today - " + i + " days end of day");
+            test.equal(m.calendar(),       m.format('[上]ddddLT'),  "Today - " + i + " days end of day");
         }
         test.done();
     },

--- a/test/lang/zh-tw.js
+++ b/test/lang/zh-tw.js
@@ -46,10 +46,10 @@ exports["lang:zh-tw"] = {
                 ['s ss',                               '50 50'],
                 ['a A',                                '下午 下午'],
                 ['t\\he DDDo \\d\\ay of t\\he ye\\ar', 'the 45 day of the year'],
-                ['L',                                  '14/02/2010'],
-                ['LL',                                 '14 二月 2010'],
-                ['LLL',                                '14 二月 2010 3:25 下午'],
-                ['LLLL',                               '星期日, 14 二月 2010 3:25 下午']
+                ['L',                                  '2010年二月14日'],
+                ['LL',                                 '2010年二月14日'],
+                ['LLL',                                '2010年二月14日下午3點25'],
+                ['LLLL',                               '2010年二月14日星期日下午3點25']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;
@@ -147,12 +147,12 @@ exports["lang:zh-tw"] = {
 
         var a = moment().hours(2).minutes(0).seconds(0);
 
-        test.equal(moment(a).calendar(),                     "今天 2:00 上午",     "today at the same time");
-        test.equal(moment(a).add({ m: 25 }).calendar(),      "今天 2:25 上午",     "Now plus 25 min");
-        test.equal(moment(a).add({ h: 1 }).calendar(),       "今天 3:00 上午",     "Now plus 1 hour");
-        test.equal(moment(a).add({ d: 1 }).calendar(),       "明天 2:00 上午",     "tomorrow at the same time");
-        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "今天 1:00 上午",     "Now minus 1 hour");
-        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "昨天 2:00 上午",     "yesterday at the same time");
+        test.equal(moment(a).calendar(),                     "今天上午2點00",     "today at the same time");
+        test.equal(moment(a).add({ m: 25 }).calendar(),      "今天上午2點25",     "Now plus 25 min");
+        test.equal(moment(a).add({ h: 1 }).calendar(),       "今天上午3點00",     "Now plus 1 hour");
+        test.equal(moment(a).add({ d: 1 }).calendar(),       "明天上午2點00",     "tomorrow at the same time");
+        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "今天上午1點00",     "Now minus 1 hour");
+        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "昨天上午2點00",     "yesterday at the same time");
         test.done();
     },
 
@@ -165,11 +165,11 @@ exports["lang:zh-tw"] = {
 
         for (i = 2; i < 7; i++) {
             m = moment().add({ d: i });
-            test.equal(m.calendar(),       m.format('[下]dddd LT'),  "Today + " + i + " days current time");
+            test.equal(m.calendar(),       m.format('[下]ddddLT'),  "Today + " + i + " days current time");
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[下]dddd LT'),  "Today + " + i + " days beginning of day");
+            test.equal(m.calendar(),       m.format('[下]ddddLT'),  "Today + " + i + " days beginning of day");
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[下]dddd LT'),  "Today + " + i + " days end of day");
+            test.equal(m.calendar(),       m.format('[下]ddddLT'),  "Today + " + i + " days end of day");
         }
         test.done();
     },
@@ -180,11 +180,11 @@ exports["lang:zh-tw"] = {
 
         for (i = 2; i < 7; i++) {
             m = moment().subtract({ d: i });
-            test.equal(m.calendar(),       m.format('[上]dddd LT'),  "Today - " + i + " days current time");
+            test.equal(m.calendar(),       m.format('[上]ddddLT'),  "Today - " + i + " days current time");
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[上]dddd LT'),  "Today - " + i + " days beginning of day");
+            test.equal(m.calendar(),       m.format('[上]ddddLT'),  "Today - " + i + " days beginning of day");
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[上]dddd LT'),  "Today - " + i + " days end of day");
+            test.equal(m.calendar(),       m.format('[上]ddddLT'),  "Today - " + i + " days end of day");
         }
         test.done();
     },


### PR DESCRIPTION
In Chinese, the dates are always expressed in a specific order.  It goes from biggest container to smallest:

```
Year > Month > Day of Month > Day of Week > Meridiem (sort of) > Hour > Minute > Second
```

I updated the `longDateFormat` definition in both of the Chinese language files.  I also changed the `:` to a `点（點）`, but that is not related to ordering error.  Sorry for combining the commits.
