### PR TITLE
parseZone passes all arguments to moment

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1755,8 +1755,8 @@
         return m;
     };
 
-    moment.parseZone = function (input) {
-        return moment(input).parseZone();
+    moment.parseZone = function () {
+        return moment.apply(null, arguments).parseZone();
     };
 
     /************************************

--- a/test/moment/zones.js
+++ b/test/moment/zones.js
@@ -481,12 +481,26 @@ exports.zones = {
         test.equal(m.hours(), 0);
         test.done();
     },
-    
+
+    "parse zone with more arguments" : function (test) {
+        var m;
+        test.expect(3);
+
+        m = moment.parseZone("2013 01 01 05 -13:00", "YYYY MM DD HH ZZ");
+        test.equal(m.format(), "2013-01-01T05:00:00-13:00", "accept input and format");
+        m = moment.parseZone("2013-01-01-13:00", "YYYY MM DD ZZ", true);
+        test.equal(m.isValid(), false, "accept input, format and strict flag");
+        m = moment.parseZone("2013-01-01-13:00", ["DD MM YYYY ZZ", "YYYY MM DD ZZ"]);
+        test.equal(m.format(), "2013-01-01T00:00:00-13:00", "accept input and array of formats");
+
+        test.done();
+    },
+
     "parse zone with a timezone from the format string" : function (test) {
         test.expect(1);
-        
+
         var m = moment("11-12-2013 -0400 +1100", "DD-MM-YYYY ZZ #####").parseZone();
-        
+
         test.equal(m.zone(), 4 * 60);
         test.done();
     },


### PR DESCRIPTION
moment.parseZone is just a shorthand for moment().parseZone(), so make sure
that all arguments passed to the static function end up in the moment factory
function.

In response to #1446
