### PR TITLE
Avoid mutating the passed array on initialization

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -347,6 +347,7 @@
     // [year, month, day , hour, minute, second, millisecond]
     function dateFromArray(input, asUTC, hoursOffset, minutesOffset) {
         var i, date, forValid = [];
+        input = input.slice(0);
         for (i = 0; i < 7; i++) {
             forValid[i] = input[i] = (input[i] == null) ? (i === 2 ? 1 : 0) : input[i];
         }

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -14,6 +14,15 @@ exports.create = {
         test.done();
     },
 
+    "array copying": function(test) {
+        var importantArray = [2009, 11];
+
+        test.expect(1);
+        moment(importantArray);
+        test.deepEqual(importantArray, [2009, 11], "initializer should not mutate the original array");
+        test.done();
+    },
+
     "number" : function(test) {
         test.expect(3);
         test.ok(moment(1000).toDate() instanceof Date, "1000");


### PR DESCRIPTION
Dangerous practice in general; in my case, messed up the data keys (which were the orders' months, like `[2012, 11]`), only because I printed the month labels with `moment(myKeyArray).format(...)`
