### PR TITLE
Removed forEach from format tests

### DIFF
--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -314,14 +314,17 @@ exports.format = {
     "calendar day timezone" : function (test) {
         test.expect(10);
 
+        moment.lang('en');
         var zones = [60, -60, 90, -90, 360, -360, 720, -720],
             b = moment().utc().startOf('day').subtract({ m : 1 }),
-            c = moment().local().startOf('day').subtract({ m : 1 });
+            c = moment().local().startOf('day').subtract({ m : 1 }),
+            i, z, a;
 
-        zones.forEach(function (z) {
-            var a = moment().zone(z).startOf('day').subtract({ m: 1 });
+        for (i = 0; i < zones.length; ++i) {
+            z = zones[i];
+            a = moment().zone(z).startOf('day').subtract({ m: 1 });
             test.equal(moment(a).zone(z).calendar(), "Yesterday at 11:59 PM", "Yesterday at 11:59 PM, not Today, or the wrong time");
-        });
+        }
 
         test.equal(moment(b).utc().calendar(), "Yesterday at 11:59 PM", "Yesterday at 11:59 PM, not Today, or the wrong time");
         test.equal(moment(c).local().calendar(), "Yesterday at 11:59 PM", "Yesterday at 11:59 PM, not Today, or the wrong time");


### PR DESCRIPTION
ie8 doesn't support `[].forEach`, so replace it with a regular for loop.
