### PR TITLE
Corrected galician translations gl.js

### DIFF
--- a/lang/gl.js
+++ b/lang/gl.js
@@ -36,7 +36,7 @@ require('../moment').lang('gl', {
     relativeTime : {
         future : "en %s",
         past : "hai %s",
-        s : "un segundo",
+        s : "uns segundos",
         m : "un minuto",
         mm : "%d minutos",
         h : "unha hora",


### PR DESCRIPTION
- Corrected "Octubro" --> "Outubro"
- Corrected "fai" --> "hai". "fai" is a spanized fail. Correct example: "two days ago" --> "hai dous días" (not "fai dous días")
- Corrected "uns segundo" --> "un segundo" (number agreement)
