### PR TITLE
Issue #1153 - IE8 Errors on type coercion

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1417,7 +1417,7 @@
         },
 
         unix : function () {
-            return Math.floor(+this / 1000);
+            return Math.floor(+(this.utc()._d) / 1000);
         },
 
         toString : function () {
@@ -1649,17 +1649,17 @@
 
         isAfter: function (input, units) {
             units = typeof units !== 'undefined' ? units : 'millisecond';
-            return +this.clone().startOf(units) > +moment(input).startOf(units);
+            return +this.clone().startOf(units).utc()._d > +moment(input).startOf(units).utc()._d;
         },
 
         isBefore: function (input, units) {
             units = typeof units !== 'undefined' ? units : 'millisecond';
-            return +this.clone().startOf(units) < +moment(input).startOf(units);
+            return +this.clone().startOf(units).utc()._d < +moment(input).startOf(units).utc()._d;
         },
 
         isSame: function (input, units) {
             units = typeof units !== 'undefined' ? units : 'millisecond';
-            return +this.clone().startOf(units) === +moment(input).startOf(units);
+            return +this.clone().startOf(units).utc()._d === +moment(input).startOf(units).utc()._d;
         },
 
         min: function (other) {


### PR DESCRIPTION
This commit replaced instances of Moment to Number type coercion in comparisons
(e.g. equivelent to "+moment()") and when returning the unix time what
is equivelent to "+moment().utc()._d".

This commit passes all unit tests and works well in IE8.
