### PR TITLE
toISOString supports long and negative years

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1739,7 +1739,12 @@
         },
 
         toISOString : function () {
-            return formatMoment(moment(this).utc(), 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
+            var m = moment(this).utc();
+            if (0 < m.year() && m.year() <= 9999) {
+                return formatMoment(m, 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
+            } else {
+                return formatMoment(m, 'YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
+            }
         },
 
         toArray : function () {

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -160,9 +160,21 @@ exports.format = {
     },
 
     "toISOString" : function (test) {
+        test.expect(4);
         var date = moment.utc("2012-10-09T20:30:40.678");
 
         test.equal(date.toISOString(), "2012-10-09T20:30:40.678Z", "should output ISO8601 on moment.fn.toISOString");
+
+        // big years
+        date = moment.utc("+020123-10-09T20:30:40.678");
+        test.equal(date.toISOString(), "+020123-10-09T20:30:40.678Z", "ISO8601 format on big positive year");
+        // negative years
+        date = moment.utc("-000001-10-09T20:30:40.678");
+        test.equal(date.toISOString(), "-000001-10-09T20:30:40.678Z", "ISO8601 format on big positive year");
+        // big negative years
+        date = moment.utc("-020123-10-09T20:30:40.678");
+        test.equal(date.toISOString(), "-020123-10-09T20:30:40.678Z", "ISO8601 format on big positive year");
+
         test.done();
     },
 


### PR DESCRIPTION
ISO format supports negative an big years with a special, 6-digit, always signed year. Check https://github.com/moment/moment/issues/1178#issuecomment-26106354
