### PR TITLE
Feature/diff duration

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -876,25 +876,23 @@
 
         diff : function (input, val, asFloat) {
             var inputMoment = this._isUTC ? moment(input).utc() : moment(input).local(),
-                zoneDiff = (this.zone() - inputMoment.zone()) * 6e4,
-                diff = this._d - inputMoment._d - zoneDiff,
-                year = this.year() - inputMoment.year(),
-                month = this.month() - inputMoment.month(),
-                date = this.date() - inputMoment.date(),
-                output;
-            if (val === 'months') {
-                output = year * 12 + month + date / 30;
-            } else if (val === 'years') {
-                output = year + (month + date / 30) / 12;
-            } else {
-                output = val === 'seconds' ? diff / 1e3 : // 1000
-                    val === 'minutes' ? diff / 6e4 : // 1000 * 60
-                    val === 'hours' ? diff / 36e5 : // 1000 * 60 * 60
-                    val === 'days' ? diff / 864e5 : // 1000 * 60 * 60 * 24
-                    val === 'weeks' ? diff / 6048e5 : // 1000 * 60 * 60 * 24 * 7
-                    diff;
+                diff = moment.duration({
+                    y: this.year() - inputMoment.year(),
+                    M: this.month() - inputMoment.month(),
+                    d: this.date() - inputMoment.date(),
+                    h: this.hours() - inputMoment.hours(),
+                    m: this.minutes() - inputMoment.minutes(),
+                    s: this.seconds() - inputMoment.seconds(),
+                    ms: this.milliseconds() - inputMoment.milliseconds()
+                });
+
+            if (val) {
+                diff = diff['as' + val.charAt(0).toUpperCase() + val.slice(1)]();
+                if (!asFloat) {
+                    diff = round(diff);
+                }
             }
-            return asFloat ? output : round(output);
+            return diff;
         },
 
         from : function (time, withoutSuffix) {

--- a/test/moment/diff.js
+++ b/test/moment/diff.js
@@ -15,6 +15,16 @@ exports.diff = {
         test.done();
     },
 
+    "diff different signatures" : function(test) {
+        test.expect(3);
+
+        test.equal(moment([2010, 0, 1]).diff(moment([2010, 0, 1, 0, 0, 6])), -6000, "moment vs. momentable");
+        test.equal(moment([2010, 0, 1]).diff(new Date(2010, 0, 1, 0, 0, 6), "seconds"), -6, "moment vs. momentable specifying key");
+        test.equal(moment([2010, 0, 1]).diff([2010, 0, 1, 0, 0, 6], "seconds", true), -6, "moment vs. momentable specifying key and noRound");
+
+        test.done();
+    },
+
     "diff key after" : function(test) {
         test.expect(9);
 
@@ -88,6 +98,16 @@ exports.diff = {
         test.expect(1);
 
         test.ok(moment([2012, 1, 19]).diff(moment([2002, 1, 20]), 'years', true) < 10, "year diff should include date of month");
+
+        test.done();
+    },
+
+    "ensure arithmetic cast" : function(test) {
+        test.expect(1);
+
+        var a = moment([2012]),
+            b = moment([2012, 0, 1, 0, 0, 0, 1]);
+        test.equal(b.diff(a) + 1, 2, "return of diff with no explicit toValue call should still act like a number if treated like one");
 
         test.done();
     }


### PR DESCRIPTION
As discussed in #282, the diff function now returns a duration instead
of just a millisecond number for the one parameter incantation.
Internally, diff uses the duration to perform the math.  This commit
passes all but two of the unit tests (fails regarding returning years as
floats).  This is not ready to be merged in.

I am opening this pull request to ask for help as to how to correctly write this function and to start some momentum on the feature.
