### PR TITLE
grunt is enough

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ To contribute, fork the library and install grunt.
 
 You can add tests to the files in `/test/moment` or add a new test file if you are adding a new feature.
 
-To run the tests, do `grunt test` to run all tests.
+To run the tests, do `grunt` to run all tests.
 
 To check the filesize, you can use `grunt size`.
 


### PR DESCRIPTION
There was not test task, `grunt` is enough for testing. In fact this was misleading for me
