### PR TITLE
1.7.2 에서 ordinal 오류나는 문제

### DIFF
--- a/lang/ko.js
+++ b/lang/ko.js
@@ -42,5 +42,5 @@ require('../moment').lang('ko', {
         y : "일년",
         yy : "%d년"
     },
-    ordinal : '%d일'
+    ordinal : function () { return '일'; }
 });


### PR DESCRIPTION
코드를 살펴본 결과 ordinal 을 함수로 호출하는데, string만 반환하게 되어있어
문제가 되었다.
