### PR TITLE
Support for Chuvash suffix changes in future fromNow

### DIFF
--- a/lang/cv.js
+++ b/lang/cv.js
@@ -24,7 +24,11 @@
                 sameElse: 'L'
             },
             relativeTime : {
-                future : "%sран",
+                future : function(output) {
+                   var affix = /сехет$/i.exec(output)
+                      ? "рен" : /çул$/i.exec(output) ? "тан" : "ран";
+                   return output + affix;
+                },
                 past : "%s каялла",
                 s : "пĕр-ик çеккунт",
                 m : "пĕр минут",

--- a/moment.js
+++ b/moment.js
@@ -1047,10 +1047,16 @@
         humanize : function (withSuffix) {
             var difference = +this,
                 rel = this.lang().relativeTime,
-                output = relativeTime(difference, !withSuffix, this.lang());
+                output = relativeTime(difference, !withSuffix, this.lang()),
+                fromNow = difference <= 0 ? rel.past : rel.future;
 
             if (withSuffix) {
-                output = (difference <= 0 ? rel.past : rel.future).replace(/%s/i, output);
+                if (typeof fromNow === 'function') {
+                    output = fromNow(output);
+                }
+                else {
+                    output = fromNow.replace(/%s/i, output);
+                }
             }
 
             return output;

--- a/test/lang/cv.js
+++ b/test/lang/cv.js
@@ -174,10 +174,12 @@ exports["lang:cv"] = {
     },
 
     "fromNow" : function(test) {
-        test.expect(2);
+        test.expect(4);
         moment.lang('cv');
         test.equal(moment().add({s:30}).fromNow(), "пĕр-ик çеккунтран", "in a few seconds");
         test.equal(moment().add({d:5}).fromNow(), "5 кунран", "in 5 days");
+        test.equal(moment().add({h:2}).fromNow(), "2 сехетрен", "in 2 hours, the right suffix!");
+        test.equal(moment().add({y:3}).fromNow(), "3 çултан", "in 3 years, the right suffix!");
         test.done();
     },
 


### PR DESCRIPTION
Chuvash uses an affix to express the future "fromNow". This affix can have different forms depending on preceeding sound. I wrote about this issue in my blog post: [Chuvash localization of moment.js](http://sharepointkunskap.wordpress.com/2012/08/11/chuvash-localization-of-moment-js/). To solve this, the core moment.js has to support custom logic for future expressions.

In this PR I added tests for this for Chuvash, changes in lang/cv.js (a function instead of a string) and a change in "humanize" function in moment.js file.
