### PR TITLE
Add specific check for "require" in hasModule check.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -27,7 +27,7 @@
         languages = {},
 
         // check for nodeJS
-        hasModule = (typeof module !== 'undefined' && module.exports),
+        hasModule = (typeof module !== 'undefined' && module.exports && typeof require !== 'undefined'),
 
         // ASP.NET json date format regex
         aspNetJsonRegex = /^\/?Date\((\-?\d+)/i,


### PR DESCRIPTION
When using moment.js in QUnit tests, hasModule resolves true and triggers makeGlobal deprecation warning. This pull request ensures that the hasModule check on line 30 only resolves as truthy when using an actual module pattern with a require fn.
