### PR TITLE
Updated meridiem to display a.m./p.m. with periods as optional case

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -52,7 +52,7 @@
         isoDurationRegex = /^(-)?P(?:(?:([0-9,.]*)Y)?(?:([0-9,.]*)M)?(?:([0-9,.]*)D)?(?:T(?:([0-9,.]*)H)?(?:([0-9,.]*)M)?(?:([0-9,.]*)S)?)?|([0-9,.]*)W)$/,
 
         // format tokens
-        formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,4}|X|zz?|ZZ?|.)/g,
+        formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|aa|AA|a|A|hh?|HH?|mm?|ss?|S{1,4}|X|zz?|ZZ?|.)/g,
         localFormattingTokens = /(\[[^\[]*\])|(\\)?(LT|LL?L?L?|l{1,4})/g,
 
         // parsing token regexes
@@ -217,10 +217,16 @@
                 return this.isoWeekday();
             },
             a    : function () {
-                return this.lang().meridiem(this.hours(), this.minutes(), true);
+                return this.lang().meridiem(this.hours(), this.minutes(), true, false);
+            },
+            aa   : function () {
+                return this.lang().meridiem(this.hours(), this.minutes(), true, true);
             },
             A    : function () {
-                return this.lang().meridiem(this.hours(), this.minutes(), false);
+                return this.lang().meridiem(this.hours(), this.minutes(), false, false);
+            },
+            AA   : function () {
+                return this.lang().meridiem(this.hours(), this.minutes(), false, true);
             },
             H    : function () {
                 return this.hours();
@@ -733,12 +739,16 @@
             return ((input + '').toLowerCase().charAt(0) === 'p');
         },
 
