### PR TITLE
fix grunt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "devDependencies" : {
         "uglify-js" : "1.3.4",
         "nodeunit"  : "latest",
-        "grunt"     : "latest"
+        "grunt"     : "~0.3.17"
     },
     "scripts": {
         "test": "grunt"


### PR DESCRIPTION
Hi,

I changed the grunt version for '~0.3.17' instead of 'latest'.
If someone run the command grunt with the latest version, this kind
of message will appear:
"Fatal error: Unable to find Gruntfile".

Thanks.
