### PR TITLE
Remove "Klockan" in `moment.calendar()`

### DIFF
--- a/lang/sv.js
+++ b/lang/sv.js
@@ -16,11 +16,11 @@ require('../moment').lang('sv', {
         LLLL : "dddd D MMMM YYYY LT"
     },
     calendar : {
-        sameDay: '[Idag klockan] LT',
-        nextDay: '[Imorgon klockan] LT',
-        lastDay: '[Igår klockan] LT',
-        nextWeek: 'dddd [klockan] LT',
-        lastWeek: '[Förra] dddd[en klockan] LT',
+        sameDay: '[Idag] LT',
+        nextDay: '[Imorgon] LT',
+        lastDay: '[Igår] LT',
+        nextWeek: 'dddd LT',
+        lastWeek: '[Förra] dddd[en] LT',
         sameElse: 'L'
     },
     relativeTime : {

--- a/test/lang/sv.js
+++ b/test/lang/sv.js
@@ -190,12 +190,12 @@ exports["lang:sv"] = {
 
         var a = moment().hours(2).minutes(0).seconds(0);
 
-        test.equal(moment(a).calendar(),                     "Idag klockan 02:00",     "today at the same time");
-        test.equal(moment(a).add({ m: 25 }).calendar(),      "Idag klockan 02:25",     "Now plus 25 min");
-        test.equal(moment(a).add({ h: 1 }).calendar(),       "Idag klockan 03:00",     "Now plus 1 hour");
-        test.equal(moment(a).add({ d: 1 }).calendar(),       "Imorgon klockan 02:00",  "tomorrow at the same time");
-        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "Idag klockan 01:00",     "Now minus 1 hour");
-        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "Igår klockan 02:00",     "yesterday at the same time");
+        test.equal(moment(a).calendar(),                     "Idag 02:00",     "today at the same time");
+        test.equal(moment(a).add({ m: 25 }).calendar(),      "Idag 02:25",     "Now plus 25 min");
+        test.equal(moment(a).add({ h: 1 }).calendar(),       "Idag 03:00",     "Now plus 1 hour");
+        test.equal(moment(a).add({ d: 1 }).calendar(),       "Imorgon 02:00",  "tomorrow at the same time");
+        test.equal(moment(a).subtract({ h: 1 }).calendar(),  "Idag 01:00",     "Now minus 1 hour");
+        test.equal(moment(a).subtract({ d: 1 }).calendar(),  "Igår 02:00",     "yesterday at the same time");
         test.done();
     },
 
@@ -207,11 +207,11 @@ exports["lang:sv"] = {
 
         for (i = 2; i < 7; i++) {
             m = moment().add({ d: i });
-            test.equal(m.calendar(),       m.format('dddd [klockan] LT'),  "Today + " + i + " days current time");
+            test.equal(m.calendar(),       m.format('dddd LT'),  "Today + " + i + " days current time");
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('dddd [klockan] LT'),  "Today + " + i + " days beginning of day");
+            test.equal(m.calendar(),       m.format('dddd LT'),  "Today + " + i + " days beginning of day");
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('dddd [klockan] LT'),  "Today + " + i + " days end of day");
+            test.equal(m.calendar(),       m.format('dddd LT'),  "Today + " + i + " days end of day");
         }
         test.done();
     },
@@ -224,11 +224,11 @@ exports["lang:sv"] = {
 
         for (i = 2; i < 7; i++) {
             m = moment().subtract({ d: i });
-            test.equal(m.calendar(),       m.format('[Förra] dddd[en klockan] LT'),  "Today - " + i + " days current time");
+            test.equal(m.calendar(),       m.format('[Förra] dddd[en] LT'),  "Today - " + i + " days current time");
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[Förra] dddd[en klockan] LT'),  "Today - " + i + " days beginning of day");
+            test.equal(m.calendar(),       m.format('[Förra] dddd[en] LT'),  "Today - " + i + " days beginning of day");
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[Förra] dddd[en klockan] LT'),  "Today - " + i + " days end of day");
+            test.equal(m.calendar(),       m.format('[Förra] dddd[en] LT'),  "Today - " + i + " days end of day");
         }
         test.done();
     },


### PR DESCRIPTION
- "Klockan" is kinda superflous.
- This makes the Swedish translation more similar to English.
