### PR TITLE
toString always prints date in English

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1420,7 +1420,7 @@
         },
 
         toString : function () {
-            return this.format("ddd MMM DD YYYY HH:mm:ss [GMT]ZZ");
+            return this.clone().lang('en').format("ddd MMM DD YYYY HH:mm:ss [GMT]ZZ");
         },
 
         toDate : function () {


### PR DESCRIPTION
Implementation of #1111

This is another breaking change. All users who do `toString` to display a moment to the user will be affected. Of course a better one would be  `.format('LLLL')` or something, but still it would be kind of breaking. Maybe we can instruct users to change toString() if they don't want to patch their code ;)
