### PR TITLE
simplifying diff

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1796,7 +1796,7 @@
         },
 
         diff : function (input, units, asFloat) {
-            var that = this._isUTC ? moment(input).zone(this._offset || 0) : moment(input).local(),
+            var that = moment(input),
                 zoneDiff = (this.zone() - that.zone()) * 6e4,
                 diff, output;
 


### PR DESCRIPTION
This fixes #1227. That line of code has bugged me for a while, because I don't understand it. It doesn't make sense for a couple reasons. We should just leave the moments as they are and let the math work itself out. It seems to work.

You can verify the fix by changing your system clock to the day before the fall DST change (Nov 2 in the US). All the tests will pass.

There are still some test failures for the spring time change, but they're testing issues, as far as I can tell, caused by 2:00 not actually existing.
