### PR TITLE
Remove ordinal from TR translations

### DIFF
--- a/lang/tr.js
+++ b/lang/tr.js
@@ -34,13 +34,7 @@
                 y : "bir yıl",
                 yy : "%d yıl"
             },
-            ordinal : function (number) {
-                var b = number % 10;
-                return (~~ (number % 100 / 10) === 1) ? 'th' :
-                    (b === 1) ? 'st' :
-                    (b === 2) ? 'nd' :
-                    (b === 3) ? 'rd' : 'th';
-            }
+            ordinal : function (number) { return ''; }
         };
 
     // Node


### PR DESCRIPTION
Turkish language do not use ordinal suffixes for any date patterns so removed that function from TR translations file.
