### PR TITLE
Adding moment#min and moment#max #755

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1361,20 +1361,12 @@
         },
 
         min: function (other) {
-            if (typeof other === "string" && other.toLowerCase() === "now") {
-                other = moment();
-            } else {
-                other = moment.apply(null, arguments);
-            }
+            other = moment.apply(null, arguments);
             return other < this ? this : other;
         },
 
         max: function (other) {
-            if (typeof other === "string" && other.toLowerCase() === "now") {
-                other = moment();
-            } else {
-                other = moment.apply(null, arguments);
-            }
+            other = moment.apply(null, arguments);
             return other > this ? this : other;
         },
 

--- a/test/moment/min_max.js
+++ b/test/moment/min_max.js
@@ -12,7 +12,7 @@ exports.min_max = {
     },
 
     "min" : function (test) {
-        test.expect(10);
+        test.expect(8);
 
         var now = moment(),
             future = now.clone().add(1, 'month'),
@@ -22,12 +22,10 @@ exports.min_max = {
         // two moments are off by a millisecond.
 
         test.ok(Math.abs(past.min(now).diff(now)) < 2,        "A past date with the minimum of now should be now");
-        test.ok(Math.abs(past.min('now').diff(now)) < 2,      "A past date with the minimum of 'now' should be now");
         test.ok(Math.abs(past.min().diff(now)) < 2,           "A past date with the minimum of implied now should be now");
         test.ok(Math.abs(past.min(future).diff(future)) < 2,  "A past date with the minimum of the future should be the future date");
 
         test.ok(Math.abs(future.min(now).diff(future)) < 2,   "A future date with the minimum of now should be the future");
-        test.ok(Math.abs(future.min('now').diff(future)) < 2, "A future date with the minimum of 'now' should be the future");
         test.ok(Math.abs(future.min().diff(future)) < 2,      "A future date with the minimum of implied now should be the future");
         test.ok(Math.abs(future.min(past).diff(future)) < 2,  "A future date with the minimum of the past should be the future");
 
@@ -38,7 +36,7 @@ exports.min_max = {
     },
 
     "max" : function (test) {
-        test.expect(10);
+        test.expect(8);
 
         var now = moment(),
             future = now.clone().add(1, 'month'),
@@ -48,12 +46,10 @@ exports.min_max = {
         // two moments are off by a millisecond.
 
         test.ok(Math.abs(past.max(now).diff(past)) < 2,    "A past date with the maximum of now should be the past");
-        test.ok(Math.abs(past.max('now').diff(past)) < 2,  "A past date with the maximum of 'now' should be the past");
         test.ok(Math.abs(past.max().diff(past)) < 2,       "A past date with the maximum of implied now should be the past");
         test.ok(Math.abs(past.max(future).diff(past)) < 2, "A past date with the maximum of the future should be the past");
 
         test.ok(Math.abs(future.max(now).diff(now)) < 2,    "A future date with the maximum of now should be now");
-        test.ok(Math.abs(future.max('now').diff(now)) < 2,  "A future date with the maximum of 'now' should be now");
         test.ok(Math.abs(future.max().diff(now)) < 2,       "A future date with the maximum of implied now should be now");
         test.ok(Math.abs(future.max(past).diff(past)) < 2,  "A future date with the maximum of the past should be the past");
 


### PR DESCRIPTION
This adds the `max` and `min` methods noted in #755.

The max method returns the original moment only if it is before the max. Otherwise, it returns the max.

``` javascript
pastMoment.max(moment()); // pastMoment
futureMoment.max(moment()); // now
futureMoment.max(pastMoment); // pastMoment
```

The min method returns the original moment only if it is after the min. Otherwise, it returns the min.

``` javascript
pastMoment.min(moment()); // now
futureMoment.min(moment()); // futureMoment
futureMoment.min(pastMoment); // futureMoment
```

Both methods accept anything that can be passed to `moment()`.

``` javascript
moment().max("septiembre 3 2006", "MMMM D YYYY", "es");
```

Passing no arguments defaults to now.

``` javascript
// all different names for the same thing
moment().max();
moment().max(moment());
```

Edit: Removed "now" argument.
