### PR TITLE
[FIX] Change some 'e' to 'ë' in Albanian.

### DIFF
--- a/lang/sq.js
+++ b/lang/sq.js
@@ -2,6 +2,7 @@
 // language : Albanian (sq)
 // author : Flakërim Ismani : https://github.com/flakerimi
 // author: Menelion Elensúle: https://github.com/Oire (tests)
+// author : Oerd Cukalla : https://github.com/oerd (fixes)
 
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
@@ -15,7 +16,7 @@
     return moment.lang('sq', {
         months : "Janar_Shkurt_Mars_Prill_Maj_Qershor_Korrik_Gusht_Shtator_Tetor_Nëntor_Dhjetor".split("_"),
         monthsShort : "Jan_Shk_Mar_Pri_Maj_Qer_Kor_Gus_Sht_Tet_Nën_Dhj".split("_"),
-        weekdays : "E Diel_E Hënë_E Marte_E Mërkure_E Enjte_E Premte_E Shtunë".split("_"),
+        weekdays : "E Diel_E Hënë_E Martë_E Mërkurë_E Enjte_E Premte_E Shtunë".split("_"),
         weekdaysShort : "Die_Hën_Mar_Mër_Enj_Pre_Sht".split("_"),
         weekdaysMin : "D_H_Ma_Më_E_P_Sh".split("_"),
         meridiem : function (hours, minutes, isLower) {
@@ -30,7 +31,7 @@
         },
         calendar : {
             sameDay : '[Sot në] LT',
-            nextDay : '[Neser në] LT',
+            nextDay : '[Nesër në] LT',
             nextWeek : 'dddd [në] LT',
             lastDay : '[Dje në] LT',
             lastWeek : 'dddd [e kaluar në] LT',
@@ -38,9 +39,9 @@
         },
         relativeTime : {
             future : "në %s",
-            past : "%s me parë",
+            past : "%s më parë",
             s : "disa sekonda",
-            m : "një minut",
+            m : "një minutë",
             mm : "%d minuta",
             h : "një orë",
             hh : "%d orë",

--- a/test/lang/sq.js
+++ b/test/lang/sq.js
@@ -143,7 +143,7 @@ exports["lang:sq"] = {
         test.expect(7);
 
         var i,
-            expected = 'E Diel Die D_E Hënë Hën H_E Marte Mar Ma_E Mërkure Mër Më_E Enjte Enj E_E Premte Pre P_E Shtunë Sht Sh'.split("_");
+            expected = 'E Diel Die D_E Hënë Hën H_E Martë Mar Ma_E Mërkurë Mër Më_E Enjte Enj E_E Premte Pre P_E Shtunë Sht Sh'.split("_");
 
         for (i = 0; i < expected.length; i++) {
             test.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
@@ -158,8 +158,8 @@ exports["lang:sq"] = {
         var start = moment([2007, 1, 28]);
 
         test.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true),  "disa sekonda", "44 seconds = a few seconds");
-        test.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  "një minut",      "45 seconds = a minute");
-        test.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  "një minut",      "89 seconds = a minute");
+        test.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  "një minutë",      "45 seconds = a minute");
+        test.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  "një minutë",      "89 seconds = a minute");
         test.equal(start.from(moment([2007, 1, 28]).add({s: 90}), true),  "2 minuta",     "90 seconds = 2 minutes");
         test.equal(start.from(moment([2007, 1, 28]).add({m: 44}), true),  "44 minuta",    "44 minutes = 44 minutes");
         test.equal(start.from(moment([2007, 1, 28]).add({m: 45}), true),  "një orë",       "45 minutes = an hour");
@@ -195,7 +195,7 @@ exports["lang:sq"] = {
         test.expect(2);
 
         test.equal(moment(30000).from(0), "në disa sekonda",  "prefix");
-        test.equal(moment(0).from(30000), "disa sekonda me parë", "suffix");
+        test.equal(moment(0).from(30000), "disa sekonda më parë", "suffix");
 
         test.done();
     },
@@ -203,7 +203,7 @@ exports["lang:sq"] = {
     "now from now" : function (test) {
         test.expect(1);
 
-        test.equal(moment().fromNow(), "disa sekonda me parë",  "now from now should display as in the past");
+        test.equal(moment().fromNow(), "disa sekonda më parë",  "now from now should display as in the past");
 
         test.done();
     },
@@ -225,7 +225,7 @@ exports["lang:sq"] = {
         test.equal(moment(a).calendar(),                     "Sot në 02:00",     "today at the same time");
         test.equal(moment(a).add({ m: 25 }).calendar(),      "Sot në 02:25",     "Now plus 25 min");
         test.equal(moment(a).add({ h: 1 }).calendar(),       "Sot në 03:00",     "Now plus 1 hour");
-        test.equal(moment(a).add({ d: 1 }).calendar(),       "Neser në 02:00",  "tomorrow at the same time");
+        test.equal(moment(a).add({ d: 1 }).calendar(),       "Nesër në 02:00",  "tomorrow at the same time");
         test.equal(moment(a).subtract({ h: 1 }).calendar(),  "Sot në 01:00",     "Now minus 1 hour");
         test.equal(moment(a).subtract({ d: 1 }).calendar(),  "Dje në 02:00", "yesterday at the same time");
 


### PR DESCRIPTION
Fixed some typos in `/lang/sq.js` and `/test/lang/sq.js`. Also,
trailing `ë` is often silent in Albanian, so it's easy to miss.

(This is a fix of the previously closed #1572 as I had forgotten 
changing the tests)
