### PR TITLE
Update nb.js

### DIFF
--- a/lang/nb.js
+++ b/lang/nb.js
@@ -11,9 +11,9 @@ require('../moment').lang('nb', {
     longDateFormat : {
         LT : "HH:mm",
         L : "DD.MM.YYYY",
-        LL : "D MMMM YYYY",
-        LLL : "D MMMM YYYY LT",
-        LLLL : "dddd D MMMM YYYY LT"
+        LL : "D. MMMM YYYY",
+        LLL : "D. MMMM YYYY LT",
+        LLLL : "dddd D. MMMM YYYY LT"
     },
     calendar : {
         sameDay: '[I dag klokken] LT',


### PR DESCRIPTION
There are dots after month day in norwegian long date formats, just as ordinals.

A valid LLLL in Norwegian Bokmål is: onsdag 21. august 2013 13.00

Actually, the HH:MM should be HH.MM with a dot as separator, according to standards (at least last time I checked), but people are increasingly using HH:MM with a colon.

In addition, the language flows better if "klokken" is taken away from all places noted. Should I create a new pull request for this?
