### PR TITLE
don't localize toString()

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1268,7 +1268,7 @@
         },
 
         toString : function () {
-            return this.format("ddd MMM DD YYYY HH:mm:ss [GMT]ZZ");
+            return moment(this).lang('en').format("ddd MMM DD YYYY HH:mm:ss [GMT]ZZ");
         },
 
         toDate : function () {

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -98,7 +98,7 @@ exports.format = {
 
         m = moment(1234567890.123, 'X');
         test.equals(m.format('X'), '1234567890', 'unix timestamp as integer');
-        
+
         test.done();
     },
 
@@ -298,6 +298,29 @@ exports.format = {
 
         var b = moment(new Date(2009, 1, 5, 15, 25, 50, 125));
         test.equal(b.toString(), b.format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'));
+        test.done();
+    },
+
+    "toString isn't localized" : function (test) {
+        test.expect(1);
+
+        var b = moment(new Date(2009, 1, 5, 15, 25, 50, 125)).lang("fr");
+        test.equal(b.toString(), moment(b).lang('en').format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'));
+        test.done();
+    },
+
+    "toString ignores defaultFormat" : function (test) {
+        test.expect(1);
+
+        var temp = moment.defaultFormat,
+            b = moment(new Date(2009, 1, 5, 15, 25, 50, 125));
+
+        moment.defaultFormat = "MM/dd";
+
+        test.equal(b.toString(), moment(b).format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ'));
+
+        moment.defaultFormat = temp;
+
         test.done();
     },
 


### PR DESCRIPTION
Since `toString()` is mainly used for logging/debugging, I believe it should _not_ localize. Otherwise, switching languages breaks logging and makes debugging harder. For example, many applications, especially in Node are going to be parsing their logs and it's weird to have different formats.

Since the docs and API are in English, I think it makes sense to use it in `toString()` too. That said, I welcome feedback to the effect of "this will make it painful for me/others to debug, since I want that in my own language".

This is basically the opposite of #1018
