### PR TITLE
Fixed a bug in cloning a Date

### DIFF
--- a/test/moment/diff.js
+++ b/test/moment/diff.js
@@ -15,7 +15,7 @@ exports.diff = {
         var oneHourDate = new Date(),
             nowDate = new Date(+oneHourDate);
         oneHourDate.setHours(oneHourDate.getHours() + 1);
-        test.equal(moment(oneHourDate).diff(nowDate), 60 * 60 * 1000, "1 hour from now = 360000");
+        test.equal(moment(oneHourDate).diff(nowDate), 60 * 60 * 1000, "1 hour from now = 3600000");
         test.done();
     },
 


### PR DESCRIPTION
To clone a Date object d you need to convert it to a Number first and then pass
it to Date constructor, like new Date(+d). Otherwise some browsers (firefox)
cut milliseconds.

Related to https://github.com/timrwood/moment/issues/625
