### PR TITLE
repairing language tests

### DIFF
--- a/test/lang/ar-ma.js
+++ b/test/lang/ar-ma.js
@@ -342,12 +342,11 @@ exports["lang:ar-ma"] = {
 
         test.done();
     },
-    
+
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ar-ma'), 'ar-ma', "module should export ar-ma");
-        
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ar-ma'), 'ar-ma', "module should export ar-ma");
+        }
         test.done();
     }
 };

--- a/test/lang/ar.js
+++ b/test/lang/ar.js
@@ -346,12 +346,11 @@ exports["lang:ar"] = {
 
         test.done();
     },
-    
+
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ar'), 'ar', "module should export ar");
-        
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ar'), 'ar', "module should export ar");
+        }
         test.done();
     }
 };

--- a/test/lang/bg.js
+++ b/test/lang/bg.js
@@ -363,9 +363,9 @@ exports["lang:bg"] = {
     },
 
     "returns the name of the language" : function (test) {
-        test.expect(1);
-
-        test.equal(require('../../lang/bg'), 'bg', "module should export bg");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/bg'), 'bg', "module should export bg");
+        }
 
         test.done();
     }

--- a/test/lang/br.js
+++ b/test/lang/br.js
@@ -270,9 +270,9 @@ exports["lang:br"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/br'), 'br', "module should export br");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/br'), 'br', "module should export br");
+        }
         
         test.done();
     }

--- a/test/lang/bs.js
+++ b/test/lang/bs.js
@@ -384,9 +384,9 @@ exports["lang:bs"] = {
     },
 
     "returns the name of the language" : function (test) {
-        test.expect(1);
-
-        test.equal(require('../../lang/bs'), 'bs', "module should export bs");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/bs'), 'bs', "module should export bs");
+        }
 
         test.done();
     }

--- a/test/lang/ca.js
+++ b/test/lang/ca.js
@@ -317,9 +317,9 @@ exports["lang:ca"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ca'), 'ca', "module should export ca");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ca'), 'ca', "module should export ca");
+        }
         
         test.done();
     }

--- a/test/lang/cs.js
+++ b/test/lang/cs.js
@@ -440,9 +440,9 @@ exports["lang:cs"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/cs'), 'cs', "module should export cs");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/cs'), 'cs', "module should export cs");
+        }
         
         test.done();
     }

--- a/test/lang/cv.js
+++ b/test/lang/cv.js
@@ -356,9 +356,9 @@ exports["lang:cv"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/cv'), 'cv', "module should export cv");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/cv'), 'cv', "module should export cv");
+        }
         
         test.done();
     }

--- a/test/lang/da.js
+++ b/test/lang/da.js
@@ -288,9 +288,9 @@ exports["lang:da"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/da'), 'da', "module should export da");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/da'), 'da', "module should export da");
+        }
         
         test.done();
     }

--- a/test/lang/de.js
+++ b/test/lang/de.js
@@ -349,9 +349,9 @@ exports["lang:de"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/de'), 'de', "module should export de");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/de'), 'de', "module should export de");
+        }
         
         test.done();
     }

--- a/test/lang/el.js
+++ b/test/lang/el.js
@@ -380,9 +380,9 @@ exports["lang:el"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/el'), 'el', "module should export el");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/el'), 'el', "module should export el");
+        }
         
         test.done();
     }

--- a/test/lang/en-au.js
+++ b/test/lang/en-au.js
@@ -351,9 +351,9 @@ exports["lang:en-au"] = {
     },
 
     "returns the name of the language" : function (test) {
-        test.expect(1);
-
-        test.equal(require('../../lang/en-au'), 'en-au', "module should export en-au");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/en-au'), 'en-au', "module should export en-au");
+        }
 
         test.done();
     }

--- a/test/lang/en-ca.js
+++ b/test/lang/en-ca.js
@@ -377,9 +377,9 @@ exports["lang:en-ca"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/en-ca'), 'en-ca', "module should export en-ca");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/en-ca'), 'en-ca', "module should export en-ca");
+        }
         
         test.done();
     }

--- a/test/lang/en-gb.js
+++ b/test/lang/en-gb.js
@@ -351,9 +351,9 @@ exports["lang:en-gb"] = {
     },
 
     "returns the name of the language" : function (test) {
-        test.expect(1);
-
-        test.equal(require('../../lang/en-gb'), 'en-gb', "module should export en-gb");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/en-gb'), 'en-gb', "module should export en-gb");
+        }
 
         test.done();
     }

