### PR TITLE
Grammar fixes in the Italian translation

### DIFF
--- a/lang/it.js
+++ b/lang/it.js
@@ -5,7 +5,7 @@
     var lang = {
             months : "Gennaio_Febbraio_Marzo_Aprile_Maggio_Giugno_Luglio_Agosto_Settebre_Ottobre_Novembre_Dicembre".split("_"),
             monthsShort : "Gen_Feb_Mar_Apr_Mag_Giu_Lug_Ago_Set_Ott_Nov_Dic".split("_"),
-            weekdays : "Domenica_Lunedi_Martedi_Mercoledi_Giovedi_Venerdi_Sabato".split("_"),
+            weekdays : "Domenica_Lunedì_Martedì_Mercoledì_Giovedì_Venerdì_Sabato".split("_"),
             weekdaysShort : "Dom_Lun_Mar_Mer_Gio_Ven_Sab".split("_"),
             weekdaysMin : "D_L_Ma_Me_G_V_S".split("_"),
             longDateFormat : {
@@ -29,7 +29,7 @@
                 s : "secondi",
                 m : "un minuto",
                 mm : "%d minuti",
-                h : "un ora",
+                h : "un'ora",
                 hh : "%d ore",
                 d : "un giorno",
                 dd : "%d giorni",

--- a/test/lang/it.js
+++ b/test/lang/it.js
@@ -113,7 +113,7 @@ exports["lang:it"] = {
     "format week" : function(test) {
         test.expect(7);
         moment.lang('it');
-        var expected = 'Domenica Dom D_Lunedi Lun L_Martedi Mar Ma_Mercoledi Mer Me_Giovedi Gio G_Venerdi Ven V_Sabato Sab S'.split("_");
+        var expected = 'Domenica Dom D_Lunedì Lun L_Martedì Mar Ma_Mercoledì Mer Me_Giovedì Gio G_Venerdì Ven V_Sabato Sab S'.split("_");
         var i;
         for (i = 0; i < expected.length; i++) {
             test.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
@@ -130,8 +130,8 @@ exports["lang:it"] = {
         test.equal(start.from(moment([2007, 1, 28]).add({s:89}), true),  "un minuto",   "89 seconds = a minute");
         test.equal(start.from(moment([2007, 1, 28]).add({s:90}), true),  "2 minuti",  "90 seconds = 2 minutes");
         test.equal(start.from(moment([2007, 1, 28]).add({m:44}), true),  "44 minuti", "44 minutes = 44 minutes");
-        test.equal(start.from(moment([2007, 1, 28]).add({m:45}), true),  "un ora",    "45 minutes = an hour");
-        test.equal(start.from(moment([2007, 1, 28]).add({m:89}), true),  "un ora",    "89 minutes = an hour");
+        test.equal(start.from(moment([2007, 1, 28]).add({m:45}), true),  "un'ora",    "45 minutes = an hour");
+        test.equal(start.from(moment([2007, 1, 28]).add({m:89}), true),  "un'ora",    "89 minutes = an hour");
         test.equal(start.from(moment([2007, 1, 28]).add({m:90}), true),  "2 ore",    "90 minutes = 2 hours");
         test.equal(start.from(moment([2007, 1, 28]).add({h:5}), true),   "5 ore",    "5 hours = 5 hours");
         test.equal(start.from(moment([2007, 1, 28]).add({h:21}), true),  "21 ore",   "21 hours = 21 hours");


### PR DESCRIPTION
In the Italian translation file, add accents to week days (like `Lunedi` -> `Lunedì`) and an apostrophe to `un'ora` (an hour). Update tests as well.
