### PR TITLE
add support to parse "Do"

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -65,6 +65,7 @@
         parseTokenTimezone = /Z|[\+\-]\d\d:?\d\d/gi, // +00:00 -00:00 +0000 -0000 or Z
         parseTokenT = /T/i, // T (ISO separator)
         parseTokenTimestampMs = /[\+\-]?\d+(\.\d{1,3})?/, // 123456789 123456789.123
+        parseTokenOrdinal = /\d{1,2}/,
 
         //strict parsing regexes
         parseTokenOneDigit = /\d/, // 0 - 9
@@ -1023,6 +1024,8 @@
         case 'e':
         case 'E':
             return parseTokenOneOrTwoDigits;
+        case 'Do':
+            return parseTokenOrdinal;
         default :
             a = new RegExp(regexpEscape(unescapeFormat(token.replace('\\', '')), "i"));
             return a;
@@ -1066,6 +1069,11 @@
         case 'DD' :
             if (input != null) {
                 datePartArray[DATE] = toInt(input);
+            }
+            break;
+        case 'Do' :
+            if (input != null) {
+                datePartArray[DATE] = toInt(parseInt(input, 10));
             }
             break;
         // DAY OF YEAR


### PR DESCRIPTION
for example

``` js
moment('May 6th', 'MMMM Do').format('MMMM Do')
// => May 1st
// expected => May 6th
```

I'm happy to look into it and put together a pull request, just wondering if this wanted or not?
