### PR TITLE
Fix issue #1715 to retrieve relativeTimeThreshold settings

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1851,6 +1851,11 @@
       if (relativeTimeThresholds[threshold] === undefined) {
         return false;
       }
+
+      if(limit  === undefined){
+        return relativeTimeThresholds[threshold];
+      }
+
       relativeTimeThresholds[threshold] = limit;
       return true;
     };

--- a/test/moment/relative_time.js
+++ b/test/moment/relative_time.js
@@ -112,5 +112,15 @@ exports.relativeTime = {
         test.equal(a.fromNow(), "a year ago", "Above custom days to years threshold");
         moment.relativeTimeThreshold('dy', 345);
         test.done();
+    },
+
+    "retrive threshold settings" : function (test) {
+        test.expect(1);
+        moment.relativeTimeThreshold('m', 45);
+        var minuteThreshold = moment.relativeTimeThreshold('m');
+
+        test.equal(minuteThreshold, 45, "Can retrieve minute setting");
+
+        test.done();
     }
 };


### PR DESCRIPTION
adding the retrieve option for relativeTimeThresholds settings

relates to: https://github.com/moment/moment/issues/1715
