### PR TITLE
Fix JavaScript setMonth() behavior

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -351,10 +351,7 @@
             mom.date(mom.date() + days * isAdding);
         }
         if (months) {
-            currentDate = mom.date();
-            mom.date(1)
-                .month(mom.month() + months * isAdding)
-                .date(Math.min(currentDate, mom.daysInMonth()));
+            mom.month(mom.month() + months * isAdding);
         }
         if (milliseconds && !ignoreUpdateOffset) {
             moment.updateOffset(mom);
@@ -1297,7 +1294,10 @@
         },
 
         month : function (input) {
-            var utc = this._isUTC ? 'UTC' : '';
+            var utc = this._isUTC ? 'UTC' : '',
+                dayOfMonth,
+                daysInMonth;
+
             if (input != null) {
                 if (typeof input === 'string') {
                     input = this.lang().monthsParse(input);
@@ -1305,7 +1305,12 @@
                         return this;
                     }
                 }
+
+                dayOfMonth = this.date();
+                this.date(1);
                 this._d['set' + utc + 'Month'](input);
+                this.date(Math.min(dayOfMonth, this.daysInMonth()));
+
                 moment.updateOffset(this);
                 return this;
             } else {

--- a/test/moment/getters_setters.js
+++ b/test/moment/getters_setters.js
@@ -61,7 +61,7 @@ exports.getters_setters = {
     },
 
     "setters" : function(test) {
-        test.expect(8);
+        test.expect(9);
 
         var a = moment();
         a.year(2011);
@@ -79,6 +79,12 @@ exports.getters_setters = {
         test.equal(a.minutes(), 7, 'minute');
         test.equal(a.seconds(), 8, 'second');
         test.equal(a.milliseconds(), 9, 'milliseconds');
+
+        // Test month() behavior. See https://github.com/timrwood/moment/pull/822
+        a = moment('20130531', 'YYYYMMDD');
+        a.month(3);
+        test.equal(a.month(), 3, 'month edge case');
+
         test.done();
     },
 


### PR DESCRIPTION
JavaScript does some weird stuff with setMonth(). This change makes its behavior more consistent.

If you have a moment object with a date around the end of the month and you try to change the month to a month that doesn't have that many days you end up with an unexpected result. You can see this exhibited using moment like this:

```
>>> var m = moment('20130531', 'YYYYMMDD');
>>> m.month();
4
>>> m.month(3);
>>> m.month();
4
```

In JS the `setMonth()` method sets the month and then applies the date and rolls over into the next month if the date (e.g. 31) is higher than the last day of the month.

While this is the normal behavior of the JS `Date` object, I would argue that it is the wrong behavior. It causes bugs that users unfamiliar with the oddities of the language won't expect. In addition the date you end up with is somewhat arbitrary and not helpful in any case I can imagine because it's not consistent or predictable without extra logic. If I'm using an object and I try to explicitly set the month I want the object to go to that month, not occasionally end up on both a different month AND date from what I expect.

If the month doesn't have enough days it's much less buggy or unexpected for it to consistently go to the last day of the month than to end up on some day toward the start of the month depending on what day of the month it is and what month I'm switching to.

In my particular case it caused a bug that could only be observed on certain days of certain months, like today. In my code it creates a new moment object and then tries to set the month based on a value returned from the server. But since the object was created today it causes it to set the month wrong. If I tried the exact same thing yesterday it would have worked fine. At least with this fix it creates consistent and predictable behavior and always sets the month to the one requested.
