### PR TITLE
Added startOf to moment.fn

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -37,7 +37,7 @@
         parseTokenTimezone = /Z|[\+\-]\d\d:?\d\d/i, // +00:00 -00:00 +0000 -0000 or Z
         parseTokenT = /T/i, // T (ISO seperator)
 
-        // preliminary iso regex 
+        // preliminary iso regex
         // 0000-00-00 + T + 00 or 00:00 or 00:00:00 or 00:00:00.000 + +00:00 or +0000
         isoRegex = /^\s*\d{4}-\d\d-\d\d(T(\d\d(:\d\d(:\d\d(\.\d\d?\d?)?)?)?)?([\+\-]\d\d:?\d\d)?)?/,
         isoFormat = 'YYYY-MM-DDTHH:mm:ssZ',
@@ -83,7 +83,7 @@
     function Duration(duration) {
         var data = this._data = {},
             years = duration.years || duration.y || 0,
-            months = duration.months || duration.M || 0, 
+            months = duration.months || duration.M || 0,
             weeks = duration.weeks || duration.w || 0,
             days = duration.days || duration.d || 0,
             hours = duration.hours || duration.h || 0,
@@ -105,7 +105,7 @@
         // it separately.
         this._months = months +
             years * 12;
-            
+
         // The following code bubbles up values, see the tests for
         // examples of what that means.
         data.milliseconds = milliseconds % 1000;
@@ -122,7 +122,7 @@
 
         days += weeks * 7;
         data.days = days % 30;
-        
+
         months += absRound(days / 30);
 
         data.months = months % 12;
@@ -505,7 +505,7 @@
                     break;
                 }
             }
-            return parseTokenTimezone.exec(string) ? 
+            return parseTokenTimezone.exec(string) ?
                 makeDateFromStringAndFormat(string, format + ' Z') :
                 makeDateFromStringAndFormat(string, format);
         }
@@ -633,7 +633,7 @@
         }
         if (languages[key]) {
             for (i = 0; i < langConfigProperties.length; i++) {
-                moment[langConfigProperties[i]] = languages[key][langConfigProperties[i]] || 
+                moment[langConfigProperties[i]] = languages[key][langConfigProperties[i]] ||
                     languages.en[langConfigProperties[i]];
             }
             currentLanguage = key;
@@ -800,7 +800,7 @@
         },
 
         isDST : function () {
-            return (this.zone() < moment([this.year()]).zone() || 
+            return (this.zone() < moment([this.year()]).zone() ||
                 this.zone() < moment([this.year(), 5]).zone());
         },
 
@@ -824,6 +824,20 @@
                 d : 1,
                 ms : -1
             });
+        },
+
+        startOf: function (anchor) {
+            var keys = ['year', 'month', 'date', 'hours', 'minutes', 'seconds', 'milliseconds'],
+                anchors = ['year', 'month', 'day', 'hour', 'minute', 'second', 'millisecond'],
+                idx = anchors.indexOf(anchor),
+                result = this, i;
+            if (idx === -1) {
+                return this;
+            }
+            for (i = idx + 1; i < keys.length; i ++) {
+                result = result[keys[i]](keys[i] === 'date' ? 1 : 0);
+            }
+            return result;
         },
 
         zone : function () {

--- a/test/moment/start_of.js
+++ b/test/moment/start_of.js
@@ -1,0 +1,54 @@
+var moment = require("../../moment");
+exports.start_of = {
+    "works for seconds": function(test) {
+        var now = new Date(),
+            startOfSecond = new Date(now);
+        startOfSecond.setMilliseconds(0);
+        test.equal(startOfSecond.getTime(), moment(now).startOf('second').valueOf());
+        test.done();
+    },
+
+    "works for minutes": function(test) {
+        var now = new Date(),
+            startOfMinute = new Date(now);
+        startOfMinute.setSeconds(0, 0);
+        test.equal(startOfMinute.getTime(), moment(now).startOf('minute').valueOf());
+        test.done();
+    },
+
+    "works for hours": function(test) {
+        var now = new Date(),
+            startOfHour = new Date(now);
+        startOfHour.setMinutes(0);
+        startOfHour.setSeconds(0, 0);
+        test.equal(startOfHour.getTime(), moment(now).startOf('hour').valueOf());
+        test.done();
+    },
+
+    "works for days": function(test) {
+        var now = new Date(),
+            startOfDay = new Date(now);
+        startOfDay.setHours(0, 0, 0, 0);
+        test.equal(startOfDay.getTime(), moment(now).startOf('day').valueOf());
+        test.done();
+    },
+
+    "works for months": function(test) {
+        var now = new Date(),
+            startOfMonth = new Date(now);
+        startOfMonth.setDate(1);
+        startOfMonth.setHours(0, 0, 0, 0);
+        test.equal(startOfMonth.getTime(), moment(now).startOf('month').valueOf());
+        test.done();
+    },
+
+    "works for years": function(test) {
+        var now = new Date(),
+            startOfYear = new Date(now);
+        startOfYear.setMonth(0);
+        startOfYear.setDate(1);
+        startOfYear.setHours(0, 0, 0, 0);
+        test.equal(startOfYear.getTime(), moment(now).startOf('year').valueOf());
+        test.done();
+    }
+};


### PR DESCRIPTION
his is a generalized version of sod, that works for years, months,
days, hours, minutes and seconds.

Usage

``` javascript
moment().startOf('year');  // x = new Date(); x.setMonth(0); x.setDate(1); x.setHours(0, 0, 0, 0);
moment().startOf('month'); // x = new Date(); x.setDate(1); x.setHours(0, 0, 0, 0);
moment().startOf('day'); // moment().sod() OR x = new Date(); x.setHours(0, 0, 0, 0);
moment().startOf('hour'); // x = new Date(); x.setMinutes(0); x.setSeconds(0, 0);
moment().startOf('minute'); // x = new Date(); x.setSeconds(0, 0);
moment().startOf('second'); // x = new Date(); x.setMilliseconds(0);
```
