### PR TITLE
allow initializing with unix timestamp as integer

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -812,7 +812,7 @@
     function makeDateFromStringAndFormat(config) {
         // This array is used to make a Date, either with `new Date` or `Date.UTC`
         var tokens = config._f.match(formattingTokens),
-            string = config._i,
+            string = '' + config._i,
             i, parsedInput;
 
         config._a = [];

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -88,7 +88,7 @@ exports.format = {
     },
 
     "unix timestamp" : function (test) {
-        test.expect(4);
+        test.expect(5);
 
         var m = moment('1234567890.123', 'X');
         test.equals(m.format('X'), '1234567890', 'unix timestamp without milliseconds');
@@ -96,6 +96,9 @@ exports.format = {
         test.equals(m.format('X.SS'), '1234567890.12', 'unix timestamp with centiseconds');
         test.equals(m.format('X.SSS'), '1234567890.123', 'unix timestamp with milliseconds');
 
+        m = moment(1234567890.123, 'X');
+        test.equals(m.format('X'), '1234567890', 'unix timestamp as integer');
+        
         test.done();
     },
 


### PR DESCRIPTION
If your are working with unix timestamps, they are often stored as integers, this fix allows you to initialize moment with an unix timestamp as an integer
