### PR TITLE
List months and weekdays

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -389,15 +389,19 @@
         }
 
         moment[field] = function (format, index) {
-            var i,
+            var i, getter,
                 method = moment.fn._lang[field],
-                results = [],
-                getter = function (i) {
-                    var m = moment().utc().set(setter, i);
-                    return method.call(moment.fn._lang, m, format || '');
-                };
+                results = [];
 
-            index = (typeof format === 'number') ? format : index;
+            if (typeof format === 'number') {
+                index = format;
+                format = undefined;
+            }
+
+            getter = function (i) {
+                var m = moment().utc().set(setter, i);
+                return method.call(moment.fn._lang, m, format || '');
+            };
 
             if (index) {
                 return getter(index);

--- a/test/moment/listers.js
+++ b/test/moment/listers.js
@@ -74,13 +74,14 @@ exports.listers = {
             }
         });
 
-        test.expect(5);
+        test.expect(6);
         test.deepEqual(moment.monthsShort(), monthsShort);
         test.deepEqual(moment.monthsShort('MMM'), monthsShort);
         test.deepEqual(moment.monthsShort('-MMM-'), monthsShortWeird);
 
         test.deepEqual(moment.monthsShort('MMM', 2), 'three');
         test.deepEqual(moment.monthsShort('-MMM-', 2), 'threesy');
+        test.deepEqual(moment.monthsShort(2), 'three');
 
         test.done();
     }


### PR DESCRIPTION
Allows for:

``` js
moment.months();
moment.shortMonths();
moment.weekdays();
moment.weekdaysShort();
moment.weekdaysMin();
```

And they work for languages for where the monthsShort string is a decided by a function:

``` js
moment.monthsShort("-MMM-");
```

Fixes, for example, #1053.
