### PR TITLE
Added nodeunit as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "devDependencies" : {
         "uglify-js" : "latest",
         "grunt"     : "latest",
+        "nodeunit"  : "latest",
         "grunt-contrib-jshint"    : "latest",
         "grunt-contrib-nodeunit"  : "latest",
         "grunt-contrib-concat"    : "latest",


### PR DESCRIPTION
nodeunit is needed as a direct dependency for grunt tasks zone and zones.

Most of you have it already installed so you don't see the error, but if you clear the node_modules file grunt won't work in the current setup.
