### PR TITLE
Removed formatting dots from Dutch month/weekday abbreviations.

### DIFF
--- a/lang/nl.js
+++ b/lang/nl.js
@@ -1,9 +1,9 @@
 (function () {
     var lang = {
             months : "januari_februari_maart_april_mei_juni_juli_augustus_september_oktober_november_december".split("_"),
-            monthsShort : "jan._feb._mar._apr._mei._jun._jul._aug._sep._okt._nov._dec.".split("_"),
+            monthsShort : "jan_feb_mar_apr_mei_jun_jul_aug_sep_okt_nov_dec".split("_"),
             weekdays : "zondag_maandag_dinsdag_woensdag_donderdag_vrijdag_zaterdag".split("_"),
-            weekdaysShort : "zo._ma._di._wo._do._vr._za.".split("_"),
+            weekdaysShort : "zo_ma_di_wo_do_vr_za".split("_"),
             longDateFormat : { 
                 LT : "HH:mm",
                 L : "DD-MM-YYYY",


### PR DESCRIPTION
This allows for custom formats such as 'D-MMM-YYYY'. Current code gives f.e. '23-jun.-2012' while '23-jun-2012' is expected/preferred.
