### PR TITLE
Set AMD global before module definition

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -14,6 +14,7 @@
         VERSION = "2.5.1",
         // the global-scope this is NOT the global object in Node.js
         globalScope = typeof global !== 'undefined' ? global : this,
+        oldGlobalMoment,
         round = Math.round,
         i,
 
@@ -2431,6 +2432,7 @@
         if (typeof ender !== 'undefined') {
             return;
         }
+        oldGlobalMoment = globalScope.moment;
         if (shouldDeprecate) {
             globalScope.moment = deprecate(
                     "Accessing Moment through the global scope is " +
@@ -2448,13 +2450,14 @@
         makeGlobal(true);
     } else if (typeof define === "function" && define.amd) {
         define("moment", function (require, exports, module) {
-            if (module.config && module.config() && module.config().noGlobal !== true) {
-                // If user provided noGlobal, he is aware of global
-                makeGlobal(module.config().noGlobal === undefined);
+            if (module.config && module.config() && module.config().noGlobal === true) {
+                // release the global variable
+                globalScope.moment = oldGlobalMoment;
             }
 
             return moment;
         });
+        makeGlobal(true);
     } else {
         makeGlobal();
     }


### PR DESCRIPTION
Make sure non AMD compatible modules work well with moment in require.js. This is based on https://github.com/moment/moment/issues/1574
