### PR TITLE
jspm configuration adjustment

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "dojoBuild": "package.js",
     "jspm": {
         "files": ["moment.js", "lang"],
-        "dependencyMap": {
+        "map": {
             "moment": "./moment"
         },
         "buildConfig": {


### PR DESCRIPTION
This makes a small adjustment for the new jspm configuration scheme being pushed out this week. This aligns the package configuration entirely with the RequireJS-style jspm loader configuration so there is a 1-1 relationship between the package.json config and the loader config.
