### PR TITLE
Change from round(...) to Math.floor(...) when calculating relative number of months

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -844,7 +844,7 @@
                 days === 1 && ['d'] ||
                 days <= 25 && ['dd', days] ||
                 days <= 45 && ['M'] ||
-                days < 345 && ['MM', round(days / 30)] ||
+                days < 345 && ['MM', Math.floor(days / 30)] ||
                 years === 1 && ['y'] || ['yy', years];
         args[2] = withoutSuffix;
         args[3] = milliseconds > 0;


### PR DESCRIPTION
I noticed that:

```
moment('2012-02-01T00:00:00').from('2012-12-11T11:29:59') == "10 months ago"
//but...
moment('2012-02-01T00:00:00').from('2012-12-11T11:30:00') == "11 months ago"
```

I expected `10 months ago` in both cases (this is the behaviour of `time_ago_in_words` in Rails). I've made a small commit which  changes this behaviour. I haven't had a chance to run the full suit of tests as I'm not on my development machine, but I thought I should open this pull request for some feedback as to weather this change in behaviour is appropriate for Moment. If so I'll go through and fix anything this change breaks!
