### PR TITLE
Establish the root object, `window` in the browser, or `global` on the server.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1081,7 +1081,9 @@
     /*global ender:false */
     if (typeof ender === 'undefined') {
         // here, `this` means `window` in the browser, or `global` on the server
-        this.moment = moment;
+        // add `moment` as a global object via a string identifier,
+        // for Closure Compiler "advanced" mode
+        this['moment'] = moment;
     }
     /*global define:false */
     if (typeof define === "function" && define.amd) {


### PR DESCRIPTION
Instead of using `window` object directly, establish the root object which will be `window` in the browser or `global` on the server.

The change imitated underscore.js.
This change would also make moment.js possible to use on mongoDB shell.
