### PR TITLE
Adding hooks for external libs to supply timezone name and timezone abbreviations

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -199,6 +199,12 @@
                 }
                 return b + leftZeroFill(~~(10 * a / 6), 4);
             },
+            z : function () {
+                return this.zoneAbbr();
+            },
+            zz : function () {
+                return this.zoneName();
+            },
             X    : function () {
                 return this.unix();
             }
@@ -1377,6 +1383,14 @@
                 return this._isUTC ? offset : this._d.getTimezoneOffset();
             }
             return this;
+        },
+
+        zoneAbbr : function () {
+            return this._isUTC ? "UTC" : "";
+        },
+
+        zoneName : function () {
+            return this._isUTC ? "Coordinated Universal Time" : "";
         },
 
         daysInMonth : function () {

--- a/test/moment/zones.js
+++ b/test/moment/zones.js
@@ -399,6 +399,22 @@ exports.zones = {
         moment.updateOffset = oldOffset;
 
         test.done();
+    },
+
+    "zone names" : function (test) {
+        test.expect(8);
+
+        test.equal(moment().zoneAbbr(),   "", "Local zone abbr should be empty");
+        test.equal(moment().format('z'),  "", "Local zone formatted abbr should be empty");
+        test.equal(moment().zoneName(),   "", "Local zone name should be empty");
+        test.equal(moment().format('zz'), "", "Local zone formatted name should be empty");
+
+        test.equal(moment.utc().zoneAbbr(),   "UTC", "UTC zone abbr should be UTC");
+        test.equal(moment.utc().format('z'),  "UTC", "UTC zone formatted abbr should be UTC");
+        test.equal(moment.utc().zoneName(),   "Coordinated Universal Time", "UTC zone abbr should be Coordinated Universal Time");
+        test.equal(moment.utc().format('zz'), "Coordinated Universal Time", "UTC zone formatted abbr should be Coordinated Universal Time");
+
+        test.done();
     }
 
 };


### PR DESCRIPTION
This is to allow libs like `moment-timezone` and others to provide timezone information by overwriting `moment.fn.zoneName` and `moment.fn.zoneAbbr`.
