### PR TITLE
toString now returns a fixed format that looks like unix data

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1028,7 +1028,7 @@
         },
 
         toString : function () {
-            return this._d.toString();
+            return this.format("ddd MMM DD YYYY HH:mm:ss [GMT]ZZ");
         },
 
         toDate : function () {

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -69,13 +69,6 @@ exports.create = {
         test.done();
     },
 
-    "string from Date.toString" : function(test) {
-        test.expect(1);
-        var str = (new Date()).toString();
-        test.equal(moment(str).toString(), str, "Parsing a string from Date.prototype.toString should match moment.fn.toString");
-        test.done();
-    },
-
     "string without format - json" : function(test) {
         test.expect(5);
         test.equal(moment("Date(1325132654000)").valueOf(), 1325132654000, "Date(1325132654000)");

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -167,5 +167,13 @@ exports.format = {
         }
 
         test.done();
+    },
+
+    "toString is just human readable format" : function(test) {
+        test.expect(1);
+
+        var b = moment(new Date(2009, 1, 5, 15, 25, 50, 125));
+        test.equal(b.toString(), b.format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'));
+        test.done();
     }
 };


### PR DESCRIPTION
This commit is the product of discussions in #475.

`toString` == `format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ')`, so that 
- works properly on utc and non-utc moments
- its uniform across browsers
