### PR TITLE
Expand localized tokens in the parser.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -618,10 +618,21 @@
 
     // format date using native date object
     function formatMoment(m, format) {
+
+        format = expandFormat(format, m.lang());
+
+        if (!formatFunctions[format]) {
+            formatFunctions[format] = makeFormatFunction(format);
+        }
+
+        return formatFunctions[format](m);
+    }
+
+    function expandFormat(format, lang) {
         var i = 5;
 
         function replaceLongDateFormatTokens(input) {
-            return m.lang().longDateFormat(input) || input;
+            return lang.longDateFormat(input) || input;
         }
 
         while (i-- && (localFormattingTokens.lastIndex = 0,
@@ -629,11 +640,7 @@
             format = format.replace(localFormattingTokens, replaceLongDateFormatTokens);
         }
 
-        if (!formatFunctions[format]) {
-            formatFunctions[format] = makeFormatFunction(format);
-        }
-
-        return formatFunctions[format](m);
+        return format;
     }
 
 
@@ -850,9 +857,11 @@
     // date from string and format string
     function makeDateFromStringAndFormat(config) {
         // This array is used to make a Date, either with `new Date` or `Date.UTC`
-        var tokens = config._f.match(formattingTokens),
+        var lang = getLangDefinition(config._l),
             string = '' + config._i,
-            i, parsedInput;
+            i, parsedInput, tokens;
+
+        tokens = expandFormat(config._f, lang).match(formattingTokens);
 
         config._a = [];
 

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -195,7 +195,16 @@ exports.create = {
                 ['HH:mm:ss S',          '00:30:00 7'],
                 ['HH:mm:ss SS',         '00:30:00 78'],
                 ['HH:mm:ss SSS',        '00:30:00 789'],
-                ['X.SSS',               '1234567890.123']
+                ['X.SSS',               '1234567890.123'],
+                ['LT',                  '12:30 AM'],
+                ['L',                   '09/02/1999'],
+                ['l',                   '9/2/1999'],
+                ['LL',                  'September 2 1999'],
+                ['ll',                  'Sep 2 1999'],
+                ['LLL',                 'September 2 1999 12:30 AM'],
+                ['lll',                 'Sep 2 1999 12:30 AM'],
+                ['LLLL',                'Thursday, September 2 1999 12:30 AM'],
+                ['llll',                'Thu, Sep 2 1999 12:30 AM']
             ],
             i;
 


### PR DESCRIPTION
Fixes #665. Pretty straightforward. Allows:

``` js
moment.lang("it");
moment("01/03/2013", "L"); // L maps to DD/MM/YYYY
moment.lang("en");
moment("03/01/2013", "L"); // L maps to MM/DD/YYYY
```
