### PR TITLE
Fix for issue 261.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -614,7 +614,7 @@
         },
 
         diff : function (input, val, asFloat) {
-            var inputMoment = moment(input),
+            var inputMoment = (moment._isUTC === undefined) ? moment(input) : input,
                 zoneDiff = (this.zone() - inputMoment.zone()) * 6e4,
                 diff = this._d - inputMoment._d - zoneDiff,
                 year = this.year() - inputMoment.year(),


### PR DESCRIPTION
It appears when you are working with two moment objects and you take the diff, the input moment's _isUTC is ignored when you parse the input into inputMoment. I've done a check to see if it looks like a moment object (by checking the _isUTC to see if it is defined) and if it is, then it just copies the input rather than parsing it. I think it should work fine on regular date objects as there is no _isUTC member.