--- a/test/lang/eo.js
+++ b/test/lang/eo.js
@@ -358,9 +358,9 @@ exports["lang:eo"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/eo'), 'eo', "module should export eo");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/eo'), 'eo', "module should export eo");
+        }
         
         test.done();
     }

--- a/test/lang/es.js
+++ b/test/lang/es.js
@@ -353,9 +353,9 @@ exports["lang:es"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/es'), 'es', "module should export es");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/es'), 'es', "module should export es");
+        }
         
         test.done();
     }

--- a/test/lang/et.js
+++ b/test/lang/et.js
@@ -359,9 +359,9 @@ exports["lang:et"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/et'), 'et', "module should export et");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/et'), 'et', "module should export et");
+        }
         
         test.done();
     }

--- a/test/lang/eu.js
+++ b/test/lang/eu.js
@@ -355,9 +355,9 @@ exports["lang:eu"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/eu'), 'eu', "module should export eu");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/eu'), 'eu', "module should export eu");
+        }
         
         test.done();
     }

--- a/test/lang/fa.js
+++ b/test/lang/fa.js
@@ -337,9 +337,9 @@ exports["lang:fa"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/fa'), 'fa', "module should export fa");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/fa'), 'fa', "module should export fa");
+        }
         
         test.done();
     }

--- a/test/lang/fi.js
+++ b/test/lang/fi.js
@@ -350,9 +350,9 @@ exports["lang:fi"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/fi'), 'fi', "module should export fi");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/fi'), 'fi', "module should export fi");
+        }
         
         test.done();
     }

--- a/test/lang/fr-ca.js
+++ b/test/lang/fr-ca.js
@@ -370,9 +370,9 @@ exports["lang:fr-ca"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/fr-ca'), 'fr-ca', "module should export fr-ca");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/fr-ca'), 'fr-ca', "module should export fr-ca");
+        }
         
         test.done();
     }

--- a/test/lang/fr.js
+++ b/test/lang/fr.js
@@ -353,9 +353,9 @@ exports["lang:fr"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/fr'), 'fr', "module should export fr");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/fr'), 'fr', "module should export fr");
+        }
         
         test.done();
     }

--- a/test/lang/gl.js
+++ b/test/lang/gl.js
@@ -334,9 +334,9 @@ exports["lang:gl"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/gl'), 'gl', "module should export gl");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/gl'), 'gl', "module should export gl");
+        }
         
         test.done();
     }

--- a/test/lang/he.js
+++ b/test/lang/he.js
@@ -313,9 +313,9 @@ exports["lang:he"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/he'), 'he', "module should export he");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/he'), 'he', "module should export he");
+        }
         
         test.done();
     }

--- a/test/lang/hi.js
+++ b/test/lang/hi.js
@@ -376,9 +376,9 @@ exports["lang:hi"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/hi'), 'hi', "module should export hi");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/hi'), 'hi', "module should export hi");
+        }
         
         test.done();
     }

--- a/test/lang/hr.js
+++ b/test/lang/hr.js
@@ -384,9 +384,9 @@ exports["lang:hr"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/hr'), 'hr', "module should export hr");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/hr'), 'hr', "module should export hr");
+        }
         
         test.done();
     }

--- a/test/lang/hu.js
+++ b/test/lang/hu.js
@@ -355,9 +355,9 @@ exports["lang:hu"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/hu'), 'hu', "module should export hu");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/hu'), 'hu', "module should export hu");
+        }
         
         test.done();
     }

--- a/test/lang/id.js
+++ b/test/lang/id.js
@@ -310,9 +310,9 @@ exports["lang:id"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/id'), 'id', "module should export id");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/id'), 'id', "module should export id");
+        }
         
         test.done();
     }

--- a/test/lang/is.js
+++ b/test/lang/is.js
@@ -363,9 +363,10 @@ exports["lang:is"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
+        if (typeof module !== 'undefined' && module.exports) {
         
-        test.equal(require('../../lang/is'), 'is', "module should export is");
+            test.equal(require('../../lang/is'), 'is', "module should export is");
+        }
         
         test.done();
     }

--- a/test/lang/it.js
+++ b/test/lang/it.js
@@ -351,9 +351,9 @@ exports["lang:it"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/it'), 'it', "module should export it");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/it'), 'it', "module should export it");
+        }
         
         test.done();
     }

