### PR TITLE
Corrected Ukrainian and optimized Russian

### DIFF
--- a/lang/ru.js
+++ b/lang/ru.js
@@ -1,34 +1,20 @@
 // moment.js language configuration
 // language : russian (ru)
 // author : Viktorminator : https://github.com/Viktorminator
-
-var pluralRules = [
-    function (n) { return ((n % 10 === 1) && (n % 100 !== 11)); },
-    function (n) { return ((n % 10) >= 2 && (n % 10) <= 4 && ((n % 10) % 1) === 0) && ((n % 100) < 12 || (n % 100) > 14); },
-    function (n) { return ((n % 10) === 0 || ((n % 10) >= 5 && (n % 10) <= 9 && ((n % 10) % 1) === 0) || ((n % 100) >= 11 && (n % 100) <= 14 && ((n % 100) % 1) === 0)); },
-    function (n) { return true; }
-];
+// Author : Menelion Elensúle : https://github.com/Oire
 
 function plural(word, num) {
-    var forms = word.split('_'),
-    minCount = Math.min(pluralRules.length, forms.length),
-    i = -1;
-
-    while (++i < minCount) {
-        if (pluralRules[i](num)) {
-            return forms[i];
-        }
-    }
-    return forms[minCount - 1];
+    var forms = word.split('_');
+    return num % 10 === 1 && num % 100 !== 11 ? forms[0] : (num % 10 >= 2 && num % 10 <= 4 && (num % 100 < 10 || num % 100 >= 20) ? forms[1] : forms[2]);
 }
 
 function relativeTimeWithPlural(number, withoutSuffix, key) {
     var format = {
-        'mm': 'минута_минуты_минут_минуты',
-        'hh': 'час_часа_часов_часа',
-        'dd': 'день_дня_дней_дня',
-        'MM': 'месяц_месяца_месяцев_месяца',
-        'yy': 'год_года_лет_года'
+        'mm': 'минута_минуты_минут',
+        'hh': 'час_часа_часов',
+        'dd': 'день_дня_дней',
+        'MM': 'месяц_месяца_месяцев',
+        'yy': 'год_года_лет'
     };
     if (key === 'm') {
         return withoutSuffix ? 'минута' : 'минуту';
@@ -100,7 +86,6 @@ require('../moment').lang('ru', {
         },
         sameElse: 'L'
     },
-    // It needs checking (adding) russian plurals and cases.
     relativeTime : {
         future : "через %s",
         past : "%s назад",
@@ -116,6 +101,7 @@ require('../moment').lang('ru', {
         y : "год",
         yy : relativeTimeWithPlural
     },
+    // FIXME: this is not Russian ordinals format
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -1,33 +1,20 @@
 // moment.js language configuration
 // language : ukrainian (uk)
 // author : zemlanin : https://github.com/zemlanin
-var pluralRules = [
-    function (n) { return ((n % 10 === 1) && (n % 100 !== 11)); },
-    function (n) { return ((n % 10) >= 2 && (n % 10) <= 4 && ((n % 10) % 1) === 0) && ((n % 100) < 12 || (n % 100) > 14); },
-    function (n) { return ((n % 10) === 0 || ((n % 10) >= 5 && (n % 10) <= 9 && ((n % 10) % 1) === 0) || ((n % 100) >= 11 && (n % 100) <= 14 && ((n % 100) % 1) === 0)); },
-    function (n) { return true; }
-];
+// Author : Menelion Elensúle : https://github.com/Oire
 
 function plural(word, num) {
-    var forms = word.split('_'),
-    minCount = Math.min(pluralRules.length, forms.length),
-    i = -1;
-
-    while (++i < minCount) {
-        if (pluralRules[i](num)) {
-            return forms[i];
-        }
-    }
-    return forms[minCount - 1];
+    var forms = word.split('_');
+    return num % 10 === 1 && num % 100 !== 11 ? forms[0] : (num % 10 >= 2 && num % 10 <= 4 && (num % 100 < 10 || num % 100 >= 20) ? forms[1] : forms[2]);
 }
 
 function relativeTimeWithPlural(number, withoutSuffix, key) {
     var format = {
-        'mm': 'хвилина_хвилини_хвилин_хвилини',
-        'hh': 'година_години_годин_години',
-        'dd': 'день_дня_днів_дня',
-        'MM': 'місяць_місяця_місяців_місяця',
-        'yy': 'рік_року_років_року'
+        'mm': 'хвилина_хвилини_хвилин',
+        'hh': 'година_години_годин',
+        'dd': 'день_дня_днів',
+        'MM': 'місяць_місяця_місяців',
+        'yy': 'рік_роки_років'
     };
     if (key === 'm') {
         return withoutSuffix ? 'хвилина' : 'хвилину';
@@ -59,7 +46,7 @@ function weekdaysCaseReplace(m, format) {
 
     nounCase = (/(\[[ВвУу]\]) ?dddd/).test(format) ? 
         'accusative' :
-        ((/\[?(?:минулої)? ?\] ?dddd/).test(format) ?
+        ((/\[?(?:минулої|наступної)? ?\] ?dddd/).test(format) ?
             'genitive' :
             'nominative');
 
@@ -75,35 +62,32 @@ require('../moment').lang('uk', {
     longDateFormat : {
         LT : "HH:mm",
         L : "DD.MM.YYYY",
-        LL : "D MMMM YYYY г.",
-        LLL : "D MMMM YYYY г., LT",
-        LLLL : "dddd, D MMMM YYYY г., LT"
+        LL : "D MMMM YYYY р.",
+        LLL : "D MMMM YYYY р., LT",
+        LLLL : "dddd, D MMMM YYYY р., LT"
     },
     calendar : {
-        sameDay: '[Сьогодні в] LT',
-        nextDay: '[Завтра в] LT',
-        lastDay: '[Вчора в] LT',
-        nextWeek: function () {
-            return this.day() === 2 ? '[У] dddd [в] LT' : '[В] dddd [в] LT';
-        },
+        sameDay: '[Сьогодні о] LT',
+        nextDay: '[Завтра о] LT',
+        lastDay: '[Вчора о] LT',
+        nextWeek: '[У] dddd [о] LT',
         lastWeek: function () {
             switch (this.day()) {
             case 0:
             case 3:
             case 5:
             case 6:
-                return '[Минулої] dddd [в] LT';
+                return '[Минулої] dddd [о] LT';
             case 1:
             case 2:
             case 4:
-                return '[Минулого] dddd [в] LT';
+                return '[Минулого] dddd [о] LT';
             }
         },
         sameElse: 'L'
     },
-    // It needs checking (adding) Ukrainian plurals and cases.
     relativeTime : {
-        future : "через %s",
+        future : "за %s",
         past : "%s тому",
         s : "декілька секунд",
         m : relativeTimeWithPlural,
@@ -117,6 +101,7 @@ require('../moment').lang('uk', {
         y : "рік",
         yy : relativeTimeWithPlural
     },
+    // FIXME: this is not Ukrainian ordinals format
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/test/lang/uk.js
+++ b/test/lang/uk.js
@@ -55,9 +55,9 @@ exports["lang:uk"] = {
                 ['a A',                                'pm PM'],
                 ['[the] DDDo [day of the year]',       'the 45. day of the year'],
                 ['L',                                  '14.02.2010'],
-                ['LL',                                 '14 лютого 2010 г.'],
-                ['LLL',                                '14 лютого 2010 г., 15:25'],
-                ['LLLL',                               'неділя, 14 лютого 2010 г., 15:25']
+                ['LL',                                 '14 лютого 2010 р.'],
+                ['LLL',                                '14 лютого 2010 р., 15:25'],
+                ['LLLL',                               'неділя, 14 лютого 2010 р., 15:25']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;
@@ -172,7 +172,7 @@ exports["lang:uk"] = {
         test.equal(start.from(moment([2007, 1, 28]).add({d:344}), true), "11 місяців",  "344 days = 11 months");
         test.equal(start.from(moment([2007, 1, 28]).add({d:345}), true), "рік",     "345 days = a year");
         test.equal(start.from(moment([2007, 1, 28]).add({d:547}), true), "рік",     "547 days = a year");
-        test.equal(start.from(moment([2007, 1, 28]).add({d:548}), true), "2 року",    "548 days = 2 years");
+        test.equal(start.from(moment([2007, 1, 28]).add({d:548}), true), "2 роки",    "548 days = 2 years");
         test.equal(start.from(moment([2007, 1, 28]).add({y:1}), true),   "рік",     "1 year = a year");
         test.equal(start.from(moment([2007, 1, 28]).add({y:5}), true),   "5 років",    "5 years = 5 years");
         test.done();
@@ -180,15 +180,15 @@ exports["lang:uk"] = {
 
     "suffix" : function(test) {
         test.expect(2);
-        test.equal(moment(30000).from(0), "через декілька секунд", "prefix");
+        test.equal(moment(30000).from(0), "за декілька секунд", "prefix");
         test.equal(moment(0).from(30000), "декілька секунд тому", "suffix");
         test.done();
     },
 
     "fromNow" : function(test) {
         test.expect(2);
-        test.equal(moment().add({s:30}).fromNow(), "через декілька секунд", "in seconds");
-        test.equal(moment().add({d:5}).fromNow(), "через 5 днів", "in 5 days");
+        test.equal(moment().add({s:30}).fromNow(), "за декілька секунд", "in seconds");
+        test.equal(moment().add({d:5}).fromNow(), "за 5 днів", "in 5 days");
         test.done();
     },
 
@@ -197,12 +197,12 @@ exports["lang:uk"] = {
 
         var a = moment().hours(2).minutes(0).seconds(0);
 
-        test.equal(moment(a).calendar(),                     "Сьогодні в 02:00",     "today at the same time");
-        test.equal(moment(a).add({ m: 25 }).calendar(),      "Сьогодні в 02:25",     "Now plus 25 min");
-        test.equal(moment(a).add({ h: 1 }).calendar(),       "Сьогодні в 03:00",     "Now plus 1 hour");
-        test.equal(moment(a).add({ d: 1 }).calendar(),       "Завтра в 02:00",      "tomorrow at the same time");
-        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "Сьогодні в 01:00",     "Now minus 1 hour");
-        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "Вчора в 02:00",       "yesterday at the same time");
+        test.equal(moment(a).calendar(),                     "Сьогодні о 02:00",     "today at the same time");
+        test.equal(moment(a).add({ m: 25 }).calendar(),      "Сьогодні о 02:25",     "Now plus 25 min");
+        test.equal(moment(a).add({ h: 1 }).calendar(),       "Сьогодні о 03:00",     "Now plus 1 hour");
+        test.equal(moment(a).add({ d: 1 }).calendar(),       "Завтра о 02:00",      "tomorrow at the same time");
+        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "Сьогодні о 01:00",     "Now minus 1 hour");
+        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "Вчора о 02:00",       "yesterday at the same time");
         test.done();
     },
 
@@ -212,17 +212,13 @@ exports["lang:uk"] = {
         var i;
         var m;
 
-        function makeFormat(d) {
-            return d.day() === 2 ? '[У] dddd [в] LT' : '[В] dddd [в] LT';
-        }
-
         for (i = 2; i < 7; i++) {
             m = moment().add({ d: i });
-            test.equal(m.calendar(),       m.format(makeFormat(m)),  "Today + " + i + " days current time");
+            test.equal(m.calendar(),       m.format('[У] dddd [о] LT'),  "Today + " + i + " days current time");
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format(makeFormat(m)),  "Today + " + i + " days beginning of day");
+            test.equal(m.calendar(),       m.format('[У] dddd [о] LT'),  "Today + " + i + " days beginning of day");
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format(makeFormat(m)),  "Today + " + i + " days end of day");
+            test.equal(m.calendar(),       m.format('[У] dddd [о] LT'),  "Today + " + i + " days end of day");
         }
         test.done();
     },
@@ -239,11 +235,11 @@ exports["lang:uk"] = {
             case 3:
             case 5:
             case 6:
-                return '[Минулої] dddd [в] LT';
+                return '[Минулої] dddd [о] LT';
             case 1:
             case 2:
             case 4:
-                return '[Минулого] dddd [в] LT';
+                return '[Минулого] dddd [о] LT';
             }
         }
 


### PR DESCRIPTION
Here's what I've done:    
- Optimized Russian and Ukrainian plural rules. Actually there are only three forms, and there's no reason to duplicate the second one (cf. original lang/ru.js);
- Changed Ukrainian messages to fit literary standard, fixes #726.
