### PR TITLE
Fixed local formatting tokens detection

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -623,7 +623,8 @@
             return m.lang().longDateFormat(input) || input;
         }
 
-        while (i-- && localFormattingTokens.test(format)) {
+        while (i-- && (localFormattingTokens.lastIndex = 0,
+                    localFormattingTokens.test(format))) {
             format = format.replace(localFormattingTokens, replaceLongDateFormatTokens);
         }
 


### PR DESCRIPTION
According to the docs:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
issuing regex.test on the same regex that is also g (global), would cause it to
remember the last match position and continue from there. Set lastIndex to
0 before every test to make sure this won't happen.

This will also fix #965, #962, #954, #943, #937, #934 and maybe more. We should fix the message that doesn't include the failing messages. I'm sick of duplicated reports ... with missing reports.
