### PR TITLE
Month abbreviation improvements for language nl

### DIFF
--- a/lang/nl.js
+++ b/lang/nl.js
@@ -2,9 +2,17 @@
 // language : dutch (nl)
 // author : Joris Röling : https://github.com/jjupiter
 (function () {
+    var monthsShortWithDots = "jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.".split("_");
+    var monthsShortWithoutDots = "jan_feb_mrt_apr_mei_jun_jul_aug_sep_okt_nov_dec".split("_");
     var lang = {
             months : "januari_februari_maart_april_mei_juni_juli_augustus_september_oktober_november_december".split("_"),
-            monthsShort : "jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.".split("_"),
+            monthsShort : function (m, format) {
+                if (/-MMM-/.test(format)) {
+                    return monthsShortWithoutDots[m.month()];
+                } else {
+                    return monthsShortWithDots[m.month()];
+                }
+            },
             weekdays : "zondag_maandag_dinsdag_woensdag_donderdag_vrijdag_zaterdag".split("_"),
             weekdaysShort : "zo._ma._di._wo._do._vr._za.".split("_"),
             weekdaysMin : "Zo_Ma_Di_Wo_Do_Vr_Za".split("_"),

--- a/test/lang/nl.js
+++ b/test/lang/nl.js
@@ -244,5 +244,15 @@ exports["lang:nl"] = {
         test.equal(weeksAgo.calendar(),       weeksAgo.format('L'),  "2 weeks ago");
         test.equal(weeksFromNow.calendar(),   weeksFromNow.format('L'),  "in 2 weeks");
     test.done();
+    },
+
+    "month abbreviation" : function(test) {
+        test.expect(2);
+        moment.lang('nl');
+         
+        test.equal(moment([2012, 5, 23]).format('D-MMM-YYYY'), '23-jun-2012', 'format month abbreviation surrounded by dashes should not include a dot');
+        test.equal(moment([2012, 5, 23]).format('D MMM YYYY'), '23 jun. 2012', 'format month abbreviation not surrounded by dashes should include a dot');
+
+        test.done();
     }
 };


### PR DESCRIPTION
Month abbreviations for nl are out of sync with CLDR, specifically 'mar.' -> 'mrt.' and 'mei.' -> 'mei'.
Additionally when a month abbreviation is surrounded by dashes (f.e. D-MMM-YYYY) , the dot is now omitted for a cleaner representation. For the original discussion, see #325.
