### PR TITLE
fix #739 , wrong Chinese meridiem time

### DIFF
--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -22,10 +22,22 @@ require('../moment').lang('zh-cn', {
     meridiem : function (hour, minute, isLower) {
         if (hour < 9) {
             return "早上";
-        } else if (hour < 11 && minute < 30) {
+        } else if (hour < 11) {
             return "上午";
-        } else if (hour < 13 && minute < 30) {
+        } else if (hour === 11) {
+            if (minute < 30) {
+                return "上午";
+            } else {
+                return "中午";
+            }
+        } else if (hour < 12) {
             return "中午";
+        } else if (hour === 12) {
+            if (minute < 30) {
+                return "中午";
+            } else {
+                return "下午";
+            }
         } else if (hour < 18) {
             return "下午";
         } else {

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -22,10 +22,22 @@ require('../moment').lang('zh-tw', {
     meridiem : function (hour, minute, isLower) {
         if (hour < 9) {
             return "早上";
-        } else if (hour < 11 && minute < 30) {
+        } else if (hour < 11) {
             return "上午";
-        } else if (hour < 13 && minute < 30) {
+        } else if (hour === 11) {
+            if (minute < 30) {
+                return "上午";
+            } else {
+                return "中午";
+            }
+        } else if (hour < 12) {
             return "中午";
+        } else if (hour === 12) {
+            if (minute < 30) {
+                return "中午";
+            } else {
+                return "下午";
+            }
         } else if (hour < 18) {
             return "下午";
         } else {


### PR DESCRIPTION
By now I just fixed the time. Now it's:

```
morning < 9 <= forenoon < 11:30 <= noon < 12:30 <= afternoon < 18 <= night
```

I plan to adjust the details once I got accurate concept of the time in Chinese.
And I asked a question at Zhihu: http://www.zhihu.com/question/21251131
