### PR TITLE
Changed longDateFormat of LT a L to right format used in Czech Republic

### DIFF
--- a/lang/cs.js
+++ b/lang/cs.js
@@ -86,8 +86,8 @@
         weekdaysShort : "ne_po_út_st_čt_pá_so".split("_"),
         weekdaysMin : "ne_po_út_st_čt_pá_so".split("_"),
         longDateFormat : {
-            LT: "H:mm",
-            L : "DD.MM.YYYY",
+            LT: "H.mm",
+            L : "DD. MM. YYYY",
             LL : "D. MMMM YYYY",
             LLL : "D. MMMM YYYY LT",
             LLLL : "dddd D. MMMM YYYY LT"


### PR DESCRIPTION
See http://en.wikipedia.org/wiki/Date_and_time_notation_in_the_Czech_Republic
