### PR TITLE
problem with eod() and UTC date

### DIFF
--- a/test/moment/sod_eod.js
+++ b/test/moment/sod_eod.js
@@ -27,8 +27,8 @@ exports.eod_sod = {
         test.equal(m.seconds(), 59, "set the seconds"); 
         test.equal(m.milliseconds(), 999, "set the seconds");
 
-	var m2 = moment.utc(new Date(2011, 1, 2, 3, 4, 5, 6));
-	test.equal(m2.eod(), m2.hours(23).minutes(59).seconds(59).milliseconds(999));
+        var m2 = moment.utc(new Date(2011, 1, 2, 3, 4, 5, 6));
+        test.equal(m2.eod(), m2.hours(23).minutes(59).seconds(59).milliseconds(999));
 
         test.done();
     }


### PR DESCRIPTION
Hi,

I think there is a problem with how eod() handle UTC formatted date. I use the version bundled with Kalendae a JS calendar widget.

In the documentation it's written:

> Set the time to the end of the day.
> 
> moment().eod(); // set the time to 11:59:59.999 pm tonight
> This is essentially the same as the following.
> 
> moment().hours(23).minutes(59).seconds(59).milliseconds(999);

But when you use eod(), the date is converted to localtime.
ex: 

> moment.utc("03-07-2012","MM-DD-YYYY").eod().toString()
> "Wed Mar 07 2012 23:59:59 GMT+0100 (CET)"
> Kalendae.moment.utc("03-07-2012","MM-DD-YYYY").hours(23).minutes(59).seconds(59).milliseconds(999).toString()
> "Thu Mar 08 2012 00:59:59 GMT+0100 (CET)"

I've created a unit test to verify the behavior. 

regards

PS: Thanks for this great lib
