### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "moment",
+  "version": "2.1.0",
+  "main": "moment.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "tasks",
+    "component.json",
+    "composer.json",
+    "CONTRIBUTING.md",
+    "ender.js",
+    "Gruntfile.js",
+    "package.js",
+    "package.json"
+  ]
+}


### PR DESCRIPTION
Eventually Bower is likely to become incompatible with the component.json format, and the warnings will turn to errors when installing with Bower.

The ignore list is patterns and files that should not be installed for end users, when moment is to be consumed as a bower package.
