### PR TITLE
fixed project name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "moment",
+  "name": "momentjs",
   "version": "2.5.1",
   "main": "moment.js",
   "ignore": [


### PR DESCRIPTION
Fixed the project name in bower.json file. Many projects are using "momentjs" name in the dependency list instead of "moment"
