### PR TITLE
include jspm package.json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "ender": "./ender.js",
     "dojoBuild": "package.js",
     "jspm": {
-        "files": ["moment.js"],
+        "files": ["moment.js", "lang"],
+        "dependencyMap": {
+            "moment": "./moment"
+        },
         "buildConfig": {
             "uglify": true
         }


### PR DESCRIPTION
This configuration makes the module play a little more nicely with jspm - reducing the download time and ensuring the source is delivered minified with source maps.

See an example here of it being served over the CDN - http://jsbin.com/EHoyItAj/1/edit.

With the download tool, one would do `jspm install moment`.

Any questions just ask. Appreciated for the time to look into this.
