### PR TITLE
AspNET duration regex now correctly handles days

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -21,7 +21,7 @@
 
         // ASP.NET json date format regex
         aspNetJsonRegex = /^\/?Date\((\-?\d+)/i,
-        aspNetTimeSpanJsonRegex = /(\-)?(\d*)?\.?(\d+)\:(\d+)\:(\d+)\.?(\d{3})?/,
+        aspNetTimeSpanJsonRegex = /(\-)?(?:(\d*)\.)?(\d+)\:(\d+)\:(\d+)\.?(\d{3})?/,
 
         // format tokens
         formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|SS?S?|X|zz?|ZZ?|.)/g,

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -138,13 +138,19 @@ exports.duration = {
     },
 
     "instatiation from serialized C# TimeSpan without days" : function (test) {
-        test.expect(6);
+        test.expect(10);
         test.equal(moment.duration("01:02:03.9999999").years(), 0, "0 years");
         test.equal(moment.duration("01:02:03.9999999").days(), 0, "0 days");
         test.equal(moment.duration("01:02:03.9999999").hours(), 1, "1 hour");
         test.equal(moment.duration("01:02:03.9999999").minutes(), 2, "2 minutes");
         test.equal(moment.duration("01:02:03.9999999").seconds(), 3, "3 seconds");
         test.equal(moment.duration("01:02:03.9999999").milliseconds(), 999, "999 milliseconds");
+
+        test.equal(moment.duration("23:59:59.9999999").days(), 0, "0 days");
+        test.equal(moment.duration("23:59:59.9999999").hours(), 23, "23 hours");
+
+        test.equal(moment.duration("500:59:59.9999999").days(), 20, "500 hours overflows to 20 days");
+        test.equal(moment.duration("500:59:59.9999999").hours(), 20, "500 hours overflows to 20 hours");
         test.done();
     },
 


### PR DESCRIPTION
Days are now completely optional and won't steal digits from the hours.

Fixing #896
