### PR TITLE
Fixed greek "previous Saturday" string - was gender female, now is gender neutral

### DIFF
--- a/min/langs.js
+++ b/min/langs.js
@@ -983,23 +983,12 @@
             nextDay : '[Αύριο {}] LT',
             nextWeek : 'dddd [{}] LT',
             lastDay : '[Χθες {}] LT',
-            lastWeek : function() {
-                switch (this.day()) {
-                    case 6:
-                        return '[το προηγούμενο] dddd [{}] LT';
-                    default:
-                        return '[την προηγούμενη] dddd [{}] LT';
-                }
-            },
+            lastWeek : '[την προηγούμενη] dddd [{}] LT',
             sameElse : 'L'
         },
         calendar : function (key, mom) {
             var output = this._calendarEl[key],
                 hours = mom && mom.hours();
-
-            if (typeof output === 'function') {
-                output = output.apply(mom);
-            }
 
             return output.replace("{}", (hours % 12 === 1 ? "στη" : "στις"));
         },

--- a/min/moment-with-langs.js
+++ b/min/moment-with-langs.js
@@ -3349,23 +3349,12 @@
             nextDay : '[Αύριο {}] LT',
             nextWeek : 'dddd [{}] LT',
             lastDay : '[Χθες {}] LT',
-            lastWeek : function() {
-                switch (this.day()) {
-                    case 6:
-                        return '[το προηγούμενο] dddd [{}] LT';
-                    default:
-                        return '[την προηγούμενη] dddd [{}] LT';
-                }
-            },
+            lastWeek : '[την προηγούμενη] dddd [{}] LT',
             sameElse : 'L'
         },
         calendar : function (key, mom) {
             var output = this._calendarEl[key],
                 hours = mom && mom.hours();
-
-            if (typeof output === 'function') {
-                output = output.apply(mom);
-            }
 
             return output.replace("{}", (hours % 12 === 1 ? "στη" : "στις"));
         },


### PR DESCRIPTION
"Την προηγούμενη Σάββατο" that appeared, was wrong. Now shows "Το προηγούμενο Σάββατο".

Contains tests.
