### PR TITLE
force moment.utc() to use utc

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1076,7 +1076,7 @@
             _l : lang,
             _i : input,
             _f : format
-        });
+        }).utc();
     };
 
     // creating with unix timestamp (in seconds)

--- a/test/moment/utc.js
+++ b/test/moment/utc.js
@@ -73,5 +73,19 @@ exports.utc = {
         test.equal(m.hours(), 23, "the hours should be correct for utc parse with timezone");
 
         test.done();
+    },
+
+    "cloning with utc" : function (test) {
+        test.expect(4);
+
+        var m = moment.utc("2012-01-02T08:20:00");
+        test.equal(moment.utc(m)._isUTC, true, "the local zone should be converted to UTC");
+        test.equal(moment.utc(m.clone().utc())._isUTC, true, "the local zone should stay in UTC");
+
+        m.zone(120);
+        test.equal(moment.utc(m)._isUTC, true, "the explicit zone should stay in UTC");
+        test.equal(moment.utc(m).zone(), 0, "the explicit zone should have an offset of 0");
+
+        test.done();
     }
 };


### PR DESCRIPTION
I think this is a bug:

``` js
moment.utc(moment())._isUTC //=> false
```

Seems like `moment.utc()` should force the issue.
