### PR TITLE
Adds comma between day-of-month and year for en-US locale.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -795,9 +795,9 @@
         _longDateFormat : {
             LT : 'h:mm A',
             L : 'MM/DD/YYYY',
-            LL : 'MMMM D YYYY',
-            LLL : 'MMMM D YYYY LT',
-            LLLL : 'dddd, MMMM D YYYY LT'
+            LL : 'MMMM D, YYYY',
+            LLL : 'MMMM D, YYYY LT',
+            LLLL : 'dddd, MMMM D, YYYY LT'
         },
         longDateFormat : function (key) {
             var output = this._longDateFormat[key];

--- a/test/lang/en.js
+++ b/test/lang/en.js
@@ -59,13 +59,13 @@ exports["lang:en"] = {
                 ['a A',                                'pm PM'],
                 ['[the] DDDo [day of the year]',       'the 45th day of the year'],
                 ['L',                                  '02/14/2010'],
-                ['LL',                                 'February 14 2010'],
-                ['LLL',                                'February 14 2010 3:25 PM'],
-                ['LLLL',                               'Sunday, February 14 2010 3:25 PM'],
+                ['LL',                                 'February 14, 2010'],
+                ['LLL',                                'February 14, 2010 3:25 PM'],
+                ['LLLL',                               'Sunday, February 14, 2010 3:25 PM'],
                 ['l',                                  '2/14/2010'],
-                ['ll',                                 'Feb 14 2010'],
-                ['lll',                                'Feb 14 2010 3:25 PM'],
-                ['llll',                               'Sun, Feb 14 2010 3:25 PM']
+                ['ll',                                 'Feb 14, 2010'],
+                ['lll',                                'Feb 14, 2010 3:25 PM'],
+                ['llll',                               'Sun, Feb 14, 2010 3:25 PM']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -254,12 +254,12 @@ exports.create = {
                 ['LT',                  '12:30 AM'],
                 ['L',                   '09/02/1999'],
                 ['l',                   '9/2/1999'],
-                ['LL',                  'September 2 1999'],
-                ['ll',                  'Sep 2 1999'],
-                ['LLL',                 'September 2 1999 12:30 AM'],
-                ['lll',                 'Sep 2 1999 12:30 AM'],
-                ['LLLL',                'Thursday, September 2 1999 12:30 AM'],
-                ['llll',                'Thu, Sep 2 1999 12:30 AM']
+                ['LL',                  'September 2, 1999'],
+                ['ll',                  'Sep 2, 1999'],
+                ['LLL',                 'September 2, 1999 12:30 AM'],
+                ['lll',                 'Sep 2, 1999 12:30 AM'],
+                ['LLLL',                'Thursday, September 2, 1999 12:30 AM'],
+                ['llll',                'Thu, Sep 2, 1999 12:30 AM']
             ],
             m,
             i;

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -30,7 +30,7 @@ exports.format = {
         test.equal(b.format('[Last]'), 'Last', 'localized tokens');
         test.equal(b.format('[L] L'), 'L 02/14/2009', 'localized tokens with escaped localized tokens');
         test.equal(b.format('[L LL LLL LLLL aLa]'), 'L LL LLL LLLL aLa', 'localized tokens with escaped localized tokens');
-        test.equal(b.format('[LLL] LLL'), 'LLL February 14 2009 3:25 PM', 'localized tokens with escaped localized tokens (recursion)');
+        test.equal(b.format('[LLL] LLL'), 'LLL February 14, 2009 3:25 PM', 'localized tokens with escaped localized tokens (recursion)');
         test.equal(b.format('YYYY[\n]DD[\n]'), '2009\n14\n', 'Newlines');
         test.done();
     },


### PR DESCRIPTION
Specifically:
- LL   => 'MMMM D, YYYY'
- LLL  => 'MMMM D, YYYY LT'
- LLLL => ''dddd, MMMM D, YYYY LT'

... and similarly for the lowercase variants.

The use of a comma between the day-of-month and year is standard
practice in US English. See:
- ICU docs [http://demo.icu-project.org/icu-bin/locexp?_=en_US](under Date & Time Patterns)
- Chicago Manual of Style (by way of the Library of Congress)
  [http://lcweb2.loc.gov/ammem/ndlpedit/handbook/numberdate.html]
- Wikipedia [http://en.wikipedia.org/wiki/Date_and_time_notation_in_the_United_States]
