### PR TITLE
Fix to Arabic week number parsings.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1500,7 +1500,7 @@
         var d = makeUTCDate(year, 0, 1).getUTCDay(), daysToAdd, dayOfYear;
 
         weekday = weekday != null ? weekday : firstDayOfWeek;
-        daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0);
+        daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0) - (d < firstDayOfWeek ? 7 : 0);
         dayOfYear = 7 * (week - 1) + (weekday - firstDayOfWeek) + daysToAdd + 1;
 
         return {

--- a/test/lang/ar.js
+++ b/test/lang/ar.js
@@ -286,7 +286,7 @@ exports["lang:ar"] = {
     },
 
     "weeks year starting wednesday" : function (test) {
-        test.expect(6);
+        test.expect(10);
 
         test.equal(moment([2002, 11, 28]).week(), 1, "Dec 28 2002 should be week 1");
         test.equal(moment([2003,  0,  1]).week(), 1, "Jan  1 2003 should be week 1");
@@ -294,6 +294,11 @@ exports["lang:ar"] = {
         test.equal(moment([2003,  0,  4]).week(), 2, "Jan  4 2003 should be week 2");
         test.equal(moment([2003,  0, 10]).week(), 2, "Jan 10 2003 should be week 2");
         test.equal(moment([2003,  0, 11]).week(), 3, "Jan 11 2003 should be week 3");
+
+        test.equal(moment("2003 1 6", "gggg w d").format("YYYY-MM-DD"), "2002-12-28", "Week 1 of 2003 should be Dec 28 2002");
+        test.equal(moment("2003 1 0", "gggg w e").format("YYYY-MM-DD"), "2002-12-28", "Week 1 of 2003 should be Dec 28 2002");
+        test.equal(moment("2003 1 6", "gggg w d").format("gggg w d"), "2003 1 6", "Saturday of week 1 of 2003 parsed should be formatted as 2003 1 6");
+        test.equal(moment("2003 1 0", "gggg w e").format("gggg w e"), "2003 1 0", "1st day of week 1 of 2003 parsed should be formatted as 2003 1 0");
 
         test.done();
     },


### PR DESCRIPTION
In Arabic week numbering (week starts on Saturday, 1st week contains January 1st) the local week numbering formatting is correct (2013-12-28 formatted as gggg ww d becomes 2014 1 6), the parsing however is shifting the weeks by one. Parsing moment('2014 1 6', 'gggg w d') returns the January 4th 2014.

Fixes the issue https://github.com/moment/moment/issues/1397