-        _meridiemParse : /[ap]\.?m?\.?/i,
-        meridiem : function (hours, minutes, isLower) {
+        _meridiemParse : /(a{1,2}|p\.?m?\.?)/i,
+        meridiem : function (hours, minutes, isLower, useDots) {
             if (hours > 11) {
-                return isLower ? 'pm' : 'PM';
+                return isLower ?
+                    (useDots ? 'p.m.' : 'pm') :
+                    (useDots ? 'P.M.' : 'PM');
             } else {
-                return isLower ? 'am' : 'AM';
+                return isLower ?
+                    (useDots ? 'a.m.' : 'am') :
+                    (useDots ? 'A.M.' : 'AM');
             }
         },
 
@@ -988,7 +998,9 @@
         case 'ddd':
         case 'dddd':
             return parseTokenWord;
+        case 'aa':
         case 'a':
+        case 'AA':
         case 'A':
             return getLangDefinition(config._l)._meridiemParse;
         case 'X':
@@ -1095,7 +1107,9 @@
             break;
         // AM / PM
         case 'a' : // fall through to A
+        case 'aa':
         case 'A' :
+        case 'AA':
             config._isPm = getLangDefinition(config._l).isPM(input);
             break;
         // 24 HOUR

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -147,7 +147,7 @@ exports.create = {
 
     "string with format dropped am/pm bug" : function (test) {
         moment.lang('en');
-        test.expect(6);
+        test.expect(8);
 
         test.equal(moment('05/1/2012 12:25:00', 'MM/DD/YYYY h:m:s a').format('MM/DD/YYYY'), '05/01/2012', 'should not break if am/pm is left off from the parsing tokens');
         test.equal(moment('05/1/2012 12:25:00 am', 'MM/DD/YYYY h:m:s a').format('MM/DD/YYYY'), '05/01/2012', 'should not break if am/pm is left off from the parsing tokens');
@@ -156,6 +156,8 @@ exports.create = {
         test.ok(moment('05/1/2012 12:25:00', 'MM/DD/YYYY h:m:s a').isValid());
         test.ok(moment('05/1/2012 12:25:00 am', 'MM/DD/YYYY h:m:s a').isValid());
         test.ok(moment('05/1/2012 12:25:00 pm', 'MM/DD/YYYY h:m:s a').isValid());
+        test.ok(moment('05/1/2012 12:25:00 a.m.', 'MM/DD/YYYY h:m:s aa').isValid());
+        test.ok(moment('05/1/2012 12:25:00 p.m.', 'MM/DD/YYYY h:m:s aa').isValid());
 
         test.done();
     },
@@ -196,20 +198,24 @@ exports.create = {
     },
 
     "matching am/pm" : function (test) {
-        test.expect(13);
+        test.expect(17);
 
         test.equal(moment('2012-09-03T03:00PM',   'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00PM', 'am/pm should parse correctly for PM');
         test.equal(moment('2012-09-03T03:00P.M.', 'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00PM', 'am/pm should parse correctly for P.M.');
+        test.equal(moment('2012-09-03T03:00P.M.', 'YYYY-MM-DDThh:mmAA').format('YYYY-MM-DDThh:mmAA'), '2012-09-03T03:00P.M.', 'a.m./p.m. should parse correctly for P.M.');
         test.equal(moment('2012-09-03T03:00P',    'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00PM', 'am/pm should parse correctly for P');
         test.equal(moment('2012-09-03T03:00pm',   'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00PM', 'am/pm should parse correctly for pm');
         test.equal(moment('2012-09-03T03:00p.m.', 'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00PM', 'am/pm should parse correctly for p.m.');
+        test.equal(moment('2012-09-03T03:00p.m.', 'YYYY-MM-DDThh:mmAA').format('YYYY-MM-DDThh:mmAA'), '2012-09-03T03:00P.M.', 'a.m./p.m. should parse correctly for p.m.');
         test.equal(moment('2012-09-03T03:00p',    'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00PM', 'am/pm should parse correctly for p');
 
         test.equal(moment('2012-09-03T03:00AM',   'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00AM', 'am/pm should parse correctly for AM');
         test.equal(moment('2012-09-03T03:00A.M.', 'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00AM', 'am/pm should parse correctly for A.M.');
+        test.equal(moment('2012-09-03T03:00A.M.', 'YYYY-MM-DDThh:mmAA').format('YYYY-MM-DDThh:mmAA'), '2012-09-03T03:00A.M.', 'a.m./p.m. should parse correctly for A.M.');
         test.equal(moment('2012-09-03T03:00A',    'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00AM', 'am/pm should parse correctly for A');
         test.equal(moment('2012-09-03T03:00am',   'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00AM', 'am/pm should parse correctly for am');
         test.equal(moment('2012-09-03T03:00a.m.', 'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00AM', 'am/pm should parse correctly for a.m.');
+        test.equal(moment('2012-09-03T03:00a.m.', 'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmAA'), '2012-09-03T03:00A.M.', 'a.m./p.m. should parse correctly for a.m.');
         test.equal(moment('2012-09-03T03:00a',    'YYYY-MM-DDThh:mmA').format('YYYY-MM-DDThh:mmA'), '2012-09-03T03:00AM', 'am/pm should parse correctly for a');
 
         test.equal(moment('5:00p.m.March 4 2012', 'h:mmAMMMM D YYYY').format('YYYY-MM-DDThh:mmA'), '2012-03-04T05:00PM', 'am/pm should parse correctly before month names');
@@ -231,10 +237,16 @@ exports.create = {
                 ['DD-MM-YYYY h:m:s',    '12-02-1999 2:45:10'],
                 ['DD-MM-YYYY h:m:s a',  '12-02-1999 2:45:10 am'],
                 ['DD-MM-YYYY h:m:s a',  '12-02-1999 2:45:10 pm'],
+                ['DD-MM-YYYY h:m:s aa',  '12-02-1999 2:45:10 a.m.'],
+                ['DD-MM-YYYY h:m:s aa',  '12-02-1999 2:45:10 p.m.'],
                 ['h:mm a',              '12:00 pm'],
                 ['h:mm a',              '12:30 pm'],
                 ['h:mm a',              '12:00 am'],
                 ['h:mm a',              '12:30 am'],
+                ['h:mm aa',              '12:00 p.m.'],
+                ['h:mm aa',              '12:30 p.m.'],
+                ['h:mm aa',              '12:00 a.m.'],
+                ['h:mm aa',              '12:30 a.m.'],
                 ['HH:mm',               '12:00'],
                 ['YYYY-MM-DDTHH:mm:ss', '2011-11-11T11:11:11'],
                 ['MM-DD-YYYY [M]',      '12-02-1999 M'],


### PR DESCRIPTION
Added an extra variable such that using aa or AA will result in a.m./p.m. or A.M./P.M. being printed, respectfully. Also works when converting from a.m. to moment format. (a.m. -> aa)
