### PR TITLE
Export moment for require.js

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1099,8 +1099,15 @@
     }
     /*global define:false */
     if (typeof define === "function" && define.amd) {
-        define("moment", [], function () {
-            return moment;
-        });
+        if(typeof require != 'undefined') {
+            define(function () {
+                return moment;
+            });
+        }
+        else {
+            define("moment", [], function () {
+                return moment;
+            });
+        }
     }
 }).call(this, Date);


### PR DESCRIPTION
The pull request at https://github.com/timrwood/moment/commit/57ccb0ca3825d090fc911ef0a3acccfa33c2f0a7 added a section to export moment for AMD modules but this doesn't work for require.js. When trying to load moment.js from require I always get undefined.

I added an additional check to see if require is defined and if so export moment using require's define function (different set of parameters than what must be standard AMD). With this change I can load moment using require.js.
