### PR TITLE
fixing zone test for half hour offsets

### DIFF
--- a/test/moment/zones.js
+++ b/test/moment/zones.js
@@ -297,7 +297,7 @@ exports.zones = {
     },
 
     "same / before / after" : function (test) {
-        var zoneA = moment(),
+        var zoneA = moment().utc(),
             zoneB = moment(zoneA).zone(120),
             zoneC = moment(zoneA).zone(-120);
 


### PR DESCRIPTION
This addresses problem 2 in #989, which is test failures that look like this:

```
>> zones - same / before / after
>> Message: two moments with different offsets should be the same hour
>> Error: two moments with different offsets should be the same hour
>> at Object.exports.zones.same / before / after (test/moment/zones.js:307:14)
>> at Object.exports.zones.setUp (test/moment/zones.js:6:9)

>> zones - same / before / after
>> Message: two moments with different offsets should be the same hour
>> Error: two moments with different offsets should be the same hour
>> at Object.exports.zones.same / before / after (test/moment/zones.js:308:14)
>> at Object.exports.zones.setUp (test/moment/zones.js:6:9)
```

The problem is that a lot of time zones are offset by a half-hour. A good list is here:

http://www.timeanddate.com/time/time-zones-interesting.html

The issue is what it means to say this:

``` js
moment().zone(30).isSame(moment(), "hour");
```

You can see why it doesn't work with the current implementation, but after thinking about it for a while, I concluded that it's not really a meaningful question in the first place. It's just a question that only makes sense between zones with the same hour alignment. So I just changed the test.
