### PR TITLE
Dropping unused variables

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -437,8 +437,7 @@
     function normalizeObjectUnits(inputObject) {
         var normalizedInput = {},
             normalizedProp,
-            prop,
-            index;
+            prop;
 
         for (prop in inputObject) {
             if (inputObject.hasOwnProperty(prop)) {
@@ -1576,9 +1575,7 @@
             match = null,
             sign,
             ret,
-            parseIso,
-            timeEmpty,
-            dateTimeEmpty;
+            parseIso;
 
         if (moment.isDuration(input)) {
             duration = {


### PR DESCRIPTION
When working in another project I noticed three WARNs from UglifyJS2 (using "-cm" arguments) which originated from `moment.js` v2.4.0; each was of the format: "WARN: Dropping unused variable _VAR_ [_path_/moment.js:_line_,_column_]"

Therefore, this Pull Request offers dropping some unused variables from the `moment.js` code in the `develop` branch. There are no new/changed unit tests, as there are no feature/bug changes requiring new test cases.

I was able to perform `grunt` before and after the changes, and there has been no change in output; both report:

```
Running "jshint:all" (jshint) task
>> 164 files lint free.

Running "nodeunit:all" (nodeunit) task
Testing ar-ma.js......................OK
Testing ar.js......................OK
Testing bg.js......................OK
Testing br.js...............OK
Testing bs.js......................OK
Testing ca.js.....................OK
Testing cs.js........................OK
Testing cv.js......................OK
Testing cy.js.....................OK
Testing da.js..................OK
Testing de.js.....................OK
Testing el.js......................OK
Testing en-au.js......................OK
Testing en-ca.js......................OK
Testing en-gb.js......................OK
Testing en.js.....................OK
Testing eo.js......................OK
Testing es.js......................OK
Testing et.js......................OK
Testing eu.js......................OK
Testing fa.js......................OK
Testing fi.js......................OK
Testing fo.js..................OK
Testing fr-ca.js.....................OK
Testing fr.js.....................OK
Testing gl.js......................OK
Testing he.js.....................OK
Testing hi.js.......................OK
Testing hr.js......................OK
Testing hu.js......................OK
Testing id.js.....................OK
Testing is.js......................OK
Testing it.js.....................OK
Testing ja.js.....................OK
Testing ka.js......................OK
Testing ko.js......................OK
Testing lb.js.........OK
Testing lt.js......................OK
Testing lv.js......................OK
Testing ml.js.......................OK
Testing mr.js.......................OK
Testing ms-my.js......................OK
Testing nb.js......................OK
Testing ne.js.......................OK
Testing nl.js.......................OK
Testing nn.js......................OK
Testing pl.js......................OK
Testing pt-br.js.....................OK
Testing pt.js.....................OK
Testing ro.js......................OK
Testing rs.js......................OK
Testing ru.js...........................OK
Testing sk.js........................OK
Testing sl.js......................OK
Testing sq.js......................OK
Testing sv.js......................OK
Testing ta.js......................OK
Testing th.js.....................OK
Testing tl-ph.js.....................OK
Testing tr.js......................OK
Testing tzm-la.js......................OK
Testing tzm.js......................OK
Testing uk.js.......................OK
Testing uz.js......................OK
Testing vn.js......................OK
Testing zh-cn.js.......................OK
Testing zh-tw.js......................OK
Testing add_subtract.js..........OK
Testing create.js.........................................OK
Testing days_in_month.js..OK
Testing diff.js.............OK
Testing duration.js.................................OK
Testing format.js......................OK
Testing getters_setters.js............OK
Testing invalid.js...OK
Testing is_after.js........OK
Testing is_before.js........OK
Testing is_moment.js.OK
Testing is_same.js........OK
Testing is_valid.js..................OK
Testing lang.js.....................OK
Testing leapyear.js.OK
Testing listers.js....OK
Testing min_max.js..OK
Testing mutable.js..OK
Testing normalizeUnits.js.OK
Testing parsing_flags.js...........OK
Testing preparse_postformat.js...OK
Testing quarter.js.OK
Testing sod_eod.js................OK
Testing string_prototype.js.OK
Testing utc.js.....OK
Testing week_year.js..OK
Testing weekday.js.........OK
Testing weeks.js...............OK
Testing zones.js.........................OK
>> 21835 assertions passed (3350ms)
```
