### PR TITLE
Add support for years outside 0000-9999.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -41,8 +41,8 @@
         parseTokenOneOrTwoDigits = /\d\d?/, // 0 - 99
         parseTokenOneToThreeDigits = /\d{1,3}/, // 0 - 999
         parseTokenThreeDigits = /\d{3}/, // 000 - 999
-        parseTokenFourDigits = /\d{4}/, // 0000 - 9999
-        parseTokenFiveToSixDigits = /[+\-\d]?\d{4,6}/, // -999,999 - 999,999
+        parseTokenFourDigits = /\d{1,4}/, // 0 - 9999
+        parseTokenSixDigits = /[+\-]?\d{1,6}/, // -999,999 - 999,999
         parseTokenWord = /[0-9a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+/i, // any word characters or numbers
         parseTokenTimezone = /Z|[\+\-]\d\d:?\d\d/i, // +00:00 -00:00 +0000 -0000 or Z
         parseTokenT = /T/i, // T (ISO seperator)
@@ -405,7 +405,7 @@
         case 'YYYY':
             return parseTokenFourDigits;
         case 'YYYYY':
-            return parseTokenFiveToSixDigits;
+            return parseTokenSixDigits;
         case 'S':
         case 'SS':
         case 'SSS':

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -300,10 +300,16 @@ exports.create = {
     },
 
     "first century" : function(test) {
-        test.expect(3);
+        test.expect(9);
         test.equal(moment([0, 0, 1]).format("YYYY-MM-DD"), "0000-01-01", "Year AD 0");
         test.equal(moment([99, 0, 1]).format("YYYY-MM-DD"), "0099-01-01", "Year AD 99");
         test.equal(moment([999, 0, 1]).format("YYYY-MM-DD"), "0999-01-01", "Year AD 999");
+        test.equal(moment('0 1 1', 'YYYY MM DD').format("YYYY-MM-DD"), "0000-01-01", "Year AD 0");
+        test.equal(moment('99 1 1', 'YYYY MM DD').format("YYYY-MM-DD"), "0099-01-01", "Year AD 99");
+        test.equal(moment('999 1 1', 'YYYY MM DD').format("YYYY-MM-DD"), "0999-01-01", "Year AD 999");
+        test.equal(moment('0 1 1', 'YYYYY MM DD').format("YYYYY-MM-DD"), "00000-01-01", "Year AD 0");
+        test.equal(moment('99 1 1', 'YYYYY MM DD').format("YYYYY-MM-DD"), "00099-01-01", "Year AD 99");
+        test.equal(moment('999 1 1', 'YYYYY MM DD').format("YYYYY-MM-DD"), "00999-01-01", "Year AD 999");
         test.done();
     },
 


### PR DESCRIPTION
It seems reasonable to support all the dates that JavaScript's Date can support. However, extending the existing YYYY format specifier to include 6-digit dates (and negative dates) will break when there are no separators, e.g. it would incorrectly attempt to parse 12345678/YYYYMMDD as the year 123456.
