### PR TITLE
Fix parsing/formatting of first century dates.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -172,7 +172,21 @@
     // note: all values past the year are optional and will default to the lowest possible value.
     // [year, month, day , hour, minute, second, millisecond]
     function dateFromArray(input) {
-        return new Date(input[0], input[1] || 0, input[2] || 1, input[3] || 0, input[4] || 0, input[5] || 0, input[6] || 0);
+        var date = new Date(0);
+        date.setFullYear(input[0], input[1] || 0, input[2] || 1);
+        date.setHours(input[3] || 0, input[4] || 0, input[5] || 0, input[6] || 0);
+        return date;
+    }
+
+    // convert an array to a UTC date.
+    // the array should mirror the parameters below
+    // note: all values past the year are optional and will default to the lowest possible value.
+    // [year, month, day , hour, minute, second, millisecond]
+    function dateFromArrayUTC(input) {
+        var date = new Date(0);
+        date.setUTCFullYear(input[0], input[1] || 0, input[2] || 1);
+        date.setUTCHours(input[3] || 0, input[4] || 0, input[5] || 0, input[6] || 0);
+        return date;
     }
 
     // format date using native date object
@@ -249,7 +263,7 @@
             case 'YY' :
                 return leftZeroFill(currentYear % 100, 2);
             case 'YYYY' :
-                return currentYear;
+                return leftZeroFill(currentYear, 4);
             // AM / PM
             case 'a' :
                 return meridiem ? meridiem(currentHours, currentMinutes, false) : (currentHours > 11 ? 'pm' : 'am');
@@ -456,7 +470,7 @@
         datePartArray[3] += config.tzh;
         datePartArray[4] += config.tzm;
         // return
-        return config.isUTC ? new Date(Date.UTC.apply({}, datePartArray)) : dateFromArray(datePartArray);
+        return (config.isUTC ? dateFromArrayUTC : dateFromArray)(datePartArray);
     }
 
     // compare two arrays, return the number of differences

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -78,9 +78,9 @@ exports.create = {
     "empty string with formats" : function(test) {
         test.expect(3);
         
-        test.equal(moment(' ', 'MM').format('YYYY-MM-DD HH:mm:ss'), '1900-01-01 00:00:00', 'should not break if input is an empty string');
-        test.equal(moment(' ', 'DD').format('YYYY-MM-DD HH:mm:ss'), '1900-01-01 00:00:00', 'should not break if input is an empty string');
-        test.equal(moment(' ', ['MM', "DD"]).format('YYYY-MM-DD HH:mm:ss'), '1900-01-01 00:00:00', 'should not break if input is an empty string');
+        test.equal(moment(' ', 'MM').format('YYYY-MM-DD HH:mm:ss'), '0000-01-01 00:00:00', 'should not break if input is an empty string');
+        test.equal(moment(' ', 'DD').format('YYYY-MM-DD HH:mm:ss'), '0000-01-01 00:00:00', 'should not break if input is an empty string');
+        test.equal(moment(' ', ['MM', "DD"]).format('YYYY-MM-DD HH:mm:ss'), '0000-01-01 00:00:00', 'should not break if input is an empty string');
         
         test.done();
     },


### PR DESCRIPTION
According to ECMA-262, `new Date(y, …)` will auto-convert `y` to `1900 + y` if `0 ≤ y ≤ 99`, hence setFullYear or setUTCFullYear is used instead.

This also zero-pads the year for the "YYYY" format, since the year may not necessarily have four digits.
