### PR TITLE
Handle wrongly cloned moments

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -387,8 +387,8 @@
     }
 
     function cloneMoment(m) {
-        var result = {};
-        for (var i in m) {
+        var result = {}, i;
+        for (i in m) {
             if (m.hasOwnProperty(i) && momentProperties.hasOwnProperty(i)) {
                 result[i] = m[i];
             }

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -106,13 +106,13 @@ exports.create = {
     },
 
     "cloning moment works with weird clones" : function (test) {
-        var extend = function(a, b) {
+        var extend = function (a, b) {
                 var i;
                 for (i in b) {
                     a[i] = b[i];
                 }
                 return a;
-            };
+            },
             now = moment(),
             nowu = moment.utc();
 

--- a/test/moment/is_moment.js
+++ b/test/moment/is_moment.js
@@ -5,7 +5,7 @@ exports.is_moment = {
         test.expect(13);
 
         var MyObj = function () {},
-            extend = function(a, b) {
+            extend = function (a, b) {
                 var i;
                 for (i in b) {
                     a[i] = b[i];


### PR DESCRIPTION
This is in response to #1404
- detect moment objects that were cloned with something like `_.extend({}, moment())` as `isMoment`-s
- properly clone them and produce _orthodox_ moment objects

Please interested parties (@chilversc, @mattbrooks2010, @RomanDidenko) -- test on knockout, or whatever fancy libraries you happen to use if it works fine with them.
