### PR TITLE
Allow ISO-8601 to be passed as a format.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1345,7 +1345,7 @@
     function makeDateFromStringAndFormat(config) {
 
         if (config._f === moment.ISO_8601) {
-            makeDateFromString(config, false);
+            parseISO(config);
             return;
         }
 
@@ -1461,12 +1461,10 @@
     }
 
     // date from iso format
-    function makeDateFromString(config, useFallback) {
+    function parseISO(config) {
         var i, l,
             string = config._i,
             match = isoRegex.exec(string);
-
-        useFallback = typeof useFallback === 'undefined' ? true : useFallback;
 
         if (match) {
             config._pf.iso = true;
@@ -1487,13 +1485,17 @@
                 config._f += "Z";
             }
             makeDateFromStringAndFormat(config);
+        } else {
+            config._isValid = false;
         }
-        else {
-            if (useFallback) {
-                moment.createFromInputFallback(config);
-            } else {
-                config._isValid = false;
-            }
+    }
+
+    // date from iso format or fallback
+    function makeDateFromString(config) {
+        parseISO(config);
+        if (config._isValid === false) {
+            delete config._isValid;
+            moment.createFromInputFallback(config);
         }
     }
 
@@ -1834,7 +1836,7 @@
     moment.defaultFormat = isoFormat;
 
     // constant that refers to the ISO standard
-    moment.ISO_8601 = 'ISO 8601';
+    moment.ISO_8601 = function () {};
 
     // Plugins that add properties should also add the key here (null value),
     // so we can properly clone ourselves.

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -395,18 +395,17 @@ exports.create = {
 
         test.equal(moment('01', ["MM", "DD"])._f, "MM", "Should use first valid format");
 
-        // pass an ISO date in the array of formats
-        function parseISO(string) {
-            return moment(string, [moment.ISO_8601, 'MM', 'HH:mm', 'YYYY']);
-        }
-        test.equal(parseISO('1994')._f, 'YYYY', 'iso: test parse YYYY');
-        test.equal(parseISO('17:15')._f, 'HH:mm', 'iso: test parse HH:mm');
-        test.equal(parseISO('06')._f, 'MM', 'iso: test parse MM');
-        test.equal(parseISO('2012-06-01')._pf.iso, true, 'iso: test parse iso');
-        
-        test.equal(moment('2014-05-05', [moment.ISO_8601, 'YYYY-MM-DD'])._pf.iso, true, 'iso: edge case array precedence iso');
-        test.equal(moment('2014-05-05', ['YYYY-MM-DD', moment.ISO_8601])._pf.iso, false, 'iso: edge case array precedence not iso');
+        test.done();
+    },
 
+    "string with array of formats + ISO": function (test) {
+        test.equal(moment('1994', [moment.ISO_8601, 'MM', 'HH:mm', 'YYYY']).year(), 1994, 'iso: test parse YYYY');
+        test.equal(moment('17:15', [moment.ISO_8601, 'MM', 'HH:mm', 'YYYY']).hour(), 17, 'iso: test parse HH:mm (1)');
+        test.equal(moment('17:15', [moment.ISO_8601, 'MM', 'HH:mm', 'YYYY']).minutes(), 15, 'iso: test parse HH:mm (2)');
+        test.equal(moment('06', [moment.ISO_8601, 'MM', 'HH:mm', 'YYYY']).month(), 6-1, 'iso: test parse MM');
+        test.equal(moment('2012-06-01', [moment.ISO_8601, 'MM', 'HH:mm', 'YYYY']).parsingFlags().iso, true, 'iso: test parse iso');
+        test.equal(moment('2014-05-05', [moment.ISO_8601, 'YYYY-MM-DD']).parsingFlags().iso, true, 'iso: edge case array precedence iso');
+        test.equal(moment('2014-05-05', ['YYYY-MM-DD', moment.ISO_8601]).parsingFlags().iso, false, 'iso: edge case array precedence not iso');
         test.done();
     },
 


### PR DESCRIPTION
This commit allows the ISO-8601 format to be passed as a format in the moment(string, array) constructor. This is an attempt to make #1680 possible.This is a preliminary commit as this addition as yielded a few issues. This is not ready for merge.

Here are some of the issues:
- `makeDateFromString` does not play nice with scoring (might be due to the way I implemented it)
- scoring cannot currently be tested because `makeDateFromString` shoves what it doesn't know into into `createFromInputFallback` which has been modified to throw always throw an error in the test suite.

I will probably try to add an optional parameter to `makeDateFromString` which tells it to not use `createFromInputFallback` to fix the second issue.
