### PR TITLE
optional immutability

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -234,13 +234,13 @@
             mom._d.setTime(+mom + ms * isAdding);
         }
         if (d) {
-            mom.date(mom.date() + d * isAdding);
+            mom.date(mom.date() + d * isAdding, true);
         }
         if (M) {
             currentDate = mom.date();
-            mom.date(1)
-                .month(mom.month() + M * isAdding)
-                .date(Math.min(currentDate, mom.daysInMonth()));
+            mom.date(1, true)
+                .month(mom.month() + M * isAdding, true)
+                .date(Math.min(currentDate, mom.daysInMonth()), true);
         }
     }
 
@@ -879,15 +879,15 @@
             return formatMoment(this, inputString ? inputString : moment.defaultFormat);
         },
 
-        add : function (input, val) {
-            var mom = this.instance(),
+        add : function (input, val, mutate) {
+            var mom = this.instance(mutate),
                 dur = val ? moment.duration(+val, input) : moment.duration(input);
             addOrSubtractDurationFromMoment(mom, dur, 1);
             return mom;
         },
 
-        subtract : function (input, val) {
-            var mom = this.instance(),
+        subtract : function (input, val, mutate) {
+            var mom = this.instance(mutate),
                 dur = val ? moment.duration(+val, input) : moment.duration(input);
             addOrSubtractDurationFromMoment(mom, dur, -1);
             return mom;
@@ -950,7 +950,7 @@
         day : function (input) {
             var day = this._isUTC ? this._d.getUTCDay() : this._d.getDay();
             return input == null ? day :
-                this.instance().add({ d : input - day });
+                this.add({ d : input - day });
         },
 
         startOf: function (val) {
@@ -959,29 +959,29 @@
             // to utilize falling through the cases.
             switch (val.replace(/s$/, '')) {
             case 'year':
-                mom.month(0);
+                mom.month(0, true);
                 /* falls through */
             case 'month':
-                mom.date(1);
+                mom.date(1, true);
                 /* falls through */
             case 'day':
-                mom.hours(0);
+                mom.hours(0, true);
                 /* falls through */
             case 'hour':
-                mom.minutes(0);
+                mom.minutes(0, true);
                 /* falls through */
             case 'minute':
-                mom.seconds(0);
+                mom.seconds(0, true);
                 /* falls through */
             case 'second':
-                mom.milliseconds(0);
+                mom.milliseconds(0, true);
                 /* falls through */
             }
             return mom;
         },
 
         endOf: function (val) {
-            return this.startOf(val).add(val.replace(/s?$/, 's'), 1).subtract('ms', 1);
+            return this.startOf(val).add(val.replace(/s?$/, 's'), 1, true).subtract('ms', 1, true);
         },
         
         sod: function () {
@@ -1015,16 +1015,16 @@
         },
 
         // Returns either this or its clone, depending on whether moment has been globally set as immutable
-        instance : function () {
-            return moment.immutable ? this.clone() : this;
+        instance : function (mutate) {
+            return !mutate && moment.immutable ? this.clone() : this;
         }
     };
 
     // helper for adding shortcuts
     function makeGetterAndSetter(name, key) {
-        moment.fn[name] = function (input) {
+        moment.fn[name] = function (input, mutate) {
             var utc = this._isUTC ? 'UTC' : '',
-                mom = this.instance();
+                mom = this.instance(mutate);
             if (input != null) {
                 mom._d['set' + utc + key](input);
                 return mom;

--- a/test/moment/immutable.js
+++ b/test/moment/immutable.js
@@ -3,7 +3,16 @@ var moment = require("../../moment");
 exports.immutable = {
 
     setUp : function(callback){
-        this.mom = moment();
+        var a = moment();
+        a.year(2011);
+        a.month(9);
+        a.date(12);
+        a.hours(6);
+        a.minutes(7);
+        a.seconds(8);
+        a.milliseconds(500);
+        this.mom = a
+
         moment.immutable = true;
         callback();
     },
@@ -14,15 +23,26 @@ exports.immutable = {
     },
 
     "instance" : function(test){
-        test.expect(1)
+        test.expect(2)
         test.notStrictEqual(this.mom.instance(), this.mom);
+        test.strictEqual(this.mom.instance(true), this.mom);
         test.done();
     },
 
     "math" : function(test){
-        test.expect(2);
+        test.expect(10);
         test.notStrictEqual(this.mom, this.mom.add('d', 1));
         test.notStrictEqual(this.mom, this.mom.subtract('d', 1))
+
+        test.equal(this.mom.add({ms:50}).milliseconds(), 550, 'Add milliseconds');
+        test.equal(this.mom.add({s:1}).seconds(), 9, 'Add seconds');
+        test.equal(this.mom.add({m:1}).minutes(), 8, 'Add minutes');
+        test.equal(this.mom.add({h:1}).hours(), 7, 'Add hours');
+        test.equal(this.mom.add({d:1}).date(), 13, 'Add date');
+        test.equal(this.mom.add({w:1}).date(), 19, 'Add week');
+        test.equal(this.mom.add({M:1}).month(), 10, 'Add month');
+        test.equal(this.mom.add({y:1}).year(), 2012, 'Add year');
+
         test.done();
     },
 
@@ -36,13 +56,23 @@ exports.immutable = {
         test.notStrictEqual(this.mom, this.mom.day(3));
         test.notStrictEqual(this.mom, this.mom.month(3));
         test.notStrictEqual(this.mom, this.mom.year(1999));
+
         test.done();
     },
 
     "startAndEnd" : function(test){
-        test.expect(2);
+        test.expect(6);
         test.notStrictEqual(this.mom, this.mom.startOf("year"));
         test.notStrictEqual(this.mom, this.mom.endOf("year"));
+
+        m = this.mom.startOf("year")
+        test.equal(m.year(), 2011, "keep the year");
+        test.equal(m.month(), 0, "strip out the month");
+
+        m = this.mom.endOf("year")
+        test.equal(m.year(), 2011, "keep the year");
+        test.equal(m.month(), 11, "set the month");
+
         test.done();
     },
 


### PR DESCRIPTION
I wrote this as an experiment and figured I'd submit it as a pull request. I created a global flag that makes moment objects immutable, forcing each of the manipulation functions to clone the moment object before
doing their work. So:

``` js
mutable = moment()
mutable.add("s", 3) == mutable  // => true
moment.immutable = true
immutable = moment()
immutable.add("s", 3) == immutable  // => false
```

I do like immutability a lot, but I could see where this might not be ideal maintainability-wise, so NBD if you don't want it. Let me know what you guys think.
