### PR TITLE
Correcting the Danish translation.

### DIFF
--- a/lang/da.js
+++ b/lang/da.js
@@ -3,11 +3,11 @@
 // author : Ulrik Nielsen : https://github.com/mrbase
 (function () {
     var lang = {
-            months : "Januar_Februar_Marts_April_Maj_Juni_Juli_August_September_Oktober_November_December".split("_"),
-            monthsShort : "Jan_Feb_Mar_Apr_Maj_Jun_Jul_Aug_Sep_Okt_Nov_Dec".split("_"),
-            weekdays : "Søndag_Mandag_Tirsdag_Onsdag_Torsdag_Fredag_Lørdag".split("_"),
-            weekdaysShort : "Søn_Man_Tir_Ons_Tor_Fre_Lør".split("_"),
-            weekdaysMin : "Sø_Ma_Ti_On_To_Fr_Lø".split("_"),
+            months : "januar_februar_marts_april_maj_juni_juli_august_september_oktober_november_december".split("_"),
+            monthsShort : "jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec".split("_"),
+            weekdays : "søndag_mandag_tirsdag_onsdag_torsdag_fredag_lørdag".split("_"),
+            weekdaysShort : "søn_man_tir_ons_tor_fre_lør".split("_"),
+            weekdaysMin : "sø_ma_ti_on_to_fr_lø".split("_"),
             longDateFormat : {
                 LT : "h:mm A",
                 L : "DD/MM/YYYY",


### PR DESCRIPTION
Weekdays and month names are not capitalized in Danish, unless they start a sentence.
