### PR TITLE
Change duration.toIsoString to duration.toISOString

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2608,7 +2608,15 @@
 
         lang : moment.fn.lang,
 
-        toIsoString : function () {
+        toIsoString : deprecate(
+            "toIsoString() is deprecated. Please use toISOString() instead " +
+            "(notice the capitals)",
+            function () {
+                return this.toISOString();
+            }
+        ),
+
+        toISOString : function () {
             // inspired by https://github.com/dordille/moment-isoduration/blob/master/moment.isoduration.js
             var years = Math.abs(this.years()),
                 months = Math.abs(this.months()),

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -284,12 +284,17 @@ exports.duration = {
 
     "serialization to ISO 8601 duration strings" : function (test) {
         test.expect(6);
-        test.equal(moment.duration({y: 1, M: 2, d: 3, h: 4, m: 5, s: 6}).toIsoString(), "P1Y2M3DT4H5M6S", "all fields");
-        test.equal(moment.duration({M: -1}).toIsoString(), "-P1M", "one month ago");
-        test.equal(moment.duration({m: -1}).toIsoString(), "-PT1M", "one minute ago");
-        test.equal(moment.duration({s: -0.5}).toIsoString(), "-PT0.5S", "one half second ago");
-        test.equal(moment.duration({y: -0.5, M: 1}).toIsoString(), "-P5M", "a month after half a year ago");
-        test.equal(moment.duration({}).toIsoString(), "P0D", "zero duration");
+        test.equal(moment.duration({y: 1, M: 2, d: 3, h: 4, m: 5, s: 6}).toISOString(), "P1Y2M3DT4H5M6S", "all fields");
+        test.equal(moment.duration({M: -1}).toISOString(), "-P1M", "one month ago");
+        test.equal(moment.duration({m: -1}).toISOString(), "-PT1M", "one minute ago");
+        test.equal(moment.duration({s: -0.5}).toISOString(), "-PT0.5S", "one half second ago");
+        test.equal(moment.duration({y: -0.5, M: 1}).toISOString(), "-P5M", "a month after half a year ago");
+        test.equal(moment.duration({}).toISOString(), "P0D", "zero duration");
+        test.done();
+    },
+
+    "toIsoString deprecation" : function (test) {
+        test.equal(moment.duration({}).toIsoString(), moment.duration({}).toISOString(), "toIsoString delegates to toISOString");
         test.done();
     },
 


### PR DESCRIPTION
Fix for #1752. Added a deprecation warning to the old toIsoString
