### PR TITLE
perf(makeDateFromInput): no need to match regex if input is a Date

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1487,18 +1487,12 @@
     }
 
     function makeDateFromInput(config) {
-        var input = config._i;
+        var input = config._i, matched;
         if (input === undefined) {
             config._d = new Date();
-            return;
         } else if (isDate(input)) {
             config._d = new Date(+input);
-            return;
-        }
-
-        var matched = aspNetJsonRegex.exec(input);
-
-        if (matched) {
+        } else if ( (matched = aspNetJsonRegex.exec(input)) !== null ) {
             config._d = new Date(+matched[1]);
         } else if (typeof input === 'string') {
             makeDateFromString(config);


### PR DESCRIPTION
The moment constructor when passed a Date should be the fastest. There is
no need to match the aspNetJsonRegex before testing if the `input` is a
Date.
