### PR TITLE
Fix Italian relativeTime

### DIFF
--- a/lang/it.js
+++ b/lang/it.js
@@ -38,7 +38,7 @@
                 return ((/^[0-9].+$/).test(s) ? "tra" : "in") + " " + s;
             },
             past : "%s fa",
-            s : "secondi",
+            s : "qualche secondo",
             m : "un minuto",
             mm : "%d minuti",
             h : "un'ora",


### PR DESCRIPTION
The Italian translation for the relative time `a few seconds` is just `secondi` (`seconds`).
It's quite unclear: let's translate it better, with `qualche secondo` (`a few seconds`).
