### PR TITLE
Fixed define call for AMD

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1730,7 +1730,7 @@
     }
     /*global define:false */
     if (typeof define === "function" && define.amd) {
-        define("moment", [], function () {
+        define(function () {
             return moment;
         });
     }


### PR DESCRIPTION
According to the [documentation](http://requirejs.org/docs/api.html#modulename)
modules should not be defined using a name, because they are less portable.

In my use case we put all 3rd party libraries in `lib/`, so moment is
`lib/moment`, not just moment.
