### PR TITLE
Properly use global this to export moment

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -12,6 +12,7 @@
 
     var moment,
         VERSION = "2.4.0",
+        global = this,
         round = Math.round,
         i,
 
@@ -2282,7 +2283,7 @@
         // add `moment` as a global object via a string identifier,
         // for Closure Compiler "advanced" mode
         if (deprecate) {
-            this.moment = function () {
+            global.moment = function () {
                 if (!warned && console && console.warn) {
                     warned = true;
                     console.warn(
@@ -2293,7 +2294,7 @@
                 return local_moment.apply(null, arguments);
             };
         } else {
-            this['moment'] = moment;
+            global['moment'] = moment;
         }
     }
 


### PR DESCRIPTION
Don't assume this is bound to the global scope in local functions.

Related to #1179

@Xotic750 you mentioned something about returns on every code-path. I didn't find such an option in jshint. Can you double check and maybe propose other jshint options we should enforce to make moment strict mode compatible?
