### PR TITLE
Add testcase for wrong escaping of "L" token.

### DIFF
--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -107,5 +107,13 @@ exports.format = {
         var isoRegex = /\d{4}.\d\d.\d\dT\d\d.\d\d.\d\d[\+\-]\d\d:\d\d/;
         test.ok(isoRegex.exec(moment().format()), "default format (" + moment().format() + ") should match ISO");
         test.done();
+    },
+
+    "escape format" : function(test) {
+        test.expect(3);
+        test.equal(moment().format('\\a'), 'a');
+        test.equal(moment().format('\\e'), 'e');
+        test.equal(moment().format('\\\\L'), 'L');
+        test.done();
     }
 };


### PR DESCRIPTION
Actually, the documentation says:

```
moment().format('\\\\L'); // outputs 'L'
```

but this not works properly. I tried to find a solution, but for now, I could not find any.
