### PR TITLE
Ensure module.config() returns an object - for Dojo compat

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2304,7 +2304,7 @@
         makeGlobal(true);
     } else if (typeof define === "function" && define.amd) {
         define("moment", function (require, exports, module) {
-            if (module.config().noGlobal !== true) {
+            if (module.config() && module.config().noGlobal !== true) {
                 // If user provided noGlobal, he is aware of global
                 makeGlobal(module.config().noGlobal === undefined);
             }


### PR DESCRIPTION
When used with the Dojo loader - `module.config()` is not required to return an empty object when no config properties are present - causing the define block to throw an error.
