### PR TITLE
Added roundTo method

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1975,7 +1975,8 @@
         month : makeAccessor('Month', true),
         
         roundTo: function (units, offset, midpoint) {
-            units = normalizeUnits(units), offset = offset || 1;
+            units = normalizeUnits(units);
+            offset = offset || 1;
             var roundUnit = function(unit) {
                 switch (midpoint) {
                     case 'up':


### PR DESCRIPTION
Round up, down or to the nearest unit.

Usage: moment.roundTo(units, [offset, midpoint])

m.roundTo('minute', 15); // Round the moment to the nearest 15 minutes.
m.roundTo('minute', 15, 'up'); // Round the moment up to the nearest 15 minutes.
m.roundTo('minute', 15, 'down'); // Round the moment down to the nearest 15 minutes.
