### PR TITLE
Fix iso parsing with more than 3 subsecond digits

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -91,7 +91,7 @@
 
         // iso time formats and regexes
         isoTimes = [
-            ['HH:mm:ss.SSSS', /(T| )\d\d:\d\d:\d\d\.\d{1,3}/],
+            ['HH:mm:ss.SSSS', /(T| )\d\d:\d\d:\d\d\.\d+/],
             ['HH:mm:ss', /(T| )\d\d:\d\d:\d\d/],
             ['HH:mm', /(T| )\d\d:\d\d/],
             ['HH', /(T| )\d\d/]

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -600,6 +600,12 @@ exports.create = {
         test.done();
     },
 
+    "parsing iso with more subsecond precision digits" : function (test) {
+        test.equal(moment.utc("2013-07-31T22:00:00.0000000Z").format(),
+                "2013-07-31T22:00:00+00:00", "more than 3 subsecond digits");
+        test.done();
+    },
+
     "null or empty" : function (test) {
         test.expect(8);
         test.equal(moment('').isValid(), false, "moment('') is not valid");


### PR DESCRIPTION
This is the patch for #1576
