### PR TITLE
Russian months recognition fixed

### DIFF
--- a/lang/ru.js
+++ b/lang/ru.js
@@ -78,6 +78,7 @@
         weekdays : weekdaysCaseReplace,
         weekdaysShort : "вск_пнд_втр_срд_чтв_птн_сбт".split("_"),
         weekdaysMin : "вс_пн_вт_ср_чт_пт_сб".split("_"),
+        monthsParse : [/^янв/i, /^фев/i, /^мар/i, /^апр/i, /^ма[й|я]/i, /^июн/i, /^июл/i, /^авг/i, /^сен/i, /^окт/i, /^ноя/i, /^дек/i],
         longDateFormat : {
             LT : "HH:mm",
             L : "DD.MM.YYYY",

--- a/test/lang/ru.js
+++ b/test/lang/ru.js
@@ -37,6 +37,11 @@ exports["lang:ru"] = {
         test.done();
     },
 
+    "parse exceptional case" : function (test) {
+        test.equal(moment('11 мая 1989', ['DD MMMM YYYY']).format('DD-MM-YYYY'), '11-05-1989');
+        test.done();
+    },
+
     "format" : function (test) {
         test.expect(22);
 


### PR DESCRIPTION
The problem is in contructing RegExp for matching against input date. In russian language words sometimes changes their ending, causing some troubles.

The bug was in dates like this: `11 мая 1989` with format `D MMMM YYYY` (which is May, 11)

moment.js parser says it is January, 11.

Also, monthsCaseReplace function definitions looks a little bit strange accepting second attribute `format`, because there is an empty string passing in moment.js code:

```
#line 406
regex = '^' + this.months(mom, '') + '|^' + this.monthsShort(mom, '');
```
