### PR TITLE
add permissive year format "**YY"

### DIFF
--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -281,6 +281,19 @@ exports.create = {
         test.done();
     },
 
+    "string with format - permissive years" : function(test) {
+        test.expect(8);
+        test.equal(moment('67', '**YY').format('YYYY'), '2067', '67 > 2067');
+        test.equal(moment('68', '**YY').format('YYYY'), '2068', '68 > 2068');
+        test.equal(moment('69', '**YY').format('YYYY'), '1969', '69 > 1969');
+        test.equal(moment('70', '**YY').format('YYYY'), '1970', '70 > 1970');
+        test.equal(moment('1967', '**YY').format('YYYY'), '1967', '1967 > 1967');
+        test.equal(moment('1968', '**YY').format('YYYY'), '1968', '1968 > 1968');
+        test.equal(moment('2069', '**YY').format('YYYY'), '2069', '2069 > 2069');
+        test.equal(moment('2070', '**YY').format('YYYY'), '2070', '2070 > 2070');
+        test.done();
+    },
+
     "implicit cloning" : function(test) {
         test.expect(2);
         var momentA = moment([2011, 10, 10]);

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -9,6 +9,14 @@ exports.format = {
         test.done();
     },
 
+    "format **YY" : function(test) {
+        test.expect(1);
+
+        var b = moment(new Date(2009, 1, 14, 15, 25, 50, 125));
+        test.equal(b.format('**YY'), '2009', '**YY ---> 2009');
+        test.done();
+    },
+
     "format escape brackets" : function(test) {
         test.expect(9);
 


### PR DESCRIPTION
add permissive year format "**YY"
create : accept both 2 and 4 digit year
format : display 4 digit same as "YYYY"

http://james.padolsey.com/javascript/permissive-user-input-validation/

example: 
http://jsfiddle.net/kBQ8k/17/
