### PR TITLE
Add language code aliases

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -549,11 +549,22 @@
     // are provided, it will load the language file module.  As a convenience,
     // this function also returns the language values.
     function loadLang(key, values) {
+        // Optional second argument key alias (e.g. en-us has alias en).
+        var alias;
+        if (arguments.length === 3) {
+            alias = values;
+            values = arguments[2];
+        }
         values.abbr = key;
         if (!languages[key]) {
             languages[key] = new Language();
         }
         languages[key].set(values);
+        if (alias) {
+            delete languages[alias];
+            languages[alias] = languages[key];
+        }
+
         return languages[key];
     }
 
@@ -1138,7 +1149,7 @@
             return moment.fn._lang._abbr;
         }
         if (values) {
-            loadLang(key, values);
+            loadLang.apply(null, arguments);
         } else if (values === null) {
             unloadLang(key);
             key = 'en';
@@ -1689,7 +1700,7 @@
 
 
     // Set default language, other languages will inherit from English.
-    moment.lang('en', {
+    moment.lang('en-us', 'en', {
         ordinal : function (number) {
             var b = number % 10,
                 output = (~~ (number % 100 / 10) === 1) ? 'th' :

--- a/test/moment/lang.js
+++ b/test/moment/lang.js
@@ -5,7 +5,7 @@ exports.lang = {
         test.expect(5);
 
         moment.lang('en');
-        test.equal(moment.lang(), 'en', 'Lang should return en by default');
+        test.equal(moment.lang(), 'en-us', 'Lang should return en-us by default');
 
         moment.lang('fr');
         test.equal(moment.lang(), 'fr', 'Lang should return the changed language');
@@ -14,10 +14,10 @@ exports.lang = {
         test.equal(moment.lang(), 'en-gb', 'Lang should return the changed language');
 
         moment.lang('en');
-        test.equal(moment.lang(), 'en', 'Lang should reset');
+        test.equal(moment.lang(), 'en-us', 'Lang alias should return full name');
 
         moment.lang('does-not-exist');
-        test.equal(moment.lang(), 'en', 'Lang should reset');
+        test.equal(moment.lang(), 'en-us', 'Lang should reset');
 
         test.done();
     },


### PR DESCRIPTION
Enable languages to set a language alias, for example 'en-us' would set an alias 'en'. This was mentioned in #963.
