### PR TITLE
Fixed flaky test

### DIFF
--- a/test/moment/diff.js
+++ b/test/moment/diff.js
@@ -9,7 +9,7 @@ exports.diff = {
         test.equal(moment(0).diff(1000), -1000, "0 - 1 second = -1000");
         test.equal(moment(new Date(1000)).diff(1000), 0, "1 second - 1 second = 0");
         var oneHourDate = new Date(),
-        nowDate = new Date();
+        nowDate = new Date(oneHourDate);
         oneHourDate.setHours(oneHourDate.getHours() + 1);
         test.equal(moment(oneHourDate).diff(nowDate), 60 * 60 * 1000, "1 hour from now = 360000");
         test.done();


### PR DESCRIPTION
There was one place left where 2 separately created dates are compared for equality. I checked all moment constructors without arguments and all Date constructors without arguments. They all seem safe now. Hope this error doesn't appear again.
