### PR TITLE
Added a way to uninstall a language definition

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -556,6 +556,11 @@
         return languages[key];
     }
 
+    // Remove a language from the `languages` cache. Mostly useful in tests.
+    function unloadLang(key) {
+        delete languages[key];
+    }
+
     // Determines which language definition to use and returns it.
     //
     // With no parameters, it will return the global language.  If you
@@ -1100,6 +1105,9 @@
         }
         if (values) {
             loadLang(key, values);
+        } else if (values === null) {
+            unloadLang(key);
+            key = 'en';
         } else if (!languages[key]) {
             getLangDefinition(key);
         }

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -458,6 +458,7 @@ exports.create = {
 
         test.equal(moment('2012 july', 'YYYY MMM', 'en').month(), 6, "should be able to parse in a specific language");
 
+        moment.lang('parselang', null);
         test.done();
     }
 };

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -303,6 +303,7 @@ exports.format = {
 
         moment.lang('postformat', {postformat: function(s) { s.replace(/./g, 'X') }});
         test.equal(moment.utc([2000, 0, 1]).toJSON(), "2000-01-01T00:00:00.000Z", "toJSON doesn't postformat");
+        moment.lang('postformat', null);
         test.done();
     }
 };

--- a/test/moment/weekday.js
+++ b/test/moment/weekday.js
@@ -110,6 +110,7 @@ exports.week_year = {
         test.equal(moment([1970, 0,  4]).weekday(), 4, "Jan  4 1970 is Sunday    -- 4th day");
         test.equal(moment([2001, 4, 14]).weekday(), 5, "May 14 2001 is Monday    -- 5th day");
         test.equal(moment([2000, 0,  4]).weekday(), 6, "Jan  4 2000 is Tuesday   -- 6th day");
+        moment.lang('dow:3,doy:6', null);
         test.done();
     },
 


### PR DESCRIPTION
moment.lang(key, null) now uninstalls a language. That's mostly useful to
remove auxiliary languages added during test runs.

This is needed by #857.
