### PR TITLE
Fixed Bulgarian ordinal numbers

### DIFF
--- a/lang/bg.js
+++ b/lang/bg.js
@@ -51,7 +51,23 @@
                 yy : "%d години"
             },
             ordinal : function (number) {
-                return '.';
+                var lastDigit = number % 10,
+                    last2Digits = number % 100;
+                if (number === 0) {
+                    return '-ев';
+                } else if (last2Digits === 0) {
+                    return '-ен';
+                } else if (last2Digits > 10 && last2Digits < 20) {
+                    return '-ти';
+                } else if (lastDigit === 1) {
+                    return '-ви';
+                } else if (lastDigit === 2) {
+                    return '-ри';
+                } else if (lastDigit === 7 || lastDigit === 8) {
+                    return '-ми';
+                } else {
+                    return '-ти';
+                }
             }
         };
 

--- a/test/lang/bg.js
+++ b/test/lang/bg.js
@@ -32,20 +32,20 @@ exports["lang:bg"] = {
         test.expect(18);
         moment.lang('bg');
         var a = [
-                ['dddd, MMMM Do YYYY, h:mm:ss a',      'неделя, февруари 14. 2010, 3:25:50 pm'],
+                ['dddd, MMMM Do YYYY, h:mm:ss a',      'неделя, февруари 14-ти 2010, 3:25:50 pm'],
                 ['ddd, hA',                            'нед, 3PM'],
-                ['M Mo MM MMMM MMM',                   '2 2. 02 февруари фев'],
+                ['M Mo MM MMMM MMM',                   '2 2-ри 02 февруари фев'],
                 ['YYYY YY',                            '2010 10'],
-                ['D Do DD',                            '14 14. 14'],
-                ['d do dddd ddd dd',                   '0 0. неделя нед нд'],
-                ['DDD DDDo DDDD',                      '45 45. 045'],
-                ['w wo ww',                            '6 6. 06'],
+                ['D Do DD',                            '14 14-ти 14'],
+                ['d do dddd ddd dd',                   '0 0-ев неделя нед нд'],
+                ['DDD DDDo DDDD',                      '45 45-ти 045'],
+                ['w wo ww',                            '6 6-ти 06'],
                 ['h hh',                               '3 03'],
                 ['H HH',                               '15 15'],
                 ['m mm',                               '25 25'],
                 ['s ss',                               '50 50'],
                 ['a A',                                'pm PM'],
-                ['t\\he DDDo \\d\\ay of t\\he ye\\ar', 'the 45. day of the year'],
+                ['t\\he DDDo \\d\\ay of t\\he ye\\ar', 'the 45-ти day of the year'],
                 ['L',                                  '14.02.2010'],
                 ['LL',                                 '14 февруари 2010'],
                 ['LLL',                                '14 февруари 2010 3:25'],
@@ -62,40 +62,40 @@ exports["lang:bg"] = {
     "format ordinal" : function(test) {
         test.expect(31);
         moment.lang('bg');
-        test.equal(moment([2011, 0, 1]).format('DDDo'), '1.', '1.');
-        test.equal(moment([2011, 0, 2]).format('DDDo'), '2.', '2.');
-        test.equal(moment([2011, 0, 3]).format('DDDo'), '3.', '3.');
-        test.equal(moment([2011, 0, 4]).format('DDDo'), '4.', '4.');
-        test.equal(moment([2011, 0, 5]).format('DDDo'), '5.', '5.');
-        test.equal(moment([2011, 0, 6]).format('DDDo'), '6.', '6.');
-        test.equal(moment([2011, 0, 7]).format('DDDo'), '7.', '7.');
-        test.equal(moment([2011, 0, 8]).format('DDDo'), '8.', '8.');
-        test.equal(moment([2011, 0, 9]).format('DDDo'), '9.', '9.');
-        test.equal(moment([2011, 0, 10]).format('DDDo'), '10.', '10.');
+        test.equal(moment([2011, 0, 1]).format('DDDo'), '1-ви', '1-ви');
+        test.equal(moment([2011, 0, 2]).format('DDDo'), '2-ри', '2-ри');
+        test.equal(moment([2011, 0, 3]).format('DDDo'), '3-ти', '3-ти');
+        test.equal(moment([2011, 0, 4]).format('DDDo'), '4-ти', '4-ти');
+        test.equal(moment([2011, 0, 5]).format('DDDo'), '5-ти', '5-ти');
+        test.equal(moment([2011, 0, 6]).format('DDDo'), '6-ти', '6-ти');
+        test.equal(moment([2011, 0, 7]).format('DDDo'), '7-ми', '7-ми');
+        test.equal(moment([2011, 0, 8]).format('DDDo'), '8-ми', '8-ми');
+        test.equal(moment([2011, 0, 9]).format('DDDo'), '9-ти', '9-ти');
+        test.equal(moment([2011, 0, 10]).format('DDDo'), '10-ти', '10-ти');
 
-        test.equal(moment([2011, 0, 11]).format('DDDo'), '11.', '11.');
-        test.equal(moment([2011, 0, 12]).format('DDDo'), '12.', '12.');
-        test.equal(moment([2011, 0, 13]).format('DDDo'), '13.', '13.');
-        test.equal(moment([2011, 0, 14]).format('DDDo'), '14.', '14.');
-        test.equal(moment([2011, 0, 15]).format('DDDo'), '15.', '15.');
-        test.equal(moment([2011, 0, 16]).format('DDDo'), '16.', '16.');
-        test.equal(moment([2011, 0, 17]).format('DDDo'), '17.', '17.');
-        test.equal(moment([2011, 0, 18]).format('DDDo'), '18.', '18.');
-        test.equal(moment([2011, 0, 19]).format('DDDo'), '19.', '19.');
-        test.equal(moment([2011, 0, 20]).format('DDDo'), '20.', '20.');
+        test.equal(moment([2011, 0, 11]).format('DDDo'), '11-ти', '11-ти');
+        test.equal(moment([2011, 0, 12]).format('DDDo'), '12-ти', '12-ти');
+        test.equal(moment([2011, 0, 13]).format('DDDo'), '13-ти', '13-ти');
+        test.equal(moment([2011, 0, 14]).format('DDDo'), '14-ти', '14-ти');
+        test.equal(moment([2011, 0, 15]).format('DDDo'), '15-ти', '15-ти');
+        test.equal(moment([2011, 0, 16]).format('DDDo'), '16-ти', '16-ти');
+        test.equal(moment([2011, 0, 17]).format('DDDo'), '17-ти', '17-ти');
+        test.equal(moment([2011, 0, 18]).format('DDDo'), '18-ти', '18-ти');
+        test.equal(moment([2011, 0, 19]).format('DDDo'), '19-ти', '19-ти');
+        test.equal(moment([2011, 0, 20]).format('DDDo'), '20-ти', '20-ти');
 
-        test.equal(moment([2011, 0, 21]).format('DDDo'), '21.', '21.');
-        test.equal(moment([2011, 0, 22]).format('DDDo'), '22.', '22.');
-        test.equal(moment([2011, 0, 23]).format('DDDo'), '23.', '23.');
-        test.equal(moment([2011, 0, 24]).format('DDDo'), '24.', '24.');
-        test.equal(moment([2011, 0, 25]).format('DDDo'), '25.', '25.');
-        test.equal(moment([2011, 0, 26]).format('DDDo'), '26.', '26.');
-        test.equal(moment([2011, 0, 27]).format('DDDo'), '27.', '27.');
-        test.equal(moment([2011, 0, 28]).format('DDDo'), '28.', '28.');
-        test.equal(moment([2011, 0, 29]).format('DDDo'), '29.', '29.');
-        test.equal(moment([2011, 0, 30]).format('DDDo'), '30.', '30.');
+        test.equal(moment([2011, 0, 21]).format('DDDo'), '21-ви', '21-ви');
+        test.equal(moment([2011, 0, 22]).format('DDDo'), '22-ри', '22-ри');
+        test.equal(moment([2011, 0, 23]).format('DDDo'), '23-ти', '23-ти');
+        test.equal(moment([2011, 0, 24]).format('DDDo'), '24-ти', '24-ти');
+        test.equal(moment([2011, 0, 25]).format('DDDo'), '25-ти', '25-ти');
+        test.equal(moment([2011, 0, 26]).format('DDDo'), '26-ти', '26-ти');
+        test.equal(moment([2011, 0, 27]).format('DDDo'), '27-ми', '27-ми');
+        test.equal(moment([2011, 0, 28]).format('DDDo'), '28-ми', '28-ми');
+        test.equal(moment([2011, 0, 29]).format('DDDo'), '29-ти', '29-ти');
+        test.equal(moment([2011, 0, 30]).format('DDDo'), '30-ти', '30-ти');
 
-        test.equal(moment([2011, 0, 31]).format('DDDo'), '31.', '31.');
+        test.equal(moment([2011, 0, 31]).format('DDDo'), '31-ви', '31-ви');
         test.done();
     },
 


### PR DESCRIPTION
Bulgarian ordinal numbers were not implemented (returned a fixed suffix '.')
Now the correct suffix is returned.
