### PR TITLE
Made isPM function more compatible with IE8 Quirks Mode and IE7 Standard...

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -471,7 +471,9 @@
         },
 
         isPM : function (input) {
-            return ((input + '').toLowerCase()[0] === 'p');
+			//IE8 Quirks Mode & IE7 Standards Mode do not allow accessing strings like arrays
+			//Using charAt should be more compatible.
+            return ((input + '').toLowerCase().charAt(0) === 'p');
         },
 
         _meridiemParse : /[ap]\.?m?\.?/i,


### PR DESCRIPTION
Had an issue where IE8 was not parsing AM/PM properly. I had failed to put a <!DOCTYPE html> tag at the top of my HTML file while I was playing around with it and this put IE8 into Quirks mode. IE8 Quirks Mode or IE7 Standards Mode doesn't appear to allow accessing strings as arrays. This resulted in the isPM function always returning false, so 1:00 PM would be parsed as 1:00 AM. Other date parsing worked, so it was hard to detect that this was an issue at first.  Switching to charAt instead of accessing the string as an array resolves this issue, and it fully passes the grunt tests. Adding <!DOCTYPE html> also fixes the issue as it pushes IE8 into Standards Mode, but not everyone does this or can use that DOCTYPE for legacy reasons.  

IE8 Quirks Mode issue only shows up in the actual IE8 browser. Setting IE10 to IE8 Quirks Mode does not result in the issue, but the WinXP version of IE8 in Quirks Mode does show the issue.
![ie8-quirks mode](https://f.cloud.github.com/assets/5317043/1044134/1fcd3b5e-100c-11e3-89b2-97f7cc2b9545.png)
![ie8-standard mode](https://f.cloud.github.com/assets/5317043/1044135/1ffafa76-100c-11e3-9f2f-22d8e3765ed2.png)
