### PR TITLE
Ensure deprecations in tests are intended

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -324,6 +324,7 @@
                 printMsg(msg);
                 firstTime = false;
             }
+            moment.deprecationHandler(null, msg);
             return fn.apply(this, arguments);
         }, fn);
     }
@@ -333,6 +334,7 @@
             printMsg(msg);
             deprecations[name] = true;
         }
+        moment.deprecationHandler(name, msg);
     }
 
     function padToken(func, count) {
@@ -1905,6 +1907,10 @@
     // Plugins that add properties should also add the key here (null value),
     // so we can properly clone ourselves.
     moment.momentProperties = momentProperties;
+
+    // Callback for all deprecated function calls.
+    // Useful for tests and debugging large codebases.
+    moment.deprecationHandler = function () {};
 
     // This function will be called whenever a moment is mutated.
     // It is intended to keep the offset in sync with the timezone.

--- a/test/locale/af.js
+++ b/test/locale/af.js
@@ -11,6 +11,9 @@ exports["locale:af"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ar-ma.js
+++ b/test/locale/ar-ma.js
@@ -8,6 +8,9 @@ exports["locale:ar-ma"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ar-sa.js
+++ b/test/locale/ar-sa.js
@@ -11,6 +11,9 @@ exports["locale:ar-sa"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ar.js
+++ b/test/locale/ar.js
@@ -8,6 +8,9 @@ exports["locale:ar"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/az.js
+++ b/test/locale/az.js
@@ -11,6 +11,9 @@ exports["locale:az"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/be.js
+++ b/test/locale/be.js
@@ -11,6 +11,9 @@ exports["locale:be"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/bg.js
+++ b/test/locale/bg.js
@@ -11,6 +11,9 @@ exports["locale:bg"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/bn.js
+++ b/test/locale/bn.js
@@ -11,6 +11,9 @@ exports["locale:bn"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/bo.js
+++ b/test/locale/bo.js
@@ -11,6 +11,9 @@ exports["locale:bo"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/br.js
+++ b/test/locale/br.js
@@ -11,6 +11,9 @@ exports["locale:br"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/bs.js
+++ b/test/locale/bs.js
@@ -11,6 +11,9 @@ exports["locale:bs"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ca.js
+++ b/test/locale/ca.js
@@ -11,6 +11,9 @@ exports["locale:ca"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/cs.js
+++ b/test/locale/cs.js
@@ -11,6 +11,9 @@ exports["locale:cs"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/cv.js
+++ b/test/locale/cv.js
@@ -11,6 +11,9 @@ exports["locale:cv"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/cy.js
+++ b/test/locale/cy.js
@@ -11,6 +11,9 @@ exports["locale:cy"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/da.js
+++ b/test/locale/da.js
@@ -11,6 +11,9 @@ exports["locale:da"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/de-at.js
+++ b/test/locale/de-at.js
@@ -11,6 +11,9 @@ exports["locale:de-at"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/de.js
+++ b/test/locale/de.js
@@ -11,6 +11,9 @@ exports["locale:de"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/el.js
+++ b/test/locale/el.js
@@ -11,6 +11,9 @@ exports["locale:el"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/en-au.js
+++ b/test/locale/en-au.js
@@ -11,6 +11,9 @@ exports["locale:en-au"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/en-ca.js
+++ b/test/locale/en-ca.js
@@ -10,6 +10,9 @@ exports["locale:en-ca"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/en-gb.js
+++ b/test/locale/en-gb.js
@@ -11,6 +11,9 @@ exports["locale:en-gb"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/en.js
+++ b/test/locale/en.js
@@ -11,6 +11,9 @@ exports["locale:en"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/eo.js
+++ b/test/locale/eo.js
@@ -11,6 +11,9 @@ exports["locale:eo"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/es.js
+++ b/test/locale/es.js
@@ -11,6 +11,9 @@ exports["locale:es"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/et.js
+++ b/test/locale/et.js
@@ -11,6 +11,9 @@ exports["locale:et"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/eu.js
+++ b/test/locale/eu.js
@@ -11,6 +11,9 @@ exports["locale:eu"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/fa.js
+++ b/test/locale/fa.js
@@ -8,6 +8,9 @@ exports["locale:fa"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/fi.js
+++ b/test/locale/fi.js
@@ -11,6 +11,9 @@ exports["locale:fi"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/fo.js
+++ b/test/locale/fo.js
@@ -11,6 +11,9 @@ exports["locale:fo"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/fr-ca.js
+++ b/test/locale/fr-ca.js
@@ -10,6 +10,9 @@ exports["locale:fr-ca"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/fr.js
+++ b/test/locale/fr.js
@@ -11,6 +11,9 @@ exports["locale:fr"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/gl.js
+++ b/test/locale/gl.js
@@ -11,6 +11,9 @@ exports["locale:gl"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/he.js
+++ b/test/locale/he.js
@@ -11,6 +11,9 @@ exports["locale:he"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/hi.js
+++ b/test/locale/hi.js
@@ -11,6 +11,9 @@ exports["locale:hi"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/hr.js
+++ b/test/locale/hr.js
@@ -11,6 +11,9 @@ exports["locale:hr"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/hu.js
+++ b/test/locale/hu.js
@@ -10,6 +10,9 @@ exports["locale:hu"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/hy-am.js
+++ b/test/locale/hy-am.js
@@ -11,6 +11,9 @@ exports["locale:hy-am"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/id.js
+++ b/test/locale/id.js
@@ -11,6 +11,9 @@ exports["locale:id"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/is.js
+++ b/test/locale/is.js
@@ -11,6 +11,9 @@ exports["locale:is"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/it.js
+++ b/test/locale/it.js
@@ -11,6 +11,9 @@ exports["locale:it"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ja.js
+++ b/test/locale/ja.js
@@ -11,6 +11,9 @@ exports["locale:ja"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ka.js
+++ b/test/locale/ka.js
@@ -10,6 +10,9 @@ exports["locale:ka"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/km.js
+++ b/test/locale/km.js
@@ -8,6 +8,12 @@ var moment = require("../../moment");
 exports["locale:km"] = {
     setUp: function (cb) {
         moment.locale('km');
+        moment.createFromInputFallback = function () {
+            throw new Error("input not handled by moment");
+        };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ko.js
+++ b/test/locale/ko.js
@@ -11,6 +11,9 @@ exports["locale:ko"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/lb.js
+++ b/test/locale/lb.js
@@ -10,6 +10,9 @@ exports["locale:lb"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/lt.js
+++ b/test/locale/lt.js
@@ -11,6 +11,9 @@ exports["locale:lt"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/lv.js
+++ b/test/locale/lv.js
@@ -11,6 +11,9 @@ exports["locale:lv"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/mk.js
+++ b/test/locale/mk.js
@@ -11,6 +11,9 @@ exports["locale:mk"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ml.js
+++ b/test/locale/ml.js
@@ -11,6 +11,9 @@ exports["locale:ml"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/mr.js
+++ b/test/locale/mr.js
@@ -11,6 +11,9 @@ exports["locale:mr"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ms-my.js
+++ b/test/locale/ms-my.js
@@ -11,6 +11,9 @@ exports["locale:ms-my"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/my.js
+++ b/test/locale/my.js
@@ -11,6 +11,9 @@ exports["locale:my"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/nb.js
+++ b/test/locale/nb.js
@@ -11,6 +11,9 @@ exports["locale:nb"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ne.js
+++ b/test/locale/ne.js
@@ -11,6 +11,9 @@ exports["locale:ne"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/nl.js
+++ b/test/locale/nl.js
@@ -11,6 +11,9 @@ exports["locale:nl"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/nn.js
+++ b/test/locale/nn.js
@@ -11,6 +11,9 @@ exports["locale:nn"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/pl.js
+++ b/test/locale/pl.js
@@ -11,6 +11,9 @@ exports["locale:pl"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/pt-br.js
+++ b/test/locale/pt-br.js
@@ -11,6 +11,9 @@ exports["locale:pt-br"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/pt.js
+++ b/test/locale/pt.js
@@ -11,6 +11,9 @@ exports["locale:pt"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ro.js
+++ b/test/locale/ro.js
@@ -11,6 +11,9 @@ exports["locale:ro"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ru.js
+++ b/test/locale/ru.js
@@ -11,6 +11,9 @@ exports["locale:ru"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/sk.js
+++ b/test/locale/sk.js
@@ -11,6 +11,9 @@ exports["locale:sk"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/sl.js
+++ b/test/locale/sl.js
@@ -11,6 +11,9 @@ exports["locale:sl"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/sq.js
+++ b/test/locale/sq.js
@@ -11,6 +11,9 @@ exports["locale:sq"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/sr-cyrl.js
+++ b/test/locale/sr-cyrl.js
@@ -11,6 +11,9 @@ exports["locale:sr-cyrl"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/sr.js
+++ b/test/locale/sr.js
@@ -11,6 +11,9 @@ exports["locale:sr"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/sv.js
+++ b/test/locale/sv.js
@@ -10,6 +10,9 @@ exports["locale:sv"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/ta.js
+++ b/test/locale/ta.js
@@ -11,6 +11,9 @@ exports["locale:ta"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/th.js
+++ b/test/locale/th.js
@@ -11,6 +11,9 @@ exports["locale:th"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/tl-ph.js
+++ b/test/locale/tl-ph.js
@@ -11,6 +11,9 @@ exports["locale:tl-ph"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/tr.js
+++ b/test/locale/tr.js
@@ -11,6 +11,9 @@ exports["locale:tr"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/tzm-latn.js
+++ b/test/locale/tzm-latn.js
@@ -9,6 +9,9 @@ exports["locale:tzm-latn"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/tzm.js
+++ b/test/locale/tzm.js
@@ -9,6 +9,9 @@ exports["locale:tzm"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/uk.js
+++ b/test/locale/uk.js
@@ -11,6 +11,9 @@ exports["locale:uk"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/uz.js
+++ b/test/locale/uz.js
@@ -11,6 +11,9 @@ exports["locale:uz"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/vi.js
+++ b/test/locale/vi.js
@@ -11,6 +11,9 @@ exports["locale:vi"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/zh-cn.js
+++ b/test/locale/zh-cn.js
@@ -11,6 +11,9 @@ exports["locale:zh-cn"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/locale/zh-tw.js
+++ b/test/locale/zh-tw.js
@@ -11,6 +11,9 @@ exports["locale:zh-tw"] = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         cb();
     },
 

--- a/test/moment/add_subtract.js
+++ b/test/moment/add_subtract.js
@@ -5,13 +5,18 @@ exports.add = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 
     "add short reverse args" : function (test) {
         test.expect(16);
 
-        var a = moment(), b, c, d;
+        var a = moment(), b, c, d,
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -41,13 +46,16 @@ exports.add = {
         test.equal(d.month(), 10, 'subtract quarter, feb 28th 2010 to nov 28th 2009');
         test.equal(d.date(), 28, 'subtract quarter, feb 28th 2010 to nov 28th 2009');
         test.equal(d.year(), 2009, 'subtract quarter, feb 28th 2010 to nov 28th 2009');
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
     "add long reverse args" : function (test) {
         test.expect(9);
 
-        var a = moment();
+        var a = moment(),
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -65,13 +73,16 @@ exports.add = {
         test.equal(a.add({months: 1}).month(), 10, 'Add month');
         test.equal(a.add({years: 1}).year(), 2012, 'Add year');
         test.equal(a.add({quarters: 1}).month(), 1, 'Add quarter');
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
     "add long singular reverse args" : function (test) {
         test.expect(9);
 
-        var a = moment();
+        var a = moment(),
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -89,13 +100,14 @@ exports.add = {
         test.equal(a.add({month: 1}).month(), 10, 'Add month');
         test.equal(a.add({year: 1}).year(), 2012, 'Add year');
         test.equal(a.add({quarter: 1}).month(), 1, 'Add quarter');
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
     "add string long reverse args" : function (test) {
-        test.expect(10);
-
-        var a = moment(), b;
+        var a = moment(), b,
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -116,13 +128,17 @@ exports.add = {
         test.equal(a.add('year', 1).year(), 2012, 'Add year');
         test.equal(b.add('day', '01').date(), 13, 'Add date');
         test.equal(a.add('quarter', 1).month(), 1, 'Add quarter');
+
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
     "add string long singular reverse args" : function (test) {
         test.expect(10);
 
-        var a = moment(), b;
+        var a = moment(), b,
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -143,13 +159,17 @@ exports.add = {
         test.equal(a.add('years', 1).year(), 2012, 'Add year');
         test.equal(b.add('days', '01').date(), 13, 'Add date');
         test.equal(a.add('quarters', 1).month(), 1, 'Add quarter');
+
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
     "add string short reverse args" : function (test) {
         test.expect(9);
 
-        var a = moment();
+        var a = moment(),
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -167,6 +187,7 @@ exports.add = {
         test.equal(a.add('M', 1).month(), 10, 'Add month');
         test.equal(a.add('y', 1).year(), 2012, 'Add year');
         test.equal(a.add('Q', 1).month(), 1, 'Add quarter');
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
@@ -245,7 +266,9 @@ exports.add = {
     "add strings string short args" : function (test) {
         test.expect(9);
 
-        var a = moment();
+        var a = moment(),
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -263,13 +286,16 @@ exports.add = {
         test.equal(a.add('M', '1').month(), 10, 'Add month');
         test.equal(a.add('y', '1').year(), 2012, 'Add year');
         test.equal(a.add('Q', '1').month(), 1, 'Add quarter');
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
     "subtract strings string short args" : function (test) {
         test.expect(9);
 
-        var a = moment();
+        var a = moment(),
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         a.year(2011);
         a.month(9);
         a.date(12);
@@ -287,6 +313,7 @@ exports.add = {
         test.equal(a.subtract('M', '1').month(), 8, 'Subtract month');
         test.equal(a.subtract('y', '1').year(), 2010, 'Subtract year');
         test.equal(a.subtract('Q', '1').month(), 5, 'Subtract quarter');
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 

--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -18,6 +18,9 @@ exports.create = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/days_in_month.js
+++ b/test/moment/days_in_month.js
@@ -5,6 +5,9 @@ exports.daysInMonth = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/diff.js
+++ b/test/moment/diff.js
@@ -37,6 +37,9 @@ exports.diff = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -5,6 +5,9 @@ exports.duration = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 
@@ -294,7 +297,10 @@ exports.duration = {
     },
 
     "toIsoString deprecation" : function (test) {
+        var originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         test.equal(moment.duration({}).toIsoString(), moment.duration({}).toISOString(), "toIsoString delegates to toISOString");
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 

--- a/test/moment/duration_from_moments.js
+++ b/test/moment/duration_from_moments.js
@@ -5,6 +5,9 @@ exports.durationFromMoments = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/format.js
+++ b/test/moment/format.js
@@ -5,6 +5,9 @@ exports.format = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/getters_setters.js
+++ b/test/moment/getters_setters.js
@@ -5,6 +5,9 @@ exports.gettersSetters = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 
@@ -47,16 +50,16 @@ exports.gettersSetters = {
         test.expect(8);
 
         var a = moment();
-        a.years(2011);
+        a.year(2011);
         a.months(9);
-        a.dates(12);
+        a.date(12);
         a.hours(6);
         a.minutes(7);
         a.seconds(8);
         a.milliseconds(9);
-        test.equal(a.years(), 2011, 'years');
+        test.equal(a.year(), 2011, 'year');
         test.equal(a.months(), 9, 'months');
-        test.equal(a.dates(), 12, 'dates');
+        test.equal(a.date(), 12, 'date');
         test.equal(a.days(), 3, 'days');
         test.equal(a.hours(), 6, 'hours');
         test.equal(a.minutes(), 7, 'minutes');

--- a/test/moment/invalid.js
+++ b/test/moment/invalid.js
@@ -5,6 +5,9 @@ exports.invalid = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/is_after.js
+++ b/test/moment/is_after.js
@@ -5,6 +5,9 @@ exports.isAfter = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/is_before.js
+++ b/test/moment/is_before.js
@@ -5,6 +5,9 @@ exports.isBefore = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/is_moment.js
+++ b/test/moment/is_moment.js
@@ -5,6 +5,9 @@ exports.isMoment = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/is_same.js
+++ b/test/moment/is_same.js
@@ -5,6 +5,9 @@ exports.isSame = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/is_valid.js
+++ b/test/moment/is_valid.js
@@ -5,6 +5,9 @@ exports.isValid = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/leapyear.js
+++ b/test/moment/leapyear.js
@@ -5,6 +5,9 @@ exports.leapyear = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/listers.js
+++ b/test/moment/listers.js
@@ -36,6 +36,9 @@ exports.listers = {
         test.equal(moment.weekdaysShort(2), "Tue");
         test.equal(moment.weekdaysMin(0), "Su");
         test.equal(moment.weekdaysMin(2), "Tu");
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         test.done();
     },
 

--- a/test/moment/locale.js
+++ b/test/moment/locale.js
@@ -6,6 +6,9 @@ exports.locale = {
             throw new Error("input not handled by moment");
         };
         moment.locale('en');
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 
@@ -120,10 +123,13 @@ exports.locale = {
     },
 
     "library deprecations" : function (test) {
+        var originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         moment.lang("dude", {months: ["Movember"]});
         test.equal(moment.locale(), "dude", "setting the lang sets the locale");
         test.equal(moment.lang(), moment.locale());
         test.equal(moment.langData(), moment.localeData(), "langData is localeData");
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
@@ -227,7 +233,10 @@ exports.locale = {
     },
 
     "duration deprecations" : function (test) {
+        var originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         test.equal(moment.duration().lang(), moment.duration().localeData(), "duration.lang is the same as duration.localeData");
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 
@@ -432,17 +441,31 @@ exports.locale = {
     "setting a language on instance returns the original moment for chaining" : function (test) {
         var mom = moment();
 
-        test.equal(mom.lang('fr'), mom, "setting the language (lang) returns the original moment for chaining");
         test.equal(mom.locale('it'), mom, "setting the language (locale) returns the original moment for chaining");
 
         test.done();
     },
 
-    "lang(key) changes the language of the instance" : function (test) {
-        var m = moment().month(0);
+    "setting a language on instance returns the original moment for chaining deprecated" : function (test) {
+        var mom = moment(),
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
+
+        test.equal(mom.lang('fr'), mom, "setting the language (lang) returns the original moment for chaining");
+
+        moment.deprecationHandler = originalDeprecationHandler;
+        test.done();
+    },
+
+
+    "lang(key) changes the language of the instance (deprecated)" : function (test) {
+        var m = moment().month(0),
+            originalDeprecationHandler = moment.deprecationHandler;
+        moment.deprecationHandler = function () {};
         m.lang("fr");
         test.equal(m.locale(), "fr", "m.lang(key) changes instance locale");
 
+        moment.deprecationHandler = originalDeprecationHandler;
         test.done();
     },
 

--- a/test/moment/min_max.js
+++ b/test/moment/min_max.js
@@ -51,6 +51,9 @@ exports.minMax = {
         test.equal(moment.max([now, past]), now, "max(now, past)");
         test.equal(moment.max([now]), now, "max(now)");
 
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         test.done();
     }
 

--- a/test/moment/mutable.js
+++ b/test/moment/mutable.js
@@ -5,6 +5,9 @@ exports.mutable = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/normalizeUnits.js
+++ b/test/moment/normalizeUnits.js
@@ -7,6 +7,9 @@ exports.normalizeUnits = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/parsing_flags.js
+++ b/test/moment/parsing_flags.js
@@ -8,6 +8,9 @@ exports.parsingFlags = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/preparse_postformat.js
+++ b/test/moment/preparse_postformat.js
@@ -74,6 +74,9 @@ exports.preparsePostformat = {
         test.equal(moment().add(6, 'd').fromNow(true), "^ days", "postformat should work on moment.fn.fromNow");
         test.equal(moment.duration(10, "h").humanize(), "!) hours", "postformat should work on moment.duration.fn.humanize");
 
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         test.done();
     },
 

--- a/test/moment/quarter.js
+++ b/test/moment/quarter.js
@@ -5,6 +5,9 @@ exports.quarter = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/relative_time.js
+++ b/test/moment/relative_time.js
@@ -1,6 +1,16 @@
 var moment = require("../../moment");
 
 exports.relativeTime = {
+    setUp : function (done) {
+        moment.createFromInputFallback = function () {
+            throw new Error("input not handled by moment");
+        };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
+        done();
+    },
+
     "default thresholds" : function (test) {
         var a = moment();
 

--- a/test/moment/sod_eod.js
+++ b/test/moment/sod_eod.js
@@ -6,6 +6,9 @@ exports.endStartOf = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/string_prototype.js
+++ b/test/moment/string_prototype.js
@@ -5,6 +5,9 @@ exports.stringPrototype = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/utc.js
+++ b/test/moment/utc.js
@@ -6,7 +6,9 @@ exports.utc = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
-
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/week_year.js
+++ b/test/moment/week_year.js
@@ -5,6 +5,9 @@ exports.weekYear = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/weekday.js
+++ b/test/moment/weekday.js
@@ -5,6 +5,9 @@ exports.weekYear = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/weeks.js
+++ b/test/moment/weeks.js
@@ -6,7 +6,9 @@ exports.weeks = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
-
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/weeks_in_year.js
+++ b/test/moment/weeks_in_year.js
@@ -1,6 +1,16 @@
 var moment = require("../../moment");
 
 exports.weeksInYear = {
+    setUp : function (done) {
+        moment.createFromInputFallback = function () {
+            throw new Error("input not handled by moment");
+        };
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
+        done();
+    },
+
     "isoWeeksInYear": function (test) {
         test.equal(moment([2004]).isoWeeksInYear(), 53, "2004 has 53 iso weeks");
         test.equal(moment([2005]).isoWeeksInYear(), 52, "2005 has 53 iso weeks");

--- a/test/moment/zone_switching.js
+++ b/test/moment/zone_switching.js
@@ -6,7 +6,9 @@ exports.zoneSwitching = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
-
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 

--- a/test/moment/zones.js
+++ b/test/moment/zones.js
@@ -6,7 +6,9 @@ exports.zones = {
         moment.createFromInputFallback = function () {
             throw new Error("input not handled by moment");
         };
-
+        moment.deprecationHandler = function (name, msg) {
+            throw new Error("got deprecation warning " + name + " " + msg);
+        };
         done();
     },
 


### PR DESCRIPTION
Add `moment.deprecationHandler` that is executed every time a deprecated method or argument is passed.

This enables the user to throw an exception or breakpoint to find a place that emits the warning

I'm not sure, but we might also want to put the following functionality in deprecationHandler somehow:
- [ ] support printing the warning every time
- [ ] support not printing a warning at all
- [ ] support disabling deprecations altogether (for speed?)

i.e don't merge for now, lets keep this until we figure out what we want from `deprecationHandler`.