### PR TITLE
Changing lang.ordinal to return number + ordinal instead of just the ordinal

### DIFF
--- a/lang/ar-ma.js
+++ b/lang/ar-ma.js
@@ -39,9 +39,6 @@ require('../moment').lang('ar-ma', {
         y : "سنة",
         yy : "%d سنوات"
     },
-    ordinal : function (number) {
-        return '';
-    },
     week : {
         dow : 6, // Saturday is the first day of the week.
         doy : 12  // The week that contains Jan 1st is the first week of the year.

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -38,9 +38,6 @@ require('../moment').lang('ar', {
         y : "سنة",
         yy : "%d سنوات"
     },
-    ordinal : function (number) {
-        return '';
-    },
     week : {
         dow : 6, // Saturday is the first day of the week.
         doy : 12  // The week that contains Jan 1st is the first week of the year.

--- a/lang/bg.js
+++ b/lang/bg.js
@@ -54,19 +54,19 @@ require('../moment').lang('bg', {
         var lastDigit = number % 10,
             last2Digits = number % 100;
         if (number === 0) {
-            return '-ев';
+            return number + '-ев';
         } else if (last2Digits === 0) {
-            return '-ен';
+            return number + '-ен';
         } else if (last2Digits > 10 && last2Digits < 20) {
-            return '-ти';
+            return number + '-ти';
         } else if (lastDigit === 1) {
-            return '-ви';
+            return number + '-ви';
         } else if (lastDigit === 2) {
-            return '-ри';
+            return number + '-ри';
         } else if (lastDigit === 7 || lastDigit === 8) {
-            return '-ми';
+            return number + '-ми';
         } else {
-            return '-ти';
+            return number + '-ти';
         }
     },
     week : {

--- a/lang/ca.js
+++ b/lang/ca.js
@@ -48,9 +48,7 @@ require('../moment').lang('ca', {
         y : "un any",
         yy : "%d anys"
     },
-    ordinal : function (number) {
-        return 'º';
-    },
+    ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -137,9 +137,7 @@ require('../moment').lang('cs', {
         y : translate,
         yy : translate
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/cv.js
+++ b/lang/cv.js
@@ -42,9 +42,7 @@ require('../moment').lang('cv', {
         y : "пĕр çул",
         yy : "%d çул"
     },
-    ordinal : function (number) {
-        return '-мĕш';
-    },
+    ordinal : '%d-мĕш',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/da.js
+++ b/lang/da.js
@@ -38,9 +38,7 @@ require('../moment').lang('da', {
         y : "år",
         yy : "%d år"
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/de.js
+++ b/lang/de.js
@@ -38,9 +38,7 @@ require('../moment').lang('de', {
         y : "einem Jahr",
         yy : "%d Jahren"
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/en-ca.js
+++ b/lang/en-ca.js
@@ -39,10 +39,11 @@ require('../moment').lang('en-ca', {
         yy : "%d years"
     },
     ordinal : function (number) {
-        var b = number % 10;
-        return (~~ (number % 100 / 10) === 1) ? 'th' :
+        var b = number % 10,
+            output = (~~ (number % 100 / 10) === 1) ? 'th' :
             (b === 1) ? 'st' :
             (b === 2) ? 'nd' :
             (b === 3) ? 'rd' : 'th';
+        return number + output;
     }
 });

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -39,11 +39,12 @@ require('../moment').lang('en-gb', {
         yy : "%d years"
     },
     ordinal : function (number) {
-        var b = number % 10;
-        return (~~ (number % 100 / 10) === 1) ? 'th' :
+        var b = number % 10,
+            output = (~~ (number % 100 / 10) === 1) ? 'th' :
             (b === 1) ? 'st' :
             (b === 2) ? 'nd' :
             (b === 3) ? 'rd' : 'th';
+        return number + output;
     },
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/lang/eo.js
+++ b/lang/eo.js
@@ -47,9 +47,7 @@ require('../moment').lang('eo', {
         y : "jaro",
         yy : "%d jaroj"
     },
-    ordinal : function (number) {
-        return "a";
-    },
+    ordinal : "%da",
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/es.js
+++ b/lang/es.js
@@ -48,9 +48,7 @@ require('../moment').lang('es', {
         y : "un año",
         yy : "%d años"
     },
-    ordinal : function (number) {
-        return 'º';
-    },
+    ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/et.js
+++ b/lang/et.js
@@ -42,9 +42,7 @@ require('../moment').lang('et', {
         y      : "aasta",
         yy     : "%d aastat"
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/eu.js
+++ b/lang/eu.js
@@ -38,9 +38,7 @@ require('../moment').lang('eu', {
         y : "urte bat",
         yy : "%d urte"
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -81,9 +81,7 @@ require('../moment').lang('fi', {
         y : translate,
         yy : translate
     },
-    ordinal : function (number) {
-        return ".";
-    },
+    ordinal : "%d.",
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/fr-ca.js
+++ b/lang/fr-ca.js
@@ -39,6 +39,6 @@ require('../moment').lang('fr-ca', {
         yy : "%d années"
     },
     ordinal : function (number) {
-        return number === 1 ? 'er' : 'ème';
+        return number + (number === 1 ? 'er' : 'ème');
     }
 });

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -39,7 +39,7 @@ require('../moment').lang('fr', {
         yy : "%d années"
     },
     ordinal : function (number) {
-        return number === 1 ? 'er' : 'ème';
+        return number + (number === 1 ? 'er' : 'ème');
     },
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/lang/gl.js
+++ b/lang/gl.js
@@ -48,9 +48,7 @@ require('../moment').lang('gl', {
         y : "un ano",
         yy : "%d anos"
     },
-    ordinal : function (number) {
-        return 'º';
-    },
+    ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/he.js
+++ b/lang/he.js
@@ -38,8 +38,5 @@ require('../moment').lang('he', {
         MM : "%d חודשים",
         y : "שנה",
         yy : "%d שנים"
-    },
-    ordinal : function (number) {
-        return ''; // Function is not required for the Hebrew language.
     }
 });

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -79,10 +79,7 @@ require('../moment').lang('hu', {
         y : translate,
         yy : translate
     },
-    ordinal : function (number) {
-        return '.';
-
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/id.js
+++ b/lang/id.js
@@ -50,9 +50,6 @@ require('../moment').lang('id', {
         y : "setahun",
         yy : "%d tahun"
     },
-    ordinal : function (number) {
-        return '';
-    },
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/is.js
+++ b/lang/is.js
@@ -106,9 +106,7 @@ require('../moment').lang('is', {
         y : translate,
         yy : translate
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/it.js
+++ b/lang/it.js
@@ -38,9 +38,7 @@ require('../moment').lang('it', {
         y : "un anno",
         yy : "%d anni"
     },
-    ordinal: function () {
-        return 'º';
-    },
+    ordinal: '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -44,8 +44,5 @@ require('../moment').lang('ja', {
         MM : "%dヶ月",
         y : "1年",
         yy : "%d年"
-    },
-    ordinal : function (number) {
-        return '';
     }
 });

--- a/lang/jp.js
+++ b/lang/jp.js
@@ -47,8 +47,5 @@ require('../moment').lang('jp', {
         MM : "%dヶ月",
         y : "1年",
         yy : "%d年"
-    },
-    ordinal : function (number) {
-        return '';
     }
 });

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -42,7 +42,5 @@ require('../moment').lang('ko', {
         y : "일년",
         yy : "%d년"
     },
-    ordinal : function (number) {
-        return '일';
-    }
+    ordinal : '%d일'
 });

--- a/lang/kr.js
+++ b/lang/kr.js
@@ -45,7 +45,5 @@ require('../moment').lang('kr', {
         y : "일년",
         yy : "%d년"
     },
-    ordinal : function (number) {
-        return '일';
-    }
+    ordinal : '%d일'
 });

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -59,9 +59,7 @@ require('../moment').lang('lv', {
         y : "gadu",
         yy : relativeTimeWithPlural
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/nb.js
+++ b/lang/nb.js
@@ -38,9 +38,7 @@ require('../moment').lang('nb', {
         y : "ett år",
         yy : "%d år"
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/ne.js
+++ b/lang/ne.js
@@ -88,9 +88,6 @@ require('../moment').lang('ne', {
         y : "एक बर्ष",
         yy : "%d बर्ष"
     },
-    ordinal : function (number) {
-        return '';
-    },
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -48,7 +48,7 @@ require('../moment').lang('nl', {
         yy : "%d jaar"
     },
     ordinal : function (number) {
-        return (number === 1 || number === 8 || number >= 20) ? 'ste' : 'de';
+        return number + ((number === 1 || number === 8 || number >= 20) ? 'ste' : 'de');
     },
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -71,9 +71,7 @@ require('../moment').lang('pl', {
         y : "rok",
         yy : translate
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -42,7 +42,5 @@ require('../moment').lang('pt-br', {
         y : "um ano",
         yy : "%d anos"
     },
-    ordinal : function (number) {
-        return 'º';
-    }
+    ordinal : '%dº'
 });

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -42,9 +42,7 @@ require('../moment').lang('pt', {
         y : "um ano",
         yy : "%d anos"
     },
-    ordinal : function (number) {
-        return 'º';
-    },
+    ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 4  // The week that contains Jan 4th is the first week of the year.

--- a/lang/ro.js
+++ b/lang/ro.js
@@ -39,9 +39,6 @@ require('../moment').lang('ro', {
         y : "un an",
         yy : "%d ani"
     },
-    ordinal : function (number) {
-        return '';
-    },
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -116,9 +116,7 @@ require('../moment').lang('ru', {
         y : "год",
         yy : relativeTimeWithPlural
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/sl.js
+++ b/lang/sl.js
@@ -126,9 +126,7 @@ require('../moment').lang('sl', {
         y      : "eno leto",
         yy     : translate
     },
-    ordinal : function (number) {
-        return '.';
-    },
+    ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
         doy : 7  // The week that contains Jan 1st is the first week of the year.

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -39,11 +39,12 @@ require('../moment').lang('sv', {
         yy : "%d år"
     },
     ordinal : function (number) {
-        var b = number % 10;
-        return (~~ (number % 100 / 10) === 1) ? 'e' :
+        var b = number % 10,
+            output = (~~ (number % 100 / 10) === 1) ? 'e' :
             (b === 1) ? 'a' :
             (b === 2) ? 'a' :
             (b === 3) ? 'e' : 'e';
+        return number + output;
     },
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/lang/th.js
+++ b/lang/th.js
@@ -44,8 +44,5 @@ require('../moment').lang('th', {
         MM : "%d เดือน",
         y : "1 ปี",
         yy : "%d ปี"
-    },
-    ordinal : function (number) {
-        return '';
     }
 });

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -67,13 +67,13 @@ require('../moment').lang('tr', {
     },
     ordinal : function (number) {
         if (number === 0) {  // special case for zero
-            return "'ıncı";
+            return number + "'ıncı";
         }
         var a = number % 10,
             b = number % 100 - a,
             c = number >= 100 ? 100 : null;
 
-        return suffixes[a] || suffixes[b] || suffixes[c];
+        return number + (suffixes[a] || suffixes[b] || suffixes[c]);
     },
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/lang/tzm-la.js
+++ b/lang/tzm-la.js
@@ -38,9 +38,6 @@ require('../moment').lang('tzm-la', {
         y : "asgas",
         yy : "%d isgasn"
     },
-    ordinal : function (number) {
-        return '';
-    },
     week : {
         dow : 6, // Saturday is the first day of the week.
         doy : 12  // The week that contains Jan 1st is the first week of the year.

--- a/lang/tzm.js
+++ b/lang/tzm.js
@@ -38,9 +38,6 @@ require('../moment').lang('tzm', {
         y : "ⴰⵙⴳⴰⵙ",
         yy : "%d ⵉⵙⴳⴰⵙⵏ"
     },
-    ordinal : function (number) {
-        return '';
-    },
     week : {
         dow : 6, // Saturday is the first day of the week.
         doy : 12  // The week that contains Jan 1st is the first week of the year.

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -50,8 +50,5 @@ require('../moment').lang('zh-cn', {
         MM : "%d个月",
         y : "1年",
         yy : "%d年"
-    },
-    ordinal : function (number) {
-        return '';
     }
 });

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -50,8 +50,5 @@ require('../moment').lang('zh-tw', {
         MM : "%d個月",
         y : "一年",
         yy : "%d年"
-    },
-    ordinal : function (number) {
-        return '';
     }
 });

--- a/moment.js
+++ b/moment.js
@@ -171,8 +171,7 @@
     }
     function ordinalizeToken(func) {
         return function (a) {
-            var b = func.call(this, a);
-            return b + this.lang().ordinal(b);
+            return this.lang().ordinal(func.call(this, a));
         };
     }
 
@@ -444,8 +443,9 @@
         },
 
         ordinal : function (number) {
-            return '';
+            return this._ordinal.replace("%d", number);
         },
+        _ordinal : "%d",
 
         preparse : function (string) {
             return string;
@@ -1324,11 +1324,12 @@
     // Set default language, other languages will inherit from English.
     moment.lang('en', {
         ordinal : function (number) {
-            var b = number % 10;
-            return (~~ (number % 100 / 10) === 1) ? 'th' :
+            var b = number % 10,
+                output = (~~ (number % 100 / 10) === 1) ? 'th' :
                 (b === 1) ? 'st' :
                 (b === 2) ? 'nd' :
                 (b === 3) ? 'rd' : 'th';
+            return number + output;
         }
     });
 


### PR DESCRIPTION
See https://github.com/timrwood/moment/issues/484#issuecomment-9923454

**Note** the following comment was copied here for simplicity.

With the new internals of the languages, all of the properties of a language config get added as `lang._property` if they are not a function, and `lang.property` if they are a function. 

[Line 119](https://github.com/timrwood/moment/blob/294685a55a971e3f27291a3659f2708e9a210204/moment.js#L199)

``` javascript
function Language(config) {
    var prop, i;
    for (i in config) {
        prop = config[i];
        if (typeof prop === 'function') {
            this[i] = prop;
        } else {
            this['_' + i] = prop;
        }
    }
}
```

Then, the default method and property on the `Language.prototype` could be something like this.

``` javascript
Language.prototype.ordinal = function (number) {
    return this._ordinal.replace("%d", number);
};
Language.prototype._ordinal = "%d";
```

Then, languages like Bulgarian, Catalan, Chuvash, and many others can just set a string as the ordinal property which would then overwrite `Language.prototype._ordinal`, but would still use `Language.prototype.ordinal`.

``` javascript
moment.lang('bg', {
   ordinal : "%d."
});
moment.lang('ca', {
   ordinal : "%dº"
});
moment.lang('cv', {
   ordinal : "%d-мĕш"
});
```

Then, no other internals would need to change except for [ordinalizeToken](https://github.com/timrwood/moment/blob/294685a55a971e3f27291a3659f2708e9a210204/moment.js#L173) which would actually be simpler.

``` javascript
// before
function ordinalizeToken(func) {
    return function (a) {
        var b = func.call(this, a);
        return b + this.lang().ordinal(b);
    };
}
// after
function ordinalizeToken(func) {
    return function (a) {
        return this.lang().ordinal(func.call(this, a));
    };
}
```
