### PR TITLE
Added support for mocking the current time

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -37,7 +37,7 @@
         parseTokenTimezone = /Z|[\+\-]\d\d:?\d\d/i, // +00:00 -00:00 +0000 -0000 or Z
         parseTokenT = /T/i, // T (ISO seperator)
 
-        // preliminary iso regex 
+        // preliminary iso regex
         // 0000-00-00 + T + 00 or 00:00 or 00:00:00 or 00:00:00.000 + +00:00 or +0000
         isoRegex = /^\s*\d{4}-\d\d-\d\d(T(\d\d(:\d\d(:\d\d(\.\d\d?\d?)?)?)?)?([\+\-]\d\d:?\d\d)?)?/,
         isoFormat = 'YYYY-MM-DDTHH:mm:ssZ',
@@ -83,7 +83,7 @@
     function Duration(duration) {
         var data = this._data = {},
             years = duration.years || duration.y || 0,
-            months = duration.months || duration.M || 0, 
+            months = duration.months || duration.M || 0,
             weeks = duration.weeks || duration.w || 0,
             days = duration.days || duration.d || 0,
             hours = duration.hours || duration.h || 0,
@@ -105,7 +105,7 @@
         // it separately.
         this._months = months +
             years * 12;
-            
+
         // The following code bubbles up values, see the tests for
         // examples of what that means.
         data.milliseconds = milliseconds % 1000;
@@ -122,7 +122,7 @@
 
         days += weeks * 7;
         data.days = days % 30;
-        
+
         months += absRound(days / 30);
 
         data.months = months % 12;
@@ -505,7 +505,7 @@
                     break;
                 }
             }
-            return parseTokenTimezone.exec(string) ? 
+            return parseTokenTimezone.exec(string) ?
                 makeDateFromStringAndFormat(string, format + ' Z') :
                 makeDateFromStringAndFormat(string, format);
         }
@@ -548,6 +548,9 @@
         var date,
             matched,
             isUTC;
+        if (input === undefined) {
+            input = moment.mockNow;
+        }
         // parse Moment object
         if (moment.isMoment(input)) {
             date = new Date(+input._d);
@@ -633,7 +636,7 @@
         }
         if (languages[key]) {
             for (i = 0; i < langConfigProperties.length; i++) {
-                moment[langConfigProperties[i]] = languages[key][langConfigProperties[i]] || 
+                moment[langConfigProperties[i]] = languages[key][langConfigProperties[i]] ||
                     languages.en[langConfigProperties[i]];
             }
             currentLanguage = key;
@@ -800,7 +803,7 @@
         },
 
         isDST : function () {
-            return (this.zone() < moment([this.year()]).zone() || 
+            return (this.zone() < moment([this.year()]).zone() ||
                 this.zone() < moment([this.year(), 5]).zone());
         },
 

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -40,6 +40,14 @@ exports.create = {
         test.done();
     },
 
+    "undefined with mockNow": function(test) {
+        test.expect(1);
+        moment.mockNow = moment().subtract('minutes', 5);
+        test.ok(moment().valueOf() === moment.mockNow.valueOf(), "undefined with mockNow");
+        delete moment.mockNow;
+        test.done();
+    },
+
     "string without format" : function(test) {
         test.expect(2);
         test.ok(moment("Aug 9, 1995").toDate() instanceof Date, "Aug 9, 1995");
@@ -67,7 +75,7 @@ exports.create = {
     "string with format dropped am/pm bug" : function(test) {
         moment.lang('en');
         test.expect(3);
-        
+
         test.equal(moment('05/1/2012', 'MM/DD/YYYY h:m:s a').format('MM/DD/YYYY'), '05/01/2012', 'should not break if am/pm is left off from the parsing tokens');
         test.equal(moment('05/1/2012 12:25:00 am', 'MM/DD/YYYY h:m:s a').format('MM/DD/YYYY'), '05/01/2012', 'should not break if am/pm is left off from the parsing tokens');
         test.equal(moment('05/1/2012 12:25:00 pm', 'MM/DD/YYYY h:m:s a').format('MM/DD/YYYY'), '05/01/2012', 'should not break if am/pm is left off from the parsing tokens');
@@ -77,11 +85,11 @@ exports.create = {
 
     "empty string with formats" : function(test) {
         test.expect(3);
-        
+
         test.equal(moment(' ', 'MM').format('YYYY-MM-DD HH:mm:ss'), '1900-01-01 00:00:00', 'should not break if input is an empty string');
         test.equal(moment(' ', 'DD').format('YYYY-MM-DD HH:mm:ss'), '1900-01-01 00:00:00', 'should not break if input is an empty string');
         test.equal(moment(' ', ['MM', "DD"]).format('YYYY-MM-DD HH:mm:ss'), '1900-01-01 00:00:00', 'should not break if input is an empty string');
-        
+
         test.done();
     },
 
@@ -118,7 +126,7 @@ exports.create = {
                 ['HH:mm:ss SSS',        '00:30:00 789']
             ],
             i;
-        
+
         test.expect(a.length);
         for (i = 0; i < a.length; i++) {
             test.equal(moment(a[i][1], a[i][0]).format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
@@ -139,7 +147,7 @@ exports.create = {
         for (i = 0; i < a.length; i++) {
             test.equal(moment(a[i][1], a[i][0]).format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
         }
-        
+
         test.done();
     },
 
@@ -270,7 +278,7 @@ exports.create = {
         var m = moment('2011-10-08T18:04:20.111Z');
 
         test.equal(m.utc().format('YYYY-MM-DDTHH:mm:ss.SSS'), '2011-10-08T18:04:20.111', "moment should be able to parse ISO 2011-10-08T18:04:20.111Z");
-        
+
         test.done();
     },
 


### PR DESCRIPTION
This is especially useful in testing.

Usage

``` js
moment.mockNow = moment().day(3);
moment().valueOf() === moment.mockNow.valueOf();
```

You can assign anything to `moment.mockNow` that you would normally pass to a moment constructor (except it doesn't allow string + format).
