### PR TITLE
Fix nl lang: monthsShort should return array instead of function

### DIFF
--- a/lang/nl.js
+++ b/lang/nl.js
@@ -2,18 +2,9 @@
 // language : dutch (nl)
 // author : Joris Röling : https://github.com/jjupiter
 
-var monthsShortWithDots = "jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.".split("_"),
-    monthsShortWithoutDots = "jan_feb_mrt_apr_mei_jun_jul_aug_sep_okt_nov_dec".split("_");
-
 require('../moment').lang('nl', {
     months : "januari_februari_maart_april_mei_juni_juli_augustus_september_oktober_november_december".split("_"),
-    monthsShort : function (m, format) {
-        if (/-MMM-/.test(format)) {
-            return monthsShortWithoutDots[m.month()];
-        } else {
-            return monthsShortWithDots[m.month()];
-        }
-    },
+    monthsShort : "jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.".split("_"),
     weekdays : "zondag_maandag_dinsdag_woensdag_donderdag_vrijdag_zaterdag".split("_"),
     weekdaysShort : "zo._ma._di._wo._do._vr._za.".split("_"),
     weekdaysMin : "Zo_Ma_Di_Wo_Do_Vr_Za".split("_"),

--- a/test/lang/nl.js
+++ b/test/lang/nl.js
@@ -251,15 +251,6 @@ exports["lang:nl"] = {
         test.done();
     },
 
-    "month abbreviation" : function (test) {
-        test.expect(2);
-
-        test.equal(moment([2012, 5, 23]).format('D-MMM-YYYY'), '23-jun-2012', 'format month abbreviation surrounded by dashes should not include a dot');
-        test.equal(moment([2012, 5, 23]).format('D MMM YYYY'), '23 jun. 2012', 'format month abbreviation not surrounded by dashes should include a dot');
-
-        test.done();
-    },
-
     // Monday is the first day of the week.
     // The week that contains Jan 4th is the first week of the year.
 


### PR DESCRIPTION
Short months should be abbreviated with a "." and there is no need for the function to switch between them. 
In fact this breaks the locale functionality since "monthsShort" will not be replaced by the language file.
