### PR TITLE
Litunanian day names in calendars with weeks not starting on Monday

### DIFF
--- a/lang/lt.js
+++ b/lang/lt.js
@@ -23,7 +23,7 @@
         "y" : "metai_metų_metus",
         "yy": "metai_metų_metus"
     },
-    weekDays = "pirmadienis_antradienis_trečiadienis_ketvirtadienis_penktadienis_šeštadienis_sekmadienis".split("_");
+    weekDays = "sekmadienis_pirmadienis_antradienis_trečiadienis_ketvirtadienis_penktadienis_šeštadienis".split("_");
 
     function translateSeconds(number, withoutSuffix, key, isFuture) {
         if (withoutSuffix) {
@@ -62,7 +62,7 @@
 
     function relativeWeekDay(moment, format) {
         var nominative = format.indexOf('dddd LT') === -1,
-            weekDay = weekDays[moment.weekday()];
+            weekDay = weekDays[moment.isoWeekday() % 7];
 
         return nominative ? weekDay : weekDay.substring(0, weekDay.length - 2) + "į";
     }

--- a/test/lang/lt.js
+++ b/test/lang/lt.js
@@ -132,6 +132,17 @@ exports["lang:lt"] = {
         test.done();
     },
 
+    "format week on US calendar" : function (test) {
+        test.expect(7);
+        moment.lang("lt", {week: {dow: 0, doy: 6}}); // Tests, whether the weekday names are correct, even if the week does not start on Moday
+        var expected = 'sekmadienis Sek S_pirmadienis Pir P_antradienis Ant A_trečiadienis Tre T_ketvirtadienis Ket K_penktadienis Pen Pn_šeštadienis Šeš Š'.split("_"), i;
+        for (i = 0; i < expected.length; i++) {
+            test.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
+        }
+        moment.lang("lt", {week: {dow: 1, doy: 4}});
+        test.done();
+    },
+
     "from" : function (test) {
         test.expect(37);
 
@@ -367,4 +378,5 @@ exports["lang:lt"] = {
         
         test.done();
     }
+
 };


### PR DESCRIPTION
In the Lithuanian localization the weekday names logic is different for the full day names and the shortened day names due to declination. This is ok when the Lithuanian weekdays numbering is used (week starts on Monday). However, when a calendar is used where the week starts on another day, the full weekday names are shifted (the abbreviated names stay correct). 

The change uses the isoWeekDay for the weekday name declination. 
