### PR TITLE
A grammatical change 

### DIFF
--- a/lang/sv.js
+++ b/lang/sv.js
@@ -16,7 +16,7 @@
                 nextDay: '[Imorgon klockan] LT',
                 lastDay: '[Igår klockan] LT',
                 nextWeek: 'dddd [klockan] LT',
-                lastWeek: '[Förra] dddd [en klockan] LT',
+                lastWeek: '[Förra] dddd[en klockan] LT',
                 sameElse: 'L'
             },
             relativeTime : {


### PR DESCRIPTION
I took out the space between dddd AND [en klockan] in the sentence: 
lastWeek: '[Förra] dddd[en klockan] LT',

previously: lastWeek: '[Förra] dddd [en klockan] LT',
Because dddd refers to the name of the day AND [en... to the specific day, e.g. "Förra tisdagen klockan 12:00". tisdag + en needs to be concatenated to get it grammatically correct.
