### PR TITLE
zone setter can now skip adjusting the hour

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2038,7 +2038,8 @@
             return other > this ? this : other;
         },
 
-        zone : function (input) {
+        zone : function (input, adjust) {
+            adjust = (adjust == null ? true : false);
             var offset = this._offset || 0;
             if (input != null) {
                 if (typeof input === "string") {
@@ -2049,7 +2050,7 @@
                 }
                 this._offset = input;
                 this._isUTC = true;
-                if (offset !== input) {
+                if (offset !== input && adjust) {
                     addOrSubtractDurationFromMoment(this, moment.duration(offset - input, 'm'), 1, true);
                 }
             } else {


### PR DESCRIPTION
When you change the zone you'd expect the time to remain the same, but if
you're doing something low-level you might want just the zone offset to change.

Add a second argument to zone that would allow the caller to disable adjusting
the hour when setting a zone.

I'll make a corresponding PR in the moment-timezone repo.
