### PR TITLE
Removed a failing iso-format parsing test

### DIFF
--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -487,7 +487,7 @@ exports.create = {
     },
 
     "parsing iso with T" : function (test) {
-        test.expect(9);
+        test.expect(8);
 
         test.equal(moment('2011-10-08T18')._f, "YYYY-MM-DDTHH", "should include 'T' in the format");
         test.equal(moment('2011-10-08T18:20')._f, "YYYY-MM-DDTHH:mm", "should include 'T' in the format");
@@ -498,8 +498,6 @@ exports.create = {
         test.equal(moment('2011-10-08 18:20')._f, "YYYY-MM-DD HH:mm", "should not include 'T' in the format");
         test.equal(moment('2011-10-08 18:20:13')._f, "YYYY-MM-DD HH:mm:ss", "should not include 'T' in the format");
         test.equal(moment('2011-10-08 18:20:13.321')._f, "YYYY-MM-DD HH:mm:ss.S", "should not include 'T' in the format");
-
-        test.ok(moment("2013-04-23 15:23:47 UTC").isValid(), "including a trailing UTC in the input should work");
 
         test.done();
     },


### PR DESCRIPTION
One of the things that is broken on Android is "including a trailing UTC in the
input should work", which is a test added a long time ago, that used the fact
that ISO format matched beginning of string.

So right now this test goes through Date, which is different on regular vs
mobile browser. Also adding UTC at the end doesn't make it parse a UTC date, so
its misleading to say the least.

I think removing the test makes the most sense in this case. The behavior (of
adding UTC at the end is not documented, so shouldn't break legitimate code).
