### PR TITLE
Avoid mutating the passed array on initialization (resubmitting against dev branch)

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -806,7 +806,7 @@
         } else if (typeof input === 'string') {
             makeDateFromString(config);
         } else if (isArray(input)) {
-            config._a = input;
+            config._a = input.slice(0);
             dateFromArray(config);
         } else {
             config._d = input instanceof Date ? input : new Date(input);

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -14,6 +14,14 @@ exports.create = {
         test.done();
     },
 
+    "array copying": function(test) {
+        var importantArray = [2009, 11];
+        test.expect(1);
+        moment(importantArray);
+        test.deepEqual(importantArray, [2009, 11], "initializer should not mutate the original array");
+        test.done();
+    },
+
     "number" : function(test) {
         test.expect(3);
         test.ok(moment(1000).toDate() instanceof Date, "1000");


### PR DESCRIPTION
Dangerous practice in general; in my case, messed up the data keys (which were the orders' months, like `[2012, 11]`), only because I printed the month labels with `moment(myKeyArray).format(...)`
