### PR TITLE
Add optional time argument to calendar method

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1922,10 +1922,11 @@
             return this.from(moment(), withoutSuffix);
         },
 
-        calendar : function () {
+        calendar : function (time) {
             // We want to compare the start of today, vs this.
             // Getting start-of-today depends on whether we're zone'd or not.
-            var sod = makeAs(moment(), this).startOf('day'),
+            var now = time || moment(),
+                sod = makeAs(now, this).startOf('day'),
                 diff = this.diff(sod, 'days', true),
                 format = diff < -6 ? 'sameElse' :
                     diff < -1 ? 'lastWeek' :

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -364,12 +364,13 @@ exports.format = {
     },
 
     "calendar day timezone" : function (test) {
-        test.expect(10);
+        test.expect(11);
 
         moment.lang('en');
         var zones = [60, -60, 90, -90, 360, -360, 720, -720],
             b = moment().utc().startOf('day').subtract({ m : 1 }),
             c = moment().local().startOf('day').subtract({ m : 1 }),
+            d = moment().local().startOf('day').subtract({ d : 2 }),
             i, z, a;
 
         for (i = 0; i < zones.length; ++i) {
@@ -380,6 +381,7 @@ exports.format = {
 
         test.equal(moment(b).utc().calendar(), "Yesterday at 11:59 PM", "Yesterday at 11:59 PM, not Today, or the wrong time");
         test.equal(moment(c).local().calendar(), "Yesterday at 11:59 PM", "Yesterday at 11:59 PM, not Today, or the wrong time");
+        test.equal(moment(c).local().calendar(d), "Tomorrow at 11:59 PM", "Tomorrow at 11:59 PM, not Yesterday, or the wrong time");
 
         test.done();
     },


### PR DESCRIPTION
For example:

``` javascript
moment().calendar()
// => Today at [...]

fakeToday = moment().subtract( 'days', 1 )
moment().calendar( fakeToday )
// "Today" from the perspective of yesterday (`fakeToday`) is "tomorrow".
// => Tomorrow at [...]
```

I'm not sure how useful this would be outside of a testing environment, but with it you can test the `calendar` method by feed it a stubbed out "now".
