### PR TITLE
added hasOwnProperty guard to lists enumeration

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1346,7 +1346,7 @@
                 h: parseIso(match[5]),
                 m: parseIso(match[6]),
                 s: parseIso(match[7]),
-                w: parseIso(match[8]),
+                w: parseIso(match[8])
             };
         }
 


### PR DESCRIPTION
[latest develop/moment.js](https://github.com/moment/moment/blob/6a5f960/moment.js) was failing to load in context of Prototype.js (which pollutes Array.prototype -- causing a recently-added enumeration grief).  moment.js 2.2.1 appears to work fine though.

here's an example http://jsfiddle.net/wzp4Z/4/ (see debug console -- fails during initialization)

this pull request wraps in a conventional hasOwnProperty guard, but i wonder if switching to <code>for (i=0; i < lists.length; i++)</code> would actually make more sense here (since lists appears to be an Array).
