### PR TITLE
Remove Date locally scoped variable from iife so mock can be inserted by unit tests etc

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -4,7 +4,7 @@
 // license : MIT
 // momentjs.com
 
-(function (Date, undefined) {
+(function (undefined) {
 
     /************************************
         Constants
@@ -1174,4 +1174,4 @@
             return moment;
         });
     }
-}).call(this, Date);
+}).call(this);


### PR DESCRIPTION
Its currently hard to mock the native Date object for the purposes of unit tests etc because moment has a  locally scoped reference. You can mock Date before moment is initialised but this is a) not reversible afterwards and b) hard to do when using modular code (e.g. requirejs) 

If we remove Date from the iife then it can be mocked as needed.

Note: this issue is also discussed in https://github.com/cjohansen/Sinon.JS/issues/171

P.S. Ive tried to follow the recommend pull request process but please do let me know if Ive made any mistakes as this is my first pull request! :)
