### PR TITLE
Avoid crashing when passing a Number and a format to Moment constructor.

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1719,7 +1719,7 @@
             config = cloneMoment(input);
 
             config._d = new Date(+input._d);
-        } else if (format) {
+        } else if (format && typeof input === 'string') {
             if (isArray(format)) {
                 makeDateFromStringAndArray(config);
             } else {


### PR DESCRIPTION
Passing a Number value and a format to the Moment constructor causes Moment to throw a JS error (from within `makeDateFromStringAndFormat`). Seems like Moment isn't designed to handle this (preferring instead `moment.utc()` but it should probably not throw errors in this case when it can parse the Number and ignore the format.
