### PR TITLE
move test to avoid DST weirdness in Samoa

### DIFF
--- a/test/moment/diff.js
+++ b/test/moment/diff.js
@@ -170,7 +170,7 @@ exports.diff = {
     "diff between utc and local" : function (test) {
         test.expect(7);
 
-        test.equal(moment([2011]).utc().diff([2010], 'years'), 1, "year diff");
+        test.equal(moment([2012]).utc().diff([2011], 'years'), 1, "year diff");
         test.equal(moment([2010, 2, 2]).utc().diff([2010, 0, 2], 'months'), 2, "month diff");
         test.equal(moment([2010, 0, 4]).utc().diff([2010], 'days'), 3, "day diff");
         test.equal(moment([2010, 0, 22]).utc().diff([2010], 'weeks'), 3, "week diff");


### PR DESCRIPTION
This should be viewed in the context of #952 and #989, but I figured I'd just submit it separately, since it's an easy one. This is a test failure from Pacific/Apia that results from them [never leaving DST in 2010](http://www.timeanddate.com/worldclock/timezone.html?n=282):

```
Testing diff.js........F....
>> diff - diff between utc and local
>> Message: year diff
>> Error: year diff
>> at Object.exports.diff.diff between utc and local (test/moment/diff.js:173:14)
```

I just used a different year.
