### PR TITLE
Fixed cloning a modified duration

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -298,9 +298,6 @@
             seconds = normalizedInput.second || 0,
             milliseconds = normalizedInput.millisecond || 0;
 
-        // store reference to input for deterministic cloning
-        this._input = duration;
-
         // representation for dateAddRemove
         this._milliseconds = +milliseconds +
             seconds * 1e3 + // 1000
@@ -1559,9 +1556,7 @@
 
     // duration
     moment.duration = function (input, key) {
-        var isDuration = moment.isDuration(input),
-            isNumber = (typeof input === 'number'),
-            duration = (isDuration ? input._input : (isNumber ? {} : input)),
+        var duration = input,
             // matching against regexp is expensive, do it on demand
             match = null,
             sign,
@@ -1570,7 +1565,14 @@
             timeEmpty,
             dateTimeEmpty;
 
-        if (isNumber) {
+        if (moment.isDuration(input)) {
+            duration = {
+                ms: input._milliseconds,
+                d: input._days,
+                M: input._months
+            };
+        } else if (typeof input === 'number') {
+            duration = {};
             if (key) {
                 duration[key] = input;
             } else {
@@ -1609,7 +1611,7 @@
 
         ret = new Duration(duration);
 
-        if (isDuration && input.hasOwnProperty('_lang')) {
+        if (moment.isDuration(input) && input.hasOwnProperty('_lang')) {
             ret._lang = input._lang;
         }
 

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -130,12 +130,14 @@ exports.duration = {
                 minutes: 9,
                 seconds: 20,
                 milliseconds: 12
-            });
+            }),
+            modified = moment.duration(1, 'day').add(moment.duration(1, 'day'));
 
-        test.expect(3);
+        test.expect(4);
         test.deepEqual(moment.duration(simple), simple, "simple clones are equal");
         test.deepEqual(moment.duration(lengthy), lengthy, "lengthy clones are equal");
         test.deepEqual(moment.duration(complicated), complicated, "complicated clones are equal");
+        test.deepEqual(moment.duration(modified), modified, "cloning modified duration works");
         test.done();
     },
 


### PR DESCRIPTION
Storing the _input for creating a duration doesn't work for cloning when the
original duration is modified, because input no longer corresponds to the new
duration. Instead use the ms, days and month values which uniquely identify
a duration.

This also happens to fix #1242
