### PR TITLE
Do not export a global in node.js

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2445,7 +2445,6 @@
     // CommonJS module is defined
     if (hasModule) {
         module.exports = moment;
-        makeGlobal(true);
     } else if (typeof define === "function" && define.amd) {
         define("moment", function (require, exports, module) {
             if (module.config && module.config() && module.config().noGlobal !== true) {


### PR DESCRIPTION
We didn't have that for a few months, nobody complained. In Node.JS environment all software is module-aware, so I really don't see the need for a global. It can be exported at will if that is desired.