--- a/test/lang/ja.js
+++ b/test/lang/ja.js
@@ -315,9 +315,9 @@ exports["lang:ja"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ja'), 'ja', "module should export ja");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ja'), 'ja', "module should export ja");
+        }
         
         test.done();
     }

--- a/test/lang/ka.js
+++ b/test/lang/ka.js
@@ -374,12 +374,12 @@ exports["lang:ka"] = {
 
         test.done();
     },
-    
+
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ka'), 'ka', "module should export ka");
-        
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ka'), 'ka', "module should export ka");
+        }
+
         test.done();
     }
 };

--- a/test/lang/ko.js
+++ b/test/lang/ko.js
@@ -362,9 +362,9 @@ exports["lang:kr"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ko'), 'ko', "module should export ko");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ko'), 'ko', "module should export ko");
+        }
         
         test.done();
     }

--- a/test/lang/lt.js
+++ b/test/lang/lt.js
@@ -361,9 +361,9 @@ exports["lang:lt"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/lt'), 'lt', "module should export lt");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/lt'), 'lt', "module should export lt");
+        }
         
         test.done();
     }

--- a/test/lang/lv.js
+++ b/test/lang/lv.js
@@ -354,9 +354,9 @@ exports["lang:lv"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/lv'), 'lv', "module should export lv");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/lv'), 'lv', "module should export lv");
+        }
         
         test.done();
     }

--- a/test/lang/ml.js
+++ b/test/lang/ml.js
@@ -376,9 +376,9 @@ exports["lang:ml"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ml'), 'ml', "module should export ml");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ml'), 'ml', "module should export ml");
+        }
         
         test.done();
     }

--- a/test/lang/mr.js
+++ b/test/lang/mr.js
@@ -376,9 +376,9 @@ exports["lang:mr"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/mr'), 'mr', "module should export mr");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/mr'), 'mr', "module should export mr");
+        }
         
         test.done();
     }

--- a/test/lang/ms-my.js
+++ b/test/lang/ms-my.js
@@ -376,9 +376,9 @@ exports["lang:ms-my"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ms-my'), 'ms-my', "module should export ms-my");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ms-my'), 'ms-my', "module should export ms-my");
+        }
         
         test.done();
     }

--- a/test/lang/nb.js
+++ b/test/lang/nb.js
@@ -355,9 +355,9 @@ exports["lang:nb"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/nb'), 'nb', "module should export nb");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/nb'), 'nb', "module should export nb");
+        }
         
         test.done();
     }

--- a/test/lang/ne.js
+++ b/test/lang/ne.js
@@ -374,9 +374,9 @@ exports["lang:ne"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ne'), 'ne', "module should export ne");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ne'), 'ne', "module should export ne");
+        }
         
         test.done();
     }

--- a/test/lang/nl.js
+++ b/test/lang/nl.js
@@ -365,9 +365,9 @@ exports["lang:nl"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/nl'), 'nl', "module should export nl");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/nl'), 'nl', "module should export nl");
+        }
         
         test.done();
     }

--- a/test/lang/nn.js
+++ b/test/lang/nn.js
@@ -354,9 +354,9 @@ exports["lang:nn"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/nn'), 'nn', "module should export nn");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/nn'), 'nn', "module should export nn");
+        }
         
         test.done();
     }

--- a/test/lang/pl.js
+++ b/test/lang/pl.js
@@ -373,9 +373,9 @@ exports["lang:pl"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/pl'), 'pl', "module should export pl");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/pl'), 'pl', "module should export pl");
+        }
         
         test.done();
     }

--- a/test/lang/pt-br.js
+++ b/test/lang/pt-br.js
@@ -356,9 +356,9 @@ exports["lang:pt-br"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/pt-br'), 'pt-br', "module should export pt-br");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/pt-br'), 'pt-br', "module should export pt-br");
+        }
         
         test.done();
     }

--- a/test/lang/pt.js
+++ b/test/lang/pt.js
@@ -346,9 +346,9 @@ exports["lang:pt"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/pt'), 'pt', "module should export pt");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/pt'), 'pt', "module should export pt");
+        }
         
         test.done();
     }

--- a/test/lang/ro.js
+++ b/test/lang/ro.js
@@ -355,9 +355,9 @@ exports["lang:ro"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ro'), 'ro', "module should export ro");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ro'), 'ro', "module should export ro");
+        }
         
         test.done();
     }

