### PR TITLE
Format function now uses "instanceof" on a var rather than "typeof" on t...

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -597,7 +597,7 @@
         return function (mom) {
             var output = "";
             for (i = 0; i < length; i++) {
-                output += typeof array[i].call === 'function' ? array[i].call(mom, format) : array[i];
+                output += array[i] instanceof Function ? array[i].call(mom, format) : array[i];
             }
             return output;
         };

--- a/test/moment/string_prototype.js
+++ b/test/moment/string_prototype.js
@@ -1,0 +1,17 @@
+var moment = require("../../moment");
+
+exports.add = {
+    "string prototype overrides call" : function(test) {
+        test.expect(1);
+
+        var prior = String.prototype.call;
+        String.prototype.call = function() { return null;};
+
+        var b = moment(new Date(2011, 7, 28, 15, 25, 50, 125));
+        test.equal(b.format('MMMM Do YYYY, h:mm a'), 'August 28th 2011, 3:25 pm');
+
+        String.prototype.call = prior;
+        test.done();
+    }
+
+};


### PR DESCRIPTION
...hat var's call to determine if the variable is a function.

This fixes an incompatibility with ClojureScript, which defines String.prototype.call as a function.

That ClojureScript defines String.prototype.call is admittedly undesirable, but the timeline for changing that behavior is unknown, and this fix will allow ClojureScript uses to use moment.js in the interim, with no downside that I'm aware of.
