### PR TITLE
Add strftime method for unix style date output formating.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -395,42 +395,76 @@
         }
 
         switch (item) {
+            case "D":
             case "%a":
                 return "ddd";
+            case "l":
             case "%A":
                 return "dddd";
+            case "M":
+            case "%h":
             case "%b":
                 return "MMM";
+            case "F":
             case "%B":
                 return "MMMM";
             case "%c":
                 return "LLLL";
+            case "j":
             case "%d":
-                return "DD";
+                return "D";
+            case "%j":
+                return "DDDD";
+            case "%e":
+                return "Do";
+            case "m":
             case "%m":
                 return "MM";
-            case "%y":
-                return "YY";
-            case "%Y":
-                return "YYYY";
+            case "A":
+            case "%p":
+                return "A";
+            case "a":
+            case "%P":
+                return "a";
+            case "s":
             case "%S":
                 return "ss";
+            case "i":
             case "%M":
                 return "mm";
+            case "H":
             case "%H":
                 return "HH";
             case "%I":
                 return "hh";
+            case "w":
             case "%w":
                 return "d";
+            case "W":
             case "%W":
+            case "%U":
                 return "ww";
             case "%x":
                 return "LL";
             case "%X":
                 return "LT";
+            case "y":
+            case "%g":
+            case "%y":
+                return "YY";
+            case "o":
+            case "Y":
+            case "%G":
+            case "%Y":
+                return "YYYY";
             case "%z":
                 return "ZZ";
+            case "z":
+                return "DDD";
+            case "d":
+                return "DD";
+            case "n":
+                return "M";
             default:
                 return item;
         }


### PR DESCRIPTION
Hello! This is only a prototype, still not finished. But I would like to know, whether it is feasible to integrate it into the core of "moment", when finalized, and created the respective tests.

I saw the plugin "moment-strftime" and is made in coffescript which adds an additional dependency, also not quite complete. Not everyone uses and not all want coffescript use. I think it would be interesting to have this feature in the core of "moment".

I have many projects needed a good interaction between the unix format (they are almost the same as python) and many cases I had to do it by hand. Datejs know, but the code is quite complex, and has given me enough problems in web browsers.

With this, you want to convey, I think I'm not the only one who would appreciate having this feature on "moment";)
