### PR TITLE
Save duration normalizedInput as _input property on duration object

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -411,6 +411,8 @@
 
         this._locale = moment.localeData();
 
+        this._input = normalizedInput;
+
         this._bubble();
     }
 

--- a/moment.js
+++ b/moment.js
@@ -2709,10 +2709,10 @@
                     case 'week': return days / 7 + this._milliseconds / 6048e5;
                     case 'day': return days + this._milliseconds / 864e5;
                     case 'hour': return days * 24 + this._milliseconds / 36e5;
-                    case 'minute': return days * 24 * 60 + this._milliseconds / 6e4;
-                    case 'second': return days * 24 * 60 * 60 + this._milliseconds / 1000;
+                    case 'minute': return days * 1440 + this._milliseconds / 6e4;
+                    case 'second': return days * 86400 + this._milliseconds / 1000;
                     // Math.floor prevents floating point math errors here
-                    case 'millisecond': return Math.floor(days * 24 * 60 * 60 * 1000) + this._milliseconds;
+                    case 'millisecond': return Math.floor(days * 864e5) + this._milliseconds;
                     default: throw new Error('Unknown unit ' + units);
                 }
             }

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -141,10 +141,10 @@ exports.duration = {
             modified = moment.duration(1, 'day').add(moment.duration(1, 'day'));
 
         test.expect(4);
-        test.deepEqual(moment.duration(simple), simple, 'simple clones are equal');
-        test.deepEqual(moment.duration(lengthy), lengthy, 'lengthy clones are equal');
-        test.deepEqual(moment.duration(complicated), complicated, 'complicated clones are equal');
-        test.deepEqual(moment.duration(modified), modified, 'cloning modified duration works');
+        test.deepEqual(moment.duration(simple).asMilliseconds(), simple.asMilliseconds(), 'simple clones are equal');
+        test.deepEqual(moment.duration(lengthy).asMilliseconds(), lengthy.asMilliseconds(), 'lengthy clones are equal');
+        test.deepEqual(moment.duration(complicated).asMilliseconds(), complicated.asMilliseconds(), 'complicated clones are equal');
+        test.deepEqual(moment.duration(modified).asMilliseconds(), modified.asMilliseconds(), 'cloning modified duration works');
         test.done();
     },
 

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -141,10 +141,10 @@ exports.duration = {
             modified = moment.duration(1, 'day').add(moment.duration(1, 'day'));
 
         test.expect(4);
-        test.deepEqual(moment.duration(simple).asMilliseconds(), simple.asMilliseconds(), 'simple clones are equal');
-        test.deepEqual(moment.duration(lengthy).asMilliseconds(), lengthy.asMilliseconds(), 'lengthy clones are equal');
-        test.deepEqual(moment.duration(complicated).asMilliseconds(), complicated.asMilliseconds(), 'complicated clones are equal');
-        test.deepEqual(moment.duration(modified).asMilliseconds(), modified.asMilliseconds(), 'cloning modified duration works');
+        test.deepEqual(moment.duration(simple)._data, simple._data, 'simple clones are equal');
+        test.deepEqual(moment.duration(lengthy)._data, lengthy._data, 'lengthy clones are equal');
+        test.deepEqual(moment.duration(complicated)._data, complicated._data, 'complicated clones are equal');
+        test.deepEqual(moment.duration(modified)._data, modified._data, 'cloning modified duration works');
         test.done();
     },
 


### PR DESCRIPTION
When working with duration objects, it can be *really* useful to know what unit quantities were used to create the duration object.

The `normalizedInput` object is already created in the duration object constructor. This update simply saves that input to the new duration object under the `_input` property.

The duration clone tests are updated to use the `asMilliseconds` method because the `_input` property will usually not match between the original and cloned duration objects. But each object should evaluate to the same number of milliseconds.

Operations such as cloning, adding, or subtracting can modify a duration object so that its `_input` property gets out of sync with the actual duration value. I think that's OK.