### PR TITLE
Better Spanish months in special case

### DIFF
--- a/lang/es.js
+++ b/lang/es.js
@@ -11,9 +11,18 @@
         factory(window.moment); // Browser global
     }
 }(function (moment) {
+    var monthsShortDot = "ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.".split("_"),
+        monthsShort = "ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic".split("_");
+
     return moment.lang('es', {
         months : "enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre".split("_"),
-        monthsShort : "ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.".split("_"),
+        monthsShort : function (m, format) {
+            if (/-MMM-/.test(format)) {
+                return monthsShort[m.month()];
+            } else {
+                return monthsShortDot[m.month()];
+            }
+        },
         weekdays : "domingo_lunes_martes_miércoles_jueves_viernes_sábado".split("_"),
         weekdaysShort : "dom._lun._mar._mié._jue._vie._sáb.".split("_"),
         weekdaysMin : "Do_Lu_Ma_Mi_Ju_Vi_Sá".split("_"),

--- a/test/lang/es.js
+++ b/test/lang/es.js
@@ -37,7 +37,7 @@ exports["lang:es"] = {
     },
 
     "format" : function (test) {
-        test.expect(22);
+        test.expect(23);
         var a = [
                 ['dddd, MMMM Do YYYY, h:mm:ss a',      'domingo, febrero 14º 2010, 3:25:50 pm'],
                 ['ddd, hA',                            'dom., 3PM'],
@@ -47,6 +47,7 @@ exports["lang:es"] = {
                 ['d do dddd ddd dd',                   '0 0º domingo dom. Do'],
                 ['DDD DDDo DDDD',                      '45 45º 045'],
                 ['w wo ww',                            '6 6º 06'],
+                ['YYYY-MMM-DD',                        '2010-feb-14'],
                 ['h hh',                               '3 03'],
                 ['H HH',                               '15 15'],
                 ['m mm',                               '25 25'],
@@ -351,12 +352,12 @@ exports["lang:es"] = {
 
         test.done();
     },
-    
+
     "returns the name of the language" : function (test) {
         if (typeof module !== 'undefined' && module.exports) {
             test.equal(require('../../lang/es'), 'es', "module should export es");
         }
-        
+
         test.done();
     }
 };


### PR DESCRIPTION
Fixes #1234. Properly format YYYY-MMM-DD expressions -- no dot in the month
name in this case.
