### PR TITLE
Adding ability to set the parse language

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -608,7 +608,7 @@
             break;
         case 'MMM' : // fall through to MMMM
         case 'MMMM' :
-            a = getLangDefinition().monthsParse(input);
+            a = getLangDefinition(config._l).monthsParse(input);
             // if we didn't find a month name, mark the date as invalid.
             if (a != null) {
                 datePartArray[1] = a;
@@ -912,19 +912,21 @@
         return new Moment(config);
     }
 
-    moment = function (input, format) {
+    moment = function (input, format, lang) {
         return makeMoment({
             _i : input,
             _f : format,
+            _l : lang,
             _isUTC : false
         });
     };
 
     // creating with utc
-    moment.utc = function (input, format) {
+    moment.utc = function (input, format, lang) {
         return makeMoment({
             _useUTC : true,
             _isUTC : true,
+            _l : lang,
             _i : input,
             _f : format
         });

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -351,5 +351,24 @@ exports.create = {
         test.equal(moment("-1000-01-01", "YYYYY-MM-DD").toDate().getFullYear(), -1000, "parse BC 1,001");
         test.equal(moment.utc("-1000-01-01", "YYYYY-MM-DD").toDate().getUTCFullYear(), -1000, "parse utc BC 1,001");
         test.done();
+    },
+
+    "parsing into a language" : function (test) {
+        test.expect(2);
+
+        moment.lang('parselang', {
+            months : "one_two_three_four_five_six_seven_eight_nine_ten_eleven_twelve".split('_'),
+            monthsShort : "one_two_three_four_five_six_seven_eight_nine_ten_eleven_twelve".split("_")
+        });
+
+        moment.lang('en');
+
+        test.equal(moment('2012 seven', 'YYYY MMM', 'parselang').month(), 6, "should be able to parse in a specific language");
+
+        moment.lang('parselang');
+
+        test.equal(moment('2012 july', 'YYYY MMM', 'en').month(), 6, "should be able to parse in a specific language");
+
+        test.done();
     }
 };


### PR DESCRIPTION
This is to support #508 so that you can set a parsing language for in input string + format.

This way, you don't have to change the global language to parse a moment into another language. Without a language key, it defaults to the current behavior using the global language.

``` javascript
moment('2012 July', 'YYYY MMM', 'en');
moment('2012 juillet', 'YYYY MMM', 'fr');
```
