### PR TITLE
Changed 'L' date format for 'nn' and 'nb' to DD-MM-YYYY

### DIFF
--- a/lang/nb.js
+++ b/lang/nb.js
@@ -10,7 +10,7 @@ require('../moment').lang('nb', {
     weekdaysMin : "sø_ma_ti_on_to_fr_lø".split("_"),
     longDateFormat : {
         LT : "HH:mm",
-        L : "YYYY-MM-DD",
+        L : "DD-MM-YYYY",
         LL : "D MMMM YYYY",
         LLL : "D MMMM YYYY LT",
         LLLL : "dddd D MMMM YYYY LT"

--- a/lang/nn.js
+++ b/lang/nn.js
@@ -10,7 +10,7 @@ require('../moment').lang('nn', {
     weekdaysMin : "su_må_ty_on_to_fr_lø".split("_"),
     longDateFormat : {
         LT : "HH:mm",
-        L : "YYYY-MM-DD",
+        L : "DD-MM-YYYY",
         LL : "D MMMM YYYY",
         LLL : "D MMMM YYYY LT",
         LLLL : "dddd D MMMM YYYY LT"

--- a/test/lang/nb.js
+++ b/test/lang/nb.js
@@ -56,11 +56,11 @@ exports["lang:nb"] = {
                 ['s ss',                               '50 50'],
                 ['a A',                                'pm PM'],
                 ['[the] DDDo [day of the year]',       'the 45. day of the year'],
-                ['L',                                  '2010-02-14'],
+                ['L',                                  '14-02-2010'],
                 ['LL',                                 '14 februar 2010'],
                 ['LLL',                                '14 februar 2010 15:25'],
                 ['LLLL',                               'søndag 14 februar 2010 15:25'],
-                ['l',                                  '2010-2-14'],
+                ['l',                                  '14-2-2010'],
                 ['ll',                                 '14 feb 2010'],
                 ['lll',                                '14 feb 2010 15:25'],
                 ['llll',                               'søn 14 feb 2010 15:25']

--- a/test/lang/nn.js
+++ b/test/lang/nn.js
@@ -56,11 +56,11 @@ exports["lang:nn"] = {
                 ['s ss',                               '50 50'],
                 ['a A',                                'pm PM'],
                 ['[the] DDDo [day of the year]',       'the 45. day of the year'],
-                ['L',                                  '2010-02-14'],
+                ['L',                                  '14-02-2010'],
                 ['LL',                                 '14 februar 2010'],
                 ['LLL',                                '14 februar 2010 15:25'],
                 ['LLLL',                               'sundag 14 februar 2010 15:25'],
-                ['l',                                  '2010-2-14'],
+                ['l',                                  '14-2-2010'],
                 ['ll',                                 '14 feb 2010'],
                 ['lll',                                '14 feb 2010 15:25'],
                 ['llll',                               'sun 14 feb 2010 15:25']


### PR DESCRIPTION
Correct dateformat for norwegian bokmål and norwegian nynorsk is
DD-MM-YYYY
See:
http://www.xn--sprkrdet-c0ac.no/nb-no/Sprakhjelp/Raad/Spoersmaal_og_svar/#dato
and
http://en.wikipedia.org/wiki/Date_format_by_country
