### PR TITLE
Changes "files" to "scripts"

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
   "version": "2.8.1",
   "main": "moment.js",
   "description": "Parse, validate, manipulate, and display dates in javascript.",
-  "files": [
+  "scripts": [
     "moment.js",
     "locale/af.js",
     "locale/ar-ma.js",
@@ -83,8 +83,5 @@
     "locale/vi.js",
     "locale/zh-cn.js",
     "locale/zh-tw.js"
-  ],
-  "scripts": [
-    "moment.js"
   ]
 }


### PR DESCRIPTION
Windows tries to create symlinks with component 0.19 when you use "files" entries, so the component is unusable on windows (it doesn't support symlinks) - reverting to "scripts".
