### PR TITLE
Don't use HTML entities in Welsh translations

### DIFF
--- a/lang/cy.js
+++ b/lang/cy.js
@@ -35,7 +35,7 @@
         },
         relativeTime: {
             future: "mewn %s",
-            past: "%s yn &#244;l",
+            past: "%s yn àl",
             s: "ychydig eiliadau",
             m: "munud",
             mm: "%d munud",

--- a/test/lang/cy.js
+++ b/test/lang/cy.js
@@ -174,7 +174,7 @@ exports["lang:cy"] = {
         test.expect(2);
 
         test.equal(moment(30000).from(0), "mewn ychydig eiliadau", "prefix");
-        test.equal(moment(0).from(30000), "ychydig eiliadau yn &#244;l", "suffix");
+        test.equal(moment(0).from(30000), "ychydig eiliadau yn àl", "suffix");
         test.done();
     },
 


### PR DESCRIPTION
Since this is a JavaScript library, we may not always use the produced strings in HTML directly. This changes the HTML entity used for "à" in Welsh translations to, well, "à".
