### PR TITLE
Fix regression re: support for mock dates.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -400,7 +400,8 @@
     }
 
     function isDate(input) {
-        return Object.prototype.toString.call(input) === '[object Date]';
+        return  Object.prototype.toString.call(input) === '[object Date]' ||
+                input instanceof Date;
     }
 
     // compare two arrays, return the number of differences


### PR DESCRIPTION
`moment(input)` needs to determine if `input` is a date.  The mechanism for 
doing this was changed in ab7824f1dcca22bdb8b73f7f98cf660305a73211 to deal
with issue #1084, namely that in a node REPL `globals.Date` may not be the
same
`Date` used by moment.

However, this prevents users from changing `Date`, for example by mocking it
via something like [Timecop.js](https://github.com/jamesarosen/Timecop.js).

This commit makes date checking lenient enough to handle both cases.
