### PR TITLE
Update /lang/sq.js fixed some missing `ë` chars

### DIFF
--- a/lang/sq.js
+++ b/lang/sq.js
@@ -15,7 +15,7 @@
     return moment.lang('sq', {
         months : "Janar_Shkurt_Mars_Prill_Maj_Qershor_Korrik_Gusht_Shtator_Tetor_Nëntor_Dhjetor".split("_"),
         monthsShort : "Jan_Shk_Mar_Pri_Maj_Qer_Kor_Gus_Sht_Tet_Nën_Dhj".split("_"),
-        weekdays : "E Diel_E Hënë_E Marte_E Mërkure_E Enjte_E Premte_E Shtunë".split("_"),
+        weekdays : "E Diel_E Hënë_E Martë_E Mërkurë_E Enjte_E Premte_E Shtunë".split("_"),
         weekdaysShort : "Die_Hën_Mar_Mër_Enj_Pre_Sht".split("_"),
         weekdaysMin : "D_H_Ma_Më_E_P_Sh".split("_"),
         meridiem : function (hours, minutes, isLower) {
@@ -30,7 +30,7 @@
         },
         calendar : {
             sameDay : '[Sot në] LT',
-            nextDay : '[Neser në] LT',
+            nextDay : '[Nesër në] LT',
             nextWeek : 'dddd [në] LT',
             lastDay : '[Dje në] LT',
             lastWeek : 'dddd [e kaluar në] LT',
@@ -38,9 +38,9 @@
         },
         relativeTime : {
             future : "në %s",
-            past : "%s me parë",
+            past : "%s më parë",
             s : "disa sekonda",
-            m : "një minut",
+            m : "një minutë",
             mm : "%d minuta",
             h : "një orë",
             hh : "%d orë",


### PR DESCRIPTION
Hi,
I edited the albanian language file as some `e`-s need to be written with the diaeresis diacritic (i.e. as `ë`). Thought you might want to merge this into master.
