### PR TITLE
implement Moment#toJSON()

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -853,6 +853,10 @@
             ];
         },
 
+        toJSON : function () {
+            return this._d.toJSON();
+        },
+
         isValid : function () {
             if (this._a) {
                 return !compareArrays(this._a, (this._a[7] ? moment.utc(this) : this).toArray());


### PR DESCRIPTION
This should make it a bit easier to serialize objects which use moment objects as properties. :)

I'm using this with Backbone, where my models use moment objects which are serialized through JSON.stringify().
