### PR TITLE
Proposed enhancement for french translation related to year

### DIFF
--- a/lang/fr.js
+++ b/lang/fr.js
@@ -35,7 +35,7 @@ require('../moment').lang('fr', {
         dd : "%d jours",
         M : "un mois",
         MM : "%d mois",
-        y : "une année",
+        y : "un an",
         yy : "%d années"
     },
     ordinal : function (number) {


### PR DESCRIPTION
It sounds more natural to say `il y a un an` than `il y a une année` and same for `dans un an` than `dans une année`.