--- a/test/lang/ru.js
+++ b/test/lang/ru.js
@@ -419,9 +419,9 @@ exports["lang:ru"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/ru'), 'ru', "module should export ru");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/ru'), 'ru', "module should export ru");
+        }
         
         test.done();
     }

--- a/test/lang/sk.js
+++ b/test/lang/sk.js
@@ -440,9 +440,9 @@ exports["lang:sk"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/sk'), 'sk', "module should export sk");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/sk'), 'sk', "module should export sk");
+        }
         
         test.done();
     }

--- a/test/lang/sl.js
+++ b/test/lang/sl.js
@@ -383,9 +383,9 @@ exports["lang:sl"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/sl'), 'sl', "module should export sl");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/sl'), 'sl', "module should export sl");
+        }
         
         test.done();
     }

--- a/test/lang/sq.js
+++ b/test/lang/sq.js
@@ -377,9 +377,9 @@ exports["lang:sq"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/sq'), 'sq', "module should export sq");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/sq'), 'sq', "module should export sq");
+        }
         
         test.done();
     }

--- a/test/lang/sv.js
+++ b/test/lang/sv.js
@@ -348,9 +348,9 @@ exports["lang:sv"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/sv'), 'sv', "module should export sv");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/sv'), 'sv', "module should export sv");
+        }
         
         test.done();
     }

--- a/test/lang/th.js
+++ b/test/lang/th.js
@@ -315,9 +315,9 @@ exports["lang:th"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/th'), 'th', "module should export th");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/th'), 'th', "module should export th");
+        }
         
         test.done();
     }

--- a/test/lang/tr.js
+++ b/test/lang/tr.js
@@ -366,9 +366,9 @@ exports["lang:tr"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/tr'), 'tr', "module should export tr");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/tr'), 'tr', "module should export tr");
+        }
         
         test.done();
     }

--- a/test/lang/tzm-la.js
+++ b/test/lang/tzm-la.js
@@ -354,9 +354,9 @@ exports["lang:tzm-la"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/tzm-la'), 'tzm-la', "module should export tzm-la");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/tzm-la'), 'tzm-la', "module should export tzm-la");
+        }
         
         test.done();
     }

--- a/test/lang/tzm.js
+++ b/test/lang/tzm.js
@@ -343,12 +343,11 @@ exports["lang:tzm"] = {
 
         test.done();
     },
-    
+
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/tzm'), 'tzm', "module should export tzm");
-        
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/tzm'), 'tzm', "module should export tzm");
+        }
         test.done();
     }
 };

--- a/test/lang/uk.js
+++ b/test/lang/uk.js
@@ -385,9 +385,9 @@ exports["lang:uk"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/uk'), 'uk', "module should export uk");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/uk'), 'uk', "module should export uk");
+        }
         
         test.done();
     }

--- a/test/lang/uz.js
+++ b/test/lang/uz.js
@@ -352,9 +352,9 @@ exports["lang:uz"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/uz'), 'uz', "module should export uz");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/uz'), 'uz', "module should export uz");
+        }
         
         test.done();
     }

--- a/test/lang/vn.js
+++ b/test/lang/vn.js
@@ -378,9 +378,9 @@ exports["lang:vn"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/vn'), 'vn', "module should export vn");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/vn'), 'vn', "module should export vn");
+        }
         
         test.done();
     }

--- a/test/lang/zh-cn.js
+++ b/test/lang/zh-cn.js
@@ -349,9 +349,9 @@ exports["lang:zh-cn"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/zh-cn'), 'zh-cn', "module should export zh-cn");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/zh-cn'), 'zh-cn', "module should export zh-cn");
+        }
         
         test.done();
     }

--- a/test/lang/zh-tw.js
+++ b/test/lang/zh-tw.js
@@ -350,9 +350,9 @@ exports["lang:zh-tw"] = {
     },
     
     "returns the name of the language" : function (test) {
-        test.expect(1);
-        
-        test.equal(require('../../lang/zh-tw'), 'zh-tw', "module should export zh-tw");
+        if (typeof module !== 'undefined' && module.exports) {
+            test.equal(require('../../lang/zh-tw'), 'zh-tw', "module should export zh-tw");
+        }
         
         test.done();
     }


### PR DESCRIPTION
We added tests to verify that languages actually exported the language they contain, but the way the test is written, it only works correctly in Node, since AMD passes the result through a callback, not as the return value to require. So our tests were failing in the browser.

I just made the test not run in the browser, and then verified it using a local instance of momentjs.com.
