### PR TITLE
fix lengthy durations not being cloned properly

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1070,12 +1070,18 @@
     moment.duration = function (input, key) {
         var isDuration = moment.isDuration(input),
             isNumber = (typeof input === 'number'),
-            duration = (isDuration ? input._data : (isNumber ? {} : input)),
+            duration = (isNumber ? {} : input),
             matched = aspNetTimeSpanJsonRegex.exec(input),
             sign,
             ret;
 
-        if (isNumber) {
+        if (isDuration) {
+            duration = {
+                ms: input._milliseconds,
+                d: input._days,
+                M: input._months
+            };
+        } else if (isNumber) {
             if (key) {
                 duration[key] = input;
             } else {

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -96,6 +96,7 @@ exports.duration = {
 
     "instantiation from another duration" : function(test) {
         var simple = moment.duration(1234),
+            lengthy = moment.duration(60 * 60 * 24 * 360 * 1e3),
             complicated = moment.duration({
                 years: 2,
                 months: 3,
@@ -107,8 +108,9 @@ exports.duration = {
                 milliseconds: 12
             });
 
-        test.expect(2);
+        test.expect(3);
         test.deepEqual(moment.duration(simple), simple, "simple clones are equal");
+        test.deepEqual(moment.duration(lengthy), lengthy, "lengthy clones are equal");
         test.deepEqual(moment.duration(complicated), complicated, "complicated clones are equal");
         test.done();
     },


### PR DESCRIPTION
`moment.duration` when passed a lengthy duration may return a
duration that is not equal to the input.  Add a test and a fix for
this bug.
