### PR TITLE
Add moment.relative

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1260,8 +1260,12 @@
     }
 
     function currentDateArray(config) {
-        var now = new Date();
-        if (config._useUTC) {
+        var now = new Date(),
+            relative = config._relative;
+        if (relative) {
+          relative = relative.toDate();
+          return [relative.getFullYear(), relative.getMonth(), relative.getDate()];
+        } else if (config._useUTC) {
             return [
                 now.getUTCFullYear(),
                 now.getUTCMonth(),
@@ -1629,6 +1633,28 @@
         c._pf = defaultParsingFlags();
 
         return makeMoment(c).utc();
+    };
+
+    moment.relative = function(relative, input, format, lang, strict) {
+        var c;
+
+        if (typeof(lang) === "boolean") {
+            strict = lang;
+            lang = undefined;
+        }
+        // object construction must be done this way.
+        // https://github.com/moment/moment/issues/1423
+        c = {};
+        c._isAMomentObject = true;
+        c._i = input;
+        c._f = format;
+        c._l = lang;
+        c._strict = strict;
+        c._isUTC = false;
+        c._pf = defaultParsingFlags();
+        c._relative = relative;
+
+        return makeMoment(c);
     };
 
     // creating with unix timestamp (in seconds)


### PR DESCRIPTION
No tests for this yet, but just wanna open this up to see if there's interest in merging. If there is, I'll add some tests/docs/cleanup.

We need the ability to parse a date relative to another date. For example, given the input "3:33 PM", I want to be able to parse this value relative to two days from now, instead of the current date/time. This allows you to do the following:

``` javascript
moment.relative(moment("2014-03-29"), "3:33 PM", "h:mm A")
```
