### PR TITLE
Make Norwegian Bokmål be more consistent. Fixes #1850

### DIFF
--- a/locale/nb.js
+++ b/locale/nb.js
@@ -14,9 +14,9 @@
 }(function (moment) {
     return moment.defineLocale('nb', {
         months : "januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember".split("_"),
-        monthsShort : "jan._feb._mars_april_mai_juni_juli_aug._sep._okt._nov._des.".split("_"),
+        monthsShort : "jan_feb_mar_apr_mai_jun_jul_aug_sep_okt_nov_des".split("_"),
         weekdays : "søndag_mandag_tirsdag_onsdag_torsdag_fredag_lørdag".split("_"),
-        weekdaysShort : "sø._ma._ti._on._to._fr._lø.".split("_"),
+        weekdaysShort : "søn_man_tirs_ons_tors_fre_lør".split("_"),
         weekdaysMin : "sø_ma_ti_on_to_fr_lø".split("_"),
         longDateFormat : {
             LT : "H.mm",


### PR DESCRIPTION
Makes Norwegian Bokmål and Norwegian Nynorsk look the same in formatting.
