### PR TITLE
Changed three letter shortenings to tam -> tammi and so forth

### DIFF
--- a/lang/fi.js
+++ b/lang/fi.js
@@ -47,7 +47,7 @@ function verbal_number(number, isFuture) {
 
 require('../moment').lang('fi', {
     months : "tammikuu_helmikuu_maaliskuu_huhtikuu_toukokuu_kesäkuu_heinäkuu_elokuu_syyskuu_lokakuu_marraskuu_joulukuu".split("_"),
-    monthsShort : "tam_hel_maa_huh_tou_kes_hei_elo_syy_lok_mar_jou".split("_"),
+    monthsShort : "tammi_helmi_maalis_huhti_touko_kesä_heinä_elo_syys_loka_marras_joulu".split("_"),
     weekdays : "sunnuntai_maanantai_tiistai_keskiviikko_torstai_perjantai_lauantai".split("_"),
     weekdaysShort : "su_ma_ti_ke_to_pe_la".split("_"),
     weekdaysMin : "su_ma_ti_ke_to_pe_la".split("_"),

--- a/test/lang/fi.js
+++ b/test/lang/fi.js
@@ -18,7 +18,7 @@ exports["lang:fi"] = {
 
     "parse" : function(test) {
         test.expect(96);
-        var tests = 'tammikuu tam_helmikuu hel_maaliskuu maa_huhtikuu huh_toukokuu tou_kesäkuu kes_heinäkuu hei_elokuu elo_syyskuu syys_lokakuu lok_marraskuu mar_joulukuu jou'.split("_");
+        var tests = 'tammikuu tammi_helmikuu helmi_maaliskuu maalis_huhtikuu huhti_toukokuu touko_kesäkuu kesä_heinäkuu heinä_elokuu elo_syyskuu syys_lokakuu loka_marraskuu marras_joulukuu joulu'.split("_");
         var i;
         function equalTest(input, mmm, i) {
             test.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
@@ -42,7 +42,7 @@ exports["lang:fi"] = {
         var a = [
                 ['dddd, MMMM Do YYYY, h:mm:ss a',      'sunnuntai, helmikuu 14. 2010, 3:25:50 pm'],
                 ['ddd, hA',                            'su, 3PM'],
-                ['M Mo MM MMMM MMM',                   '2 2. 02 helmikuu hel'],
+                ['M Mo MM MMMM MMM',                   '2 2. 02 helmikuu helmi'],
                 ['YYYY YY',                            '2010 10'],
                 ['D Do DD',                            '14 14. 14'],
                 ['d do dddd ddd dd',                   '0 0. sunnuntai su su'],
@@ -59,9 +59,9 @@ exports["lang:fi"] = {
                 ['LLL',                                '14. helmikuuta 2010, klo 15.25'],
                 ['LLLL',                               'sunnuntai, 14. helmikuuta 2010, klo 15.25'],
                 ['l',                                  '14.2.2010'],
-                ['ll',                                 '14. hel 2010'],
-                ['lll',                                '14. hel 2010, klo 15.25'],
-                ['llll',                               'su, 14. hel 2010, klo 15.25']
+                ['ll',                                 '14. helmi 2010'],
+                ['lll',                                '14. helmi 2010, klo 15.25'],
+                ['llll',                               'su, 14. helmi 2010, klo 15.25']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;
@@ -112,7 +112,7 @@ exports["lang:fi"] = {
 
     "format month" : function(test) {
         test.expect(12);
-        var expected = 'tammikuu tam_helmikuu hel_maaliskuu maa_huhtikuu huh_toukokuu tou_kesäkuu kes_heinäkuu hei_elokuu elo_syyskuu syy_lokakuu lok_marraskuu mar_joulukuu jou'.split("_");
+        var expected = 'tammikuu tammi_helmikuu helmi_maaliskuu maalis_huhtikuu huhti_toukokuu touko_kesäkuu kesä_heinäkuu heinä_elokuu elo_syyskuu syys_lokakuu loka_marraskuu marras_joulukuu joulu'.split("_");
         var i;
         for (i = 0; i < expected.length; i++) {
             test.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);


### PR DESCRIPTION
Well, this isn't perfect, but since somebody might want to shorten the literal form of months to something, this is the best option I could come up with.
