### PR TITLE
Create String setters for moment#month and moment#day

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -57,7 +57,7 @@
         parseTimezoneChunker = /([\+\-]|\d\d)/gi,
 
         // getter and setter names
-        proxyGettersAndSetters = 'Month|Date|Hours|Minutes|Seconds|Milliseconds'.split('|'),
+        proxyGettersAndSetters = 'Date|Hours|Minutes|Seconds|Milliseconds'.split('|'),
         unitMillisecondFactors = {
             'Milliseconds' : 1,
             'Seconds' : 1e3,
@@ -358,7 +358,7 @@
         },
 
         monthsParse : function (monthName) {
-            var i, mom, regex, output;
+            var i, mom, regex;
 
             if (!this._monthsParse) {
                 this._monthsParse = [];
@@ -391,6 +391,27 @@
         _weekdaysMin : "Su_Mo_Tu_We_Th_Fr_Sa".split("_"),
         weekdaysMin : function (m) {
             return this._weekdaysMin[m.day()];
+        },
+
+        weekdaysParse : function (weekdayName) {
+            var i, mom, regex;
+
+            if (!this._weekdaysParse) {
+                this._weekdaysParse = [];
+            }
+
+            for (i = 0; i < 7; i++) {
+                // make the regex if we don't have it already
+                if (!this._weekdaysParse[i]) {
+                    mom = moment([2000, 1]).day(i);
+                    regex = '^' + this.weekdays(mom, '') + '|^' + this.weekdaysShort(mom, '') + '|^' + this.weekdaysMin(mom, '');
+                    this._weekdaysParse[i] = new RegExp(regex.replace('.', ''), 'i');
+                }
+                // test the regex
+                if (this._weekdaysParse[i].test(weekdayName)) {
+                    return i;
+                }
+            }
         },
 
         _longDateFormat : {
@@ -1185,8 +1206,33 @@
 
         day : function (input) {
             var day = this._isUTC ? this._d.getUTCDay() : this._d.getDay();
-            return input == null ? day :
-                this.add({ d : input - day });
+            if (input != null) {
+                if (typeof input === 'string') {
+                    input = this.lang().weekdaysParse(input);
+                    if (typeof input !== 'number') {
+                        return this;
+                    }
+                }
+                return this.add({ d : input - day });
+            } else {
+                return day;
+            }
+        },
+
+        month : function (input) {
+            var utc = this._isUTC ? 'UTC' : '';
+            if (input != null) {
+                if (typeof input === 'string') {
+                    input = this.lang().monthsParse(input);
+                    if (typeof input !== 'number') {
+                        return this;
+                    }
+                }
+                this._d['set' + utc + 'Month'](input);
+                return this;
+            } else {
+                return this._d['get' + utc + 'Month']();
+            }
         },
 
         startOf: function (units) {
@@ -1301,6 +1347,7 @@
 
     // add plural methods
     moment.fn.days = moment.fn.day;
+    moment.fn.months = moment.fn.month;
     moment.fn.weeks = moment.fn.week;
     moment.fn.isoWeeks = moment.fn.isoWeek;
 

--- a/test/moment/getters_setters.js
+++ b/test/moment/getters_setters.js
@@ -81,6 +81,20 @@ exports.getters_setters = {
         test.equal(a.milliseconds(), 9, 'milliseconds');
         test.done();
     },
+    
+    "setters strings" : function(test) {
+        test.expect(7);
+
+        var a = moment().lang('en');
+        test.equal(a.day(0).day('Wednesday').day(), 3, 'day full name');
+        test.equal(a.day(0).day('Wed').day(), 3, 'day short name');
+        test.equal(a.day(0).day('We').day(), 3, 'day minimal name');
+        test.equal(a.day(0).day('invalid').day(), 0, 'invalid day name');
+        test.equal(a.month(0).month('April').month(), 3, 'month full name');
+        test.equal(a.month(0).month('Apr').month(), 3, 'month short name');
+        test.equal(a.month(0).month('invalid').month(), 0, 'invalid month name');
+        test.done();
+    },
 
     "setters - falsey values" : function(test) {
         test.expect(1);

--- a/test/moment/weeks.js
+++ b/test/moment/weeks.js
@@ -1,6 +1,6 @@
 var moment = require("../../moment");
 
-exports.utc = {
+exports.weeks = {
     setUp : function (cb) {
         moment.lang('en');
         cb();


### PR DESCRIPTION
I wish to be able to set the month or weekday based on a name ('January' or 'Sunday') instead of a number (0). In other words, I want to use `moment().month('February')` or `moment().day('Sunday')`.

I should note that you can work around this limitation for month names by creating a second moment: `moment().month( moment('February', 'MMMM').month() )`.
