### PR TITLE
date from string and format missing year is valid

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -671,6 +671,8 @@
             } else {
                 value = Math.ceil(coercedNumber);
             }
+        } else if (argumentForCoercion === undefined) {
+            return;
         }
 
         return value;
@@ -1356,7 +1358,7 @@
 
         // Zero out whatever was not defaulted, including time
         for (; i < 7; i++) {
-            config._a[i] = input[i] = (config._a[i] == null) ? (i === 2 ? 1 : 0) : config._a[i];
+            config._a[i] = input[i] = (config._a[i] == null) ? (i === DATE ? 1 : 0) : config._a[i];
         }
 
         config._d = (config._useUTC ? makeUTCDate : makeDate).apply(null, input);
@@ -2054,7 +2056,8 @@
     };
 
     moment.parseTwoDigitYear = function (input) {
-        return toInt(input) + (toInt(input) > 68 ? 1900 : 2000);
+        var inputVal = toInt(input) || 0;
+        return inputVal + (inputVal > 68 ? 1900 : 2000);
     };
 
     /************************************


### PR DESCRIPTION
When making a date from string and format, I expect a missing year to make the date invalid.
http://jsfiddle.net/jw8o2g2a/2/

674: The toInt function should not default to 0 when the argument is undefined.  This returns a technically valid year even though no year was provided.

2059: parseTwoDigitYear attempts to take an input value and add 1900 or 2000 to it.  If the value is undefined, this will return NaN, so default to 0.

1361: use DATE constant rather than hard coded value
