### PR TITLE
Performance optimization isBefore/isAfter/isSame

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2267,11 +2267,8 @@
         isAfter: function (input, units) {
             units = normalizeUnits(typeof units !== 'undefined' ? units : 'millisecond');
             if (units === 'millisecond') {
-                if (moment.isMoment(input)) {
-                    return this.valueOf() > input.valueOf();
-                } else {
-                    return this.valueOf() > moment(input).valueOf();
-                }
+                input = moment.isMoment(input) ? input : moment(input);
+                return +this > +input;
             } else {
                 return +this.clone().startOf(units) > +moment(input).startOf(units);
             }
@@ -2280,11 +2277,8 @@
         isBefore: function (input, units) {
             units = normalizeUnits(typeof units !== 'undefined' ? units : 'millisecond');
             if (units === 'millisecond') {
-                if (moment.isMoment(input)) {
-                    return this.valueOf() < input.valueOf();
-                } else {
-                    return this.valueOf() < moment(input).valueOf();
-                }
+                input = moment.isMoment(input) ? input : moment(input);
+                return +this < +input;
             } else {
                 return +this.clone().startOf(units) < +moment(input).startOf(units);
             }
@@ -2293,11 +2287,8 @@
         isSame: function (input, units) {
             units = normalizeUnits(units || 'millisecond');
             if (units === 'millisecond') {
-                if (moment.isMoment(input)) {
-                    return this.valueOf() === input.valueOf();
-                } else {
-                    return this.valueOf() === moment(input).valueOf();
-                }
+                input = moment.isMoment(input) ? input : moment(input);
+                return +this === +input;
             } else {
                 return +this.clone().startOf(units) === +makeAs(input, this).startOf(units);
             }


### PR DESCRIPTION
- optimized performance of isBefore/isAfter/isSame by using valueOf and
  not momentizing/cloning already existing moment objects
- 90% performance improvement when using without specific unit and the
   input is already a moment object

reviewed by PatrickBic
