### PR TITLE
Added pastFromNow

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1238,8 +1238,8 @@
         },
 
         pastFromNow : function (withoutSuffix) {
-            var now = moment();
-            var past = this < now ? this : now;
+            var now = moment(),
+                past = this < now ? this : now;
             return past.from(now, withoutSuffix);
         },
 


### PR DESCRIPTION
This is a useful alternative to fromNow when you know the date is in the past.
See @icambron comment in issue #537.
Let me know if you prefer adding an option parameter to `fromNow`.
