### PR TITLE
fix durations not being cloned properly

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -254,6 +254,9 @@
             seconds = duration.seconds || duration.second || duration.s || 0,
             milliseconds = duration.milliseconds || duration.millisecond || duration.ms || 0;
 
+        // store reference to input for deterministic cloning
+        this._input = duration;
+
         // representation for dateAddRemove
         this._milliseconds = milliseconds +
             seconds * 1e3 + // 1000
@@ -1070,7 +1073,7 @@
     moment.duration = function (input, key) {
         var isDuration = moment.isDuration(input),
             isNumber = (typeof input === 'number'),
-            duration = (isDuration ? input._data : (isNumber ? {} : input)),
+            duration = (isDuration ? input._input : (isNumber ? {} : input)),
             matched = aspNetTimeSpanJsonRegex.exec(input),
             sign,
             ret;

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -96,6 +96,7 @@ exports.duration = {
 
     "instantiation from another duration" : function(test) {
         var simple = moment.duration(1234),
+            lengthy = moment.duration(60 * 60 * 24 * 360 * 1e3),
             complicated = moment.duration({
                 years: 2,
                 months: 3,
@@ -107,8 +108,9 @@ exports.duration = {
                 milliseconds: 12
             });
 
-        test.expect(2);
+        test.expect(3);
         test.deepEqual(moment.duration(simple), simple, "simple clones are equal");
+        test.deepEqual(moment.duration(lengthy), lengthy, "lengthy clones are equal");
         test.deepEqual(moment.duration(complicated), complicated, "complicated clones are equal");
         test.done();
     },


### PR DESCRIPTION
`moment.duration` does not return an equivalent Duration for all
inputs.  Add a test for this and fix the issue by reusing the
Duration's constructor argument.

This is an alternative approach to https://github.com/timrwood/moment/pull/858.
