### PR TITLE
adding a start/endOf week support

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1149,15 +1149,17 @@
         },
 
         startOf: function (units) {
+            units = units.replace(/s$/, '');
             // the following switch intentionally omits break keywords
             // to utilize falling through the cases.
-            switch (units.replace(/s$/, '')) {
+            switch (units) {
             case 'year':
                 this.month(0);
                 /* falls through */
             case 'month':
                 this.date(1);
                 /* falls through */
+            case 'week':
             case 'day':
                 this.hours(0);
                 /* falls through */
@@ -1171,6 +1173,12 @@
                 this.milliseconds(0);
                 /* falls through */
             }
+
+            // weeks are a special case
+            if (units === 'week') {
+                this.day(0);
+            }
+
             return this;
         },
 

--- a/test/moment/sod_eod.js
+++ b/test/moment/sod_eod.js
@@ -101,6 +101,40 @@ exports.eod_sod = {
         test.equal(m.milliseconds(), 999, "set the seconds");
         test.done();
     },
+
+    "start of week" : function(test) {
+        test.expect(9);
+
+        var m = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).startOf('week');
+        var ms = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).startOf('weeks');
+        test.equal(+m, +ms, "Plural or singular should work");
+        test.equal(m.year(), 2011, "keep the year");
+        test.equal(m.month(), 0, "rolls back to January");
+        test.equal(m.day(), 0, "set day of week");
+        test.equal(m.date(), 30, "set correct date");
+        test.equal(m.hours(), 0, "strip out the hours");
+        test.equal(m.minutes(), 0, "strip out the minutes");
+        test.equal(m.seconds(), 0, "strip out the seconds");
+        test.equal(m.milliseconds(), 0, "strip out the milliseconds");
+        test.done();
+    },
+    
+    "end of week" : function(test) {
+        test.expect(9);
+
+        var m = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).endOf('week');
+        var ms = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).endOf('weeks');
+        test.equal(+m, +ms, "Plural or singular should work");
+        test.equal(m.year(), 2011, "keep the year");
+        test.equal(m.month(), 1, "keep the month");
+        test.equal(m.day(), 6, "set the day of the week");
+        test.equal(m.date(), 5, "set the day");
+        test.equal(m.hours(), 23, "set the hours");
+        test.equal(m.minutes(), 59, "set the minutes");
+        test.equal(m.seconds(), 59, "set the seconds");
+        test.equal(m.milliseconds(), 999, "set the seconds");
+        test.done();
+    },
     
     "start of day" : function(test) {
         test.expect(8);


### PR DESCRIPTION
adding weeks support to startOf/endOf for convenience and consistency with startOf/endOf('month')

fixes issue raised here: https://github.com/timrwood/moment/issues/558
