### PR TITLE
Fix AMD support, remove the module name

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1563,7 +1563,7 @@
     }
     /*global define:false */
     if (typeof define === "function" && define.amd) {
-        define("moment", [], function () {
+        define(function () {
             return moment;
         });
     }


### PR DESCRIPTION
‘You can explicitly name modules yourself, but it makes the modules less portable. (…) It is normally best to avoid coding in a name for the module and just let the optimization tool burn in the module names.’

Please see http://requirejs.org/docs/api.html#modulename.
