### PR TITLE
Allow AMD module loader to set noGlobal in config to prevent moment poll...

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -12,12 +12,7 @@
 
     var moment,
         VERSION = "2.2.1",
-
-        // local cached Math methods
         round = Math.round,
-        floor = Math.floor,
-        ceil = Math.ceil,
-
         i,
 
         // internal storage for language config files


### PR DESCRIPTION
...uting the global space.

Option has to be set by the user otherwise everything loads as previously.

Loader would now look like this to choose noGlobal

```
(function (global, undef) {
    "use strict";

    var projectString = "myProject",
        momentCDN,// = "//cdnjs.cloudflare.com/ajax/libs/moment.js/2.1.0/moment.min",
        momentString = "moment";

    (function (name, definition) {
        if (global.module !== undef && global.module.exports) {
            global.module.exports = definition(global.require(momentCDN));
        } else if (typeof global.define === "function" && global.define.amd) {
            var projectPaths = {},
                projectConfig = {};

            projectPaths[momentString] = momentCDN;
            projectConfig[momentString] = {};
            projectConfig[momentString].noGlobal = true;
            global.require.config({
                paths: projectPaths,
                config: projectConfig
            });

            global.define(name, [momentString], definition);
        } else {
            global[name] = definition(global.moment);
        }
    }(projectString, function (moment) {
        moment.fn.newFunction = function () {
            // code
        };

        function MyFunction() {
            // code
        }

        return {
            "MyFunction": MyFunction,
                "momentPrivate": moment
        };
    }));
}(this));

requirejs(["myProject"], function (myProject) {
    "use strict";

    console.log("Private", myProject.momentPrivate);
    console.log("Global", window["moment"]);
});
```
