### PR TITLE
Add the ability to set the formatting language as part of the format method.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -152,11 +152,11 @@
             M    : function () {
                 return this.month() + 1;
             },
-            MMM  : function (format) {
-                return this.lang().monthsShort(this, format);
+            MMM  : function (format, lang) {
+                return lang.monthsShort(this, format);
             },
-            MMMM : function (format) {
-                return this.lang().months(this, format);
+            MMMM : function (format, lang) {
+                return lang.months(this, format);
             },
             D    : function () {
                 return this.date();
@@ -167,14 +167,14 @@
             d    : function () {
                 return this.day();
             },
-            dd   : function (format) {
-                return this.lang().weekdaysMin(this, format);
+            dd   : function (format, lang) {
+                return lang.weekdaysMin(this, format);
             },
-            ddd  : function (format) {
-                return this.lang().weekdaysShort(this, format);
+            ddd  : function (format, lang) {
+                return lang.weekdaysShort(this, format);
             },
-            dddd : function (format) {
-                return this.lang().weekdays(this, format);
+            dddd : function (format, lang) {
+                return lang.weekdays(this, format);
             },
             w    : function () {
                 return this.week();
@@ -219,11 +219,11 @@
             E : function () {
                 return this.isoWeekday();
             },
-            a    : function () {
-                return this.lang().meridiem(this.hours(), this.minutes(), true);
+            a    : function (format, lang) {
+                return lang.meridiem(this.hours(), this.minutes(), true);
             },
-            A    : function () {
-                return this.lang().meridiem(this.hours(), this.minutes(), false);
+            A    : function (format, lang) {
+                return lang.meridiem(this.hours(), this.minutes(), false);
             },
             H    : function () {
                 return this.hours();
@@ -318,13 +318,13 @@
     }
 
     function padToken(func, count) {
-        return function (a) {
-            return leftZeroFill(func.call(this, a), count);
+        return function (format, lang) {
+            return leftZeroFill(func.call(this, format, lang), count);
         };
     }
     function ordinalizeToken(func, period) {
-        return function (a) {
-            return this.lang().ordinal(func.call(this, a), period);
+        return function (format, lang) {
+            return lang.ordinal(func.call(this, format, lang), period);
         };
     }
 
@@ -915,29 +915,35 @@
             }
         }
 
-        return function (mom) {
+        return function (mom, lang) {
             var output = "";
             for (i = 0; i < length; i++) {
-                output += array[i] instanceof Function ? array[i].call(mom, format) : array[i];
+                output += array[i] instanceof Function ? array[i].call(mom, format, lang) : array[i];
             }
             return output;
         };
     }
 
     // format date using native date object
-    function formatMoment(m, format) {
+    function formatMoment(m, format, options) {
+        var lang;
+        if(options && options.lang) {
+            lang = getLangDefinition(options.lang);
+        } else {
+            lang = m.lang();
+        }
 
         if (!m.isValid()) {
-            return m.lang().invalidDate();
+            return lang.invalidDate();
         }
 
-        format = expandFormat(format, m.lang());
+        format = expandFormat(format, lang);
 
         if (!formatFunctions[format]) {
-            formatFunctions[format] = makeFormatFunction(format);
+            formatFunctions[format] = makeFormatFunction(format, lang);
         }
 
-        return formatFunctions[format](m);
+        return formatFunctions[format](m, lang);
     }
 
     function expandFormat(format, lang) {
@@ -1892,9 +1898,16 @@
             return this;
         },
 
-        format : function (inputString) {
-            var output = formatMoment(this, inputString || moment.defaultFormat);
-            return this.lang().postformat(output);
+        format : function (inputString, options) {
+            var lang;
+            if(options && options.lang) {
+                lang = getLangDefinition(options.lang);
+            } else {
+                lang = this.lang();
+            }
+
+            var output = formatMoment(this, inputString || moment.defaultFormat, options);
+            return lang.postformat(output);
         },
 
         add : function (input, val) {

--- a/moment.js
+++ b/moment.js
@@ -940,7 +940,7 @@
         format = expandFormat(format, lang);
 
         if (!formatFunctions[format]) {
-            formatFunctions[format] = makeFormatFunction(format, lang);
+            formatFunctions[format] = makeFormatFunction(format);
         }
 
         return formatFunctions[format](m, lang);

--- a/test/moment/format_lang_override.js
+++ b/test/moment/format_lang_override.js
@@ -1,0 +1,91 @@
+var moment = require("../../moment");
+
+exports.format_lang_override = {
+    setUp : function (cb) {
+        moment.lang('en');
+        moment.createFromInputFallback = function () {
+            throw new Error("input not handled by moment");
+        };
+        cb();
+    },
+
+    tearDown : function (cb) {
+        moment.lang('en');
+        cb();
+    },
+
+    "format" : function (test) {
+        test.expect(22);
+
+        var a = [
+                ['dddd, MMMM Do YYYY, a h:mm:ss',      '星期日, 二月 14日 2010, 下午 3:25:50'],
+                ['ddd, Ah',                            '周日, 下午3'],
+                ['M Mo MM MMMM MMM',                   '2 2月 02 二月 2月'],
+                ['YYYY YY',                            '2010 10'],
+                ['D Do DD',                            '14 14日 14'],
+                ['d do dddd ddd dd',                   '0 0日 星期日 周日 日'],
+                ['DDD DDDo DDDD',                      '45 45日 045'],
+                ['w wo ww',                            '6 6周 06'],
+                ['h hh',                               '3 03'],
+                ['H HH',                               '15 15'],
+                ['m mm',                               '25 25'],
+                ['s ss',                               '50 50'],
+                ['a A',                                '下午 下午'],
+                ['[这年的第] DDDo',                     '这年的第 45日'],
+                ['L',                                  '2010-02-14'],
+                ['LL',                                 '2010年2月14日'],
+                ['LLL',                                '2010年2月14日下午3点25'],
+                ['LLLL',                               '2010年2月14日星期日下午3点25'],
+                ['l',                                  '2010-02-14'],
+                ['ll',                                 '2010年2月14日'],
+                ['lll',                                '2010年2月14日下午3点25'],
+                ['llll',                               '2010年2月14日星期日下午3点25']
+            ],
+            b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
+            i;
+
+        for (i = 0; i < a.length; i++) {
+            test.equal(b.format(a[i][0], { lang: 'zh-cn' }), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
+        }
+
+        test.done();
+    },
+
+    "format month" : function (test) {
+        test.expect(12);
+
+        var expected = '一月 1月_二月 2月_三月 3月_四月 4月_五月 5月_六月 6月_七月 7月_八月 8月_九月 9月_十月 10月_十一月 11月_十二月 12月'.split("_"), i;
+
+        for (i = 0; i < expected.length; i++) {
+            test.equal(moment([2011, i, 1]).format('MMMM MMM', { lang: 'zh-cn' }), expected[i], expected[i]);
+        }
+
+        test.done();
+    },
+
+    "format week" : function (test) {
+        test.expect(7);
+
+        var expected = '星期日 周日 日_星期一 周一 一_星期二 周二 二_星期三 周三 三_星期四 周四 四_星期五 周五 五_星期六 周六 六'.split("_"), i;
+
+        for (i = 0; i < expected.length; i++) {
+            test.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd', { lang: 'zh-cn' }), expected[i], expected[i]);
+        }
+
+        test.done();
+    },
+
+    "meridiem" : function (test) {
+        test.expect(6);
+
+        test.equal(moment([2011, 2, 23,  0, 0]).format('A', { lang: 'zh-cn' }), "凌晨", "before dawn");
+        test.equal(moment([2011, 2, 23,  6, 0]).format('A', { lang: 'zh-cn' }), "早上", "morning");
+        test.equal(moment([2011, 2, 23,  9, 0]).format('A', { lang: 'zh-cn' }), "上午", "before noon");
+        test.equal(moment([2011, 2, 23, 12, 0]).format('A', { lang: 'zh-cn' }), "中午", "noon");
+        test.equal(moment([2011, 2, 23, 13, 0]).format('A', { lang: 'zh-cn' }), "下午", "afternoon");
+        test.equal(moment([2011, 2, 23, 18, 0]).format('A', { lang: 'zh-cn' }), "晚上", "night");
+
+        test.done();
+    }
+
+};

--- a/test/moment/format_lang_override.js
+++ b/test/moment/format_lang_override.js
@@ -1,6 +1,6 @@
 var moment = require("../../moment");
 
-exports.format_lang_override = {
+exports.formatLangOverride = {
     setUp : function (cb) {
         moment.lang('en');
         moment.createFromInputFallback = function () {


### PR DESCRIPTION
This pull-request adds the ability to configure the language as part of the format method, instead of changing it globally.

```
moment().format('LLL', { lang: 'pt' });
```

The change is primarily for node.js server side uses. When rendering a date for a client, it's not desirable to modify the global language, but only for that call.

On the server-side, this change could be used alongside the [locale](https://github.com/jed/locale) module to negotiate the correct language for displaying dates.

```
var supported = new locale.Locales(["en", "en_US", "ja", ... ]);
app.get('/', function(req, res, next) {
  var locales = new locale.Locales(req.headers["accept-language"]);
  res.render('template', { 
    localDate: moment().format('LLL', { lang: locales.best(supported) })
  });
});