### PR TITLE
Added strict parsing

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -987,7 +987,7 @@
         });
 
         // Handle stuff after last formatting token.
-        if (non_token_start != config._f.length) {
+        if (non_token_start !== config._f.length) {
             regexp += regexpEscape(unescapeFormat(config._f.substring(non_token_start)));
         }
         regexp = new RegExp('^' + regexp + '$');

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -491,7 +491,7 @@ exports.create = {
         test.done();
     },
 
-    "strict parsing" : function(test) {
+    "strict parsing" : function (test) {
         test.expect(10);
         test.equal(moment("2012-05", "YYYY-MM", true).format("YYYY-MM"), "2012-05", "parse correct string");
         test.equal(moment(" 2012-05", "YYYY-MM", true).isValid(), false, "fail on extra whitespace");


### PR DESCRIPTION
I've wanted this for a long time -- strict parsing. It builds one regex of all the tokens and matches it against the whole string. Then it matches the match groups against the tokens.

I guess we can add stricter regexes for the tokens (for example MM will match 2 digits only, instead of one digit).
