### PR TITLE
make moment.js compatible with older version of requirejs

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2304,7 +2304,7 @@
         makeGlobal(true);
     } else if (typeof define === "function" && define.amd) {
         define("moment", function (require, exports, module) {
-            if (module.config() && module.config().noGlobal !== true) {
+            if (module.config && module.config() && module.config().noGlobal !== true) {
                 // If user provided noGlobal, he is aware of global
                 makeGlobal(module.config().noGlobal === undefined);
             }


### PR DESCRIPTION
Using older version of requirejs (1.0.4), module.config function doesn't exists and moment.js crashes on load.

This PR is so make momentjs be compatible with older version of requirejs
