### PR TITLE
In IE11 I'm seeing module being registered as type "object" but is null....

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -33,7 +33,7 @@
         momentProperties = [],
 
         // check for nodeJS
-        hasModule = (typeof module !== 'undefined' && module.exports),
+        hasModule = (typeof module !== 'undefined' && module && module.exports),
 
         // ASP.NET json date format regex
         aspNetJsonRegex = /^\/?Date\((\-?\d+)/i,


### PR DESCRIPTION
... This also makes sure that, even if module is not undefined, it is also not null before checking property export.

I'm not entirely sure why this is not registering as undefined, but it seems related to this: http://javascriptweblog.wordpress.com/2011/08/08/fixing-the-javascript-typeof-operator/

> What’s wrong with typeof?
> 
> The most glaring issue is that typeof null returns “object”. It’s simply a mistake. There’s talk of fixing it in the next version of the ECMAScript specification, although this would undoubtedly introduce backwards compatibility issues.
