### PR TITLE
Years and months convert to whole number of days with duration as getters

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2662,7 +2662,7 @@
                 months = this._months + daysToYears(days) * 12;
                 return units === 'month' ? months : months / 12;
             } else {
-                days += yearsToDays(this._months / 12);
+                days += Math.floor(yearsToDays(this._months / 12));
                 switch (units) {
                     case 'week': return days / 7;
                     case 'day': return days;

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -445,73 +445,89 @@ exports.duration = {
         test.done();
     },
 
-    'asGetters' : function (test) {
-        var d = moment.duration({
-            years: 2,
-            months: 3,
-            weeks: 2,
-            days: 1,
-            hours: 8,
-            minutes: 9,
-            seconds: 20,
-            milliseconds: 12
-        });
+    // 'asGetters' : function (test) {
+    //     var d = moment.duration({
+    //         years: 2,
+    //         months: 3,
+    //         weeks: 2,
+    //         days: 1,
+    //         hours: 8,
+    //         minutes: 9,
+    //         seconds: 20,
+    //         milliseconds: 12
+    //     });
 
-        test.expect(8);
-        // These are of course very fragile. Their existence merely hints that
-        // changing the way 'as' works changes the output.
-        test.equal(d.asYears().toFixed(2),          '2.29', 'years');
-        test.equal(d.asMonths().toFixed(2),        '27.50', 'months');
-        test.equal(d.asWeeks().toFixed(2),        '119.59', 'weeks');
-        test.equal(d.asDays().toFixed(2),         '837.14', 'days');
-        test.equal(d.asHours().toFixed(2),      '20091.25', 'hours');
-        test.equal(d.asMinutes().toFixed(2),  '1205475.03', 'minutes');
-        test.equal(d.asSeconds().toFixed(2), '72328502.01', 'seconds');
-        test.equal(d.asMilliseconds(),         72328502012, 'milliseconds');
+    //     test.expect(8);
+    //     // These are of course very fragile. Their existence merely hints that
+    //     // changing the way 'as' works changes the output.
+    //     test.equal(d.asYears().toFixed(2),          '2.29', 'years');
+    //     test.equal(d.asMonths().toFixed(2),        '27.50', 'months');
+    //     test.equal(d.asWeeks().toFixed(2),        '119.59', 'weeks');
+    //     test.equal(d.asDays().toFixed(2),         '837.14', 'days');
+    //     test.equal(d.asHours().toFixed(2),      '20091.25', 'hours');
+    //     test.equal(d.asMinutes().toFixed(2),  '1205475.03', 'minutes');
+    //     test.equal(d.asSeconds().toFixed(2), '72328502.01', 'seconds');
+    //     test.equal(d.asMilliseconds(),         72328502012, 'milliseconds');
+    //     test.done();
+    // },
+    'as getters' : function (test) {
+        // Moment.js version 2.7.0
+        test.equal(moment.duration(1, 'year').asDays(), 365, '1 year as days');
+        test.equal(moment.duration(1, 'year').asHours(), 8760, '1 year as hours');
+        test.equal(moment.duration(1, 'year').asMinutes(), 525600, '1 year as minutes');
+        test.equal(moment.duration(1, 'year').asSeconds(), 31536000, '1 year as seconds');
+        test.equal(moment.duration(1, 'month').asDays(), 30, '1 month as days');
+        test.equal(moment.duration(1, 'month').asHours(), 720, '1 month as hours');
+        test.equal(moment.duration(1, 'month').asMinutes(), 43200, '1 month as minutes');
+        test.equal(moment.duration(1, 'month').asSeconds(), 2592000, '1 month as seconds');
+
+        // These won't work
+        // test.equal(moment.duration(30, 'days').asMonths(), 1, '30 days as month');
+        // test.equal(moment.duration(365, 'days').asYears(), 1, '365 days as years');
         test.done();
     },
 
-    'generic as getter' : function (test) {
-        var d = moment.duration({
-            years: 2,
-            months: 3,
-            weeks: 2,
-            days: 1,
-            hours: 8,
-            minutes: 9,
-            seconds: 20,
-            milliseconds: 12
-        });
+    // 'generic as getter' : function (test) {
+    //     var d = moment.duration({
+    //         years: 2,
+    //         months: 3,
+    //         weeks: 2,
+    //         days: 1,
+    //         hours: 8,
+    //         minutes: 9,
+    //         seconds: 20,
+    //         milliseconds: 12
+    //     });
 
-        // These are of course very fragile. Their existence merely hints that
-        // changing the way 'as' works changes the output.
-        test.expect(24);
-        test.equal(d.as('years').toFixed(2),          '2.29', 'years');
-        test.equal(d.as('year').toFixed(2),           '2.29', 'years = year');
-        test.equal(d.as('y').toFixed(2),              '2.29', 'years = y');
-        test.equal(d.as('months').toFixed(2),         '27.50', 'months');
-        test.equal(d.as('month').toFixed(2),          '27.50', 'months = month');
-        test.equal(d.as('M').toFixed(2),              '27.50', 'months = M');
-        test.equal(d.as('weeks').toFixed(2),          '119.59', 'weeks');
-        test.equal(d.as('week').toFixed(2),           '119.59', 'weeks = week');
-        test.equal(d.as('w').toFixed(2),              '119.59', 'weeks = w');
-        test.equal(d.as('days').toFixed(2),           '837.14', 'days');
-        test.equal(d.as('day').toFixed(2),            '837.14', 'days = day');
-        test.equal(d.as('d').toFixed(2),              '837.14', 'days = d');
-        test.equal(d.as('hours').toFixed(2),          '20091.25', 'hours');
-        test.equal(d.as('hour').toFixed(2),           '20091.25', 'hours = hour');
-        test.equal(d.as('h').toFixed(2),              '20091.25', 'hours = h');
-        test.equal(d.as('minutes').toFixed(2),        '1205475.03', 'minutes');
-        test.equal(d.as('minute').toFixed(2),         '1205475.03', 'minutes = minute');
-        test.equal(d.as('m').toFixed(2),              '1205475.03', 'minutes = m');
-        test.equal(d.as('seconds').toFixed(2),        '72328502.01', 'seconds');
-        test.equal(d.as('second').toFixed(2),         '72328502.01', 'seconds = second');
-        test.equal(d.as('s').toFixed(2),              '72328502.01', 'seconds = s');
-        test.equal(d.as('milliseconds'),              72328502012, 'milliseconds');
-        test.equal(d.as('millisecond'),               72328502012, 'milliseconds = millisecond');
-        test.equal(d.as('ms'),                        72328502012, 'milliseconds = ms');
-        test.done();
-    },
+    //     // These are of course very fragile. Their existence merely hints that
+    //     // changing the way 'as' works changes the output.
+    //     test.expect(24);
+    //     test.equal(d.as('years').toFixed(2),          '2.29', 'years');
+    //     test.equal(d.as('year').toFixed(2),           '2.29', 'years = year');
+    //     test.equal(d.as('y').toFixed(2),              '2.29', 'years = y');
+    //     test.equal(d.as('months').toFixed(2),         '27.50', 'months');
+    //     test.equal(d.as('month').toFixed(2),          '27.50', 'months = month');
+    //     test.equal(d.as('M').toFixed(2),              '27.50', 'months = M');
+    //     test.equal(d.as('weeks').toFixed(2),          '119.59', 'weeks');
+    //     test.equal(d.as('week').toFixed(2),           '119.59', 'weeks = week');
+    //     test.equal(d.as('w').toFixed(2),              '119.59', 'weeks = w');
+    //     test.equal(d.as('days').toFixed(2),           '837.14', 'days');
+    //     test.equal(d.as('day').toFixed(2),            '837.14', 'days = day');
+    //     test.equal(d.as('d').toFixed(2),              '837.14', 'days = d');
+    //     test.equal(d.as('hours').toFixed(2),          '20091.25', 'hours');
+    //     test.equal(d.as('hour').toFixed(2),           '20091.25', 'hours = hour');
+    //     test.equal(d.as('h').toFixed(2),              '20091.25', 'hours = h');
+    //     test.equal(d.as('minutes').toFixed(2),        '1205475.03', 'minutes');
+    //     test.equal(d.as('minute').toFixed(2),         '1205475.03', 'minutes = minute');
+    //     test.equal(d.as('m').toFixed(2),              '1205475.03', 'minutes = m');
+    //     test.equal(d.as('seconds').toFixed(2),        '72328502.01', 'seconds');
+    //     test.equal(d.as('second').toFixed(2),         '72328502.01', 'seconds = second');
+    //     test.equal(d.as('s').toFixed(2),              '72328502.01', 'seconds = s');
+    //     test.equal(d.as('milliseconds'),              72328502012, 'milliseconds');
+    //     test.equal(d.as('millisecond'),               72328502012, 'milliseconds = millisecond');
+    //     test.equal(d.as('ms'),                        72328502012, 'milliseconds = ms');
+    //     test.done();
+    // },
 
     'isDuration' : function (test) {
         test.expect(3);


### PR DESCRIPTION
This is an attempt at fixing #1884.

Also `days in one month` and `days in one year` yield floating point numbers in google.com, which is intended to be much more user friendly than moment (moment is developer friendly :)).

The `as` getters are intended for conversion, and this is exactly what we do here. It just `looks broken` as @jsmreese put it. @icambron what do you think?

@jsmreese -- on the other hand if you don't want to display floating point numbers to the client you can just round them. I hope you're not using moment to convert 1 month into 30 days, but instead -- variable (possibly unexpected) input into days, which will most probably yield a non-natural number of days.

TODO:
- [ ] tests for all possible input and output units
- [ ] remove commented out tests
