### PR TITLE
Unified interface for locale functions between global moment and moment instances

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -282,7 +282,14 @@
 
         deprecations = {},
 
-        lists = ['months', 'monthsShort', 'weekdays', 'weekdaysShort', 'weekdaysMin'];
+        lists = ['months', 'monthsShort', 'weekdays', 'weekdaysShort', 'weekdaysMin'],
+        localeList = {
+            months: 'month',
+            monthsShort: 'monthShort',
+            weekdays: 'weekday',
+            weekdaysShort: 'weekdayShort',
+            weekdaysMin: 'weekdayMin'
+        };
 
     // Pick the first defined of two or three arguments. dfl comes from
     // default.
@@ -748,16 +755,6 @@
     /************************************
         Locale
     ************************************/
-    var localeList = {
-        months: 'month',
-        monthsShort: 'monthShort',
-        weekdays: 'weekday',
-        weekdaysShort: 'weekdayShort',
-        weekdaysMin: 'weekdayMin'
-    };
-
-    var extendLocale = {};
-
     function makeLocaleList (listName, singleName) {
         var count, setter;
 
@@ -773,18 +770,17 @@
             return;
         }
 
-        extendLocale[listName] = function (format, index) {
-
+        Locale.prototype[listName] = function (format, index) {
             var i, getter,
                 method = this[singleName],
-                results = [];
+                results = [],
+                self = this;
 
             if (typeof format === 'number') {
                 index = format;
                 format = undefined;
             }
 
-            var self = this;
             getter = function (i) {
                 var m = moment().utc().set(setter, i);
                 return method.call(self, m, format || '');
@@ -802,21 +798,20 @@
         };
     }
 
-    for (var list in localeList) {
-      makeLocaleList(list, localeList[list]);
+    for (i in localeList) {
+        makeLocaleList(i, localeList[i]);
     }
 
     function wrapToFunction (obj, accessor) {
-      if (typeof obj === 'function') {
-        return obj;
-      } else {
-        return function (m) {
-          return obj[m[accessor]()];
+        if (typeof obj === 'function') {
+            return obj;
+        } else {
+            return function (m) {
+                return obj[m[accessor]()];
+            };
         }
-      }
     }
 
-    extend(Locale.prototype, extendLocale);
     extend(Locale.prototype, {
 
         set : function (config) {
@@ -824,10 +819,9 @@
             for (i in config) {
                 prop = config[i];
                 if (['months', 'monthsShort'].indexOf(i) >= 0) {
-                  this['_' + i] = wrapToFunction(prop, 'month');
-                } else if (['weekdays', 'weekdaysShort',
-                            'weekdaysMin'].indexOf(i) >= 0) {
-                  this['_' + i] = wrapToFunction(prop, 'day');
+                    this['_' + i] = wrapToFunction(prop, 'month');
+                } else if (['weekdays', 'weekdaysShort', 'weekdaysMin'].indexOf(i) >= 0) {
+                    this['_' + i] = wrapToFunction(prop, 'day');
                 }
                 else if (typeof prop === 'function') {
                     this[i] = prop;

--- a/test/moment/listers.js
+++ b/test/moment/listers.js
@@ -57,7 +57,8 @@ exports.listers = {
             monthsShort = 'on_tw_th_fo_fi_si_se_ei_ni_te_el_tw'.split('_'),
             weekdays = 'one_two_three_four_five_six_seven'.split('_'),
             weekdaysShort = 'on_tw_th_fo_fi_si_se'.split('_'),
-            weekdaysMin = '1_2_3_4_5_6_7'.split('_');
+            weekdaysMin = '1_2_3_4_5_6_7'.split('_'),
+            m;
 
         moment.locale('numerologists', {
             months : months,
@@ -67,7 +68,7 @@ exports.listers = {
             weekdaysMin: weekdaysMin
         });
 
-        var m = moment();
+        m = moment();
         test.deepEqual(m.localeData().months(), months);
         test.deepEqual(m.localeData().monthsShort(), monthsShort);
         test.deepEqual(m.localeData().weekdays(), weekdays);
@@ -91,7 +92,8 @@ exports.listers = {
 
     'with functions' : function (test) {
         var monthsShort = 'one_two_three_four_five_six_seven_eight_nine_ten_eleven_twelve'.split('_'),
-            monthsShortWeird = 'onesy_twosy_threesy_foursy_fivesy_sixsy_sevensy_eightsy_ninesy_tensy_elevensy_twelvesy'.split('_');
+            monthsShortWeird = 'onesy_twosy_threesy_foursy_fivesy_sixsy_sevensy_eightsy_ninesy_tensy_elevensy_twelvesy'.split('_'),
+            m;
 
         moment.locale('difficult', {
 
@@ -101,7 +103,7 @@ exports.listers = {
             }
         });
 
-        var m = moment();
+        m = moment();
         test.expect(6);
         test.deepEqual(m.localeData().monthsShort(), monthsShort);
         test.deepEqual(m.localeData().monthsShort('MMM'), monthsShort);

--- a/test/moment/listers.js
+++ b/test/moment/listers.js
@@ -16,26 +16,39 @@ exports.listers = {
     },
 
     'default' : function (test) {
+        var m = moment();
         test.expect(5);
-        test.deepEqual(moment.months(), ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']);
-        test.deepEqual(moment.monthsShort(), ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
-        test.deepEqual(moment.weekdays(), ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']);
-        test.deepEqual(moment.weekdaysShort(), ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
-        test.deepEqual(moment.weekdaysMin(), ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
+        test.deepEqual(m.localeData().months(), ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']);
+        test.deepEqual(m.localeData().monthsShort(), ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
+        test.deepEqual(m.localeData().weekdays(), ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']);
+        test.deepEqual(m.localeData().weekdaysShort(), ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+        test.deepEqual(m.localeData().weekdaysMin(), ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
+        test.done();
+    },
+
+    'globalMethods': function (test) {
+        var m = moment();
+        test.expect(5);
+        test.deepEqual(m.localeData().months(), moment.months());
+        test.deepEqual(m.localeData().monthsShort(), moment.monthsShort());
+        test.deepEqual(m.localeData().weekdays(), moment.weekdays());
+        test.deepEqual(m.localeData().weekdaysShort(), moment.weekdaysShort());
+        test.deepEqual(m.localeData().weekdaysMin(), moment.weekdaysMin());
         test.done();
     },
 
     'index' : function (test) {
-        test.equal(moment.months(0), 'January');
-        test.equal(moment.months(2), 'March');
-        test.equal(moment.monthsShort(0), 'Jan');
-        test.equal(moment.monthsShort(2), 'Mar');
-        test.equal(moment.weekdays(0), 'Sunday');
-        test.equal(moment.weekdays(2), 'Tuesday');
-        test.equal(moment.weekdaysShort(0), 'Sun');
-        test.equal(moment.weekdaysShort(2), 'Tue');
-        test.equal(moment.weekdaysMin(0), 'Su');
-        test.equal(moment.weekdaysMin(2), 'Tu');
+        var m = moment();
+        test.equal(m.localeData().months(0), 'January');
+        test.equal(m.localeData().months(2), 'March');
+        test.equal(m.localeData().monthsShort(0), 'Jan');
+        test.equal(m.localeData().monthsShort(2), 'Mar');
+        test.equal(m.localeData().weekdays(0), 'Sunday');
+        test.equal(m.localeData().weekdays(2), 'Tuesday');
+        test.equal(m.localeData().weekdaysShort(0), 'Sun');
+        test.equal(m.localeData().weekdaysShort(2), 'Tue');
+        test.equal(m.localeData().weekdaysMin(0), 'Su');
+        test.equal(m.localeData().weekdaysMin(2), 'Tu');
         test.done();
     },
 
@@ -54,23 +67,24 @@ exports.listers = {
             weekdaysMin: weekdaysMin
         });
 
-        test.deepEqual(moment.months(), months);
-        test.deepEqual(moment.monthsShort(), monthsShort);
-        test.deepEqual(moment.weekdays(), weekdays);
-        test.deepEqual(moment.weekdaysShort(), weekdaysShort);
-        test.deepEqual(moment.weekdaysMin(), weekdaysMin);
+        var m = moment();
+        test.deepEqual(m.localeData().months(), months);
+        test.deepEqual(m.localeData().monthsShort(), monthsShort);
+        test.deepEqual(m.localeData().weekdays(), weekdays);
+        test.deepEqual(m.localeData().weekdaysShort(), weekdaysShort);
+        test.deepEqual(m.localeData().weekdaysMin(), weekdaysMin);
 
-        test.equal(moment.months(0), 'one');
-        test.equal(moment.monthsShort(0), 'on');
-        test.equal(moment.weekdays(0), 'one');
-        test.equal(moment.weekdaysShort(0), 'on');
-        test.equal(moment.weekdaysMin(0), '1');
+        test.equal(m.localeData().months(0), 'one');
+        test.equal(m.localeData().monthsShort(0), 'on');
+        test.equal(m.localeData().weekdays(0), 'one');
+        test.equal(m.localeData().weekdaysShort(0), 'on');
+        test.equal(m.localeData().weekdaysMin(0), '1');
 
-        test.equal(moment.months(2), 'three');
-        test.equal(moment.monthsShort(2), 'th');
-        test.equal(moment.weekdays(2), 'three');
-        test.equal(moment.weekdaysShort(2), 'th');
-        test.equal(moment.weekdaysMin(2), '3');
+        test.equal(m.localeData().months(2), 'three');
+        test.equal(m.localeData().monthsShort(2), 'th');
+        test.equal(m.localeData().weekdays(2), 'three');
+        test.equal(m.localeData().weekdaysShort(2), 'th');
+        test.equal(m.localeData().weekdaysMin(2), '3');
 
         test.done();
     },
@@ -87,15 +101,32 @@ exports.listers = {
             }
         });
 
+        var m = moment();
         test.expect(6);
-        test.deepEqual(moment.monthsShort(), monthsShort);
-        test.deepEqual(moment.monthsShort('MMM'), monthsShort);
-        test.deepEqual(moment.monthsShort('-MMM-'), monthsShortWeird);
+        test.deepEqual(m.localeData().monthsShort(), monthsShort);
+        test.deepEqual(m.localeData().monthsShort('MMM'), monthsShort);
+        test.deepEqual(m.localeData().monthsShort('-MMM-'), monthsShortWeird);
 
-        test.deepEqual(moment.monthsShort('MMM', 2), 'three');
-        test.deepEqual(moment.monthsShort('-MMM-', 2), 'threesy');
-        test.deepEqual(moment.monthsShort(2), 'three');
+        test.deepEqual(m.localeData().monthsShort('MMM', 2), 'three');
+        test.deepEqual(m.localeData().monthsShort('-MMM-', 2), 'threesy');
+        test.deepEqual(m.localeData().monthsShort(2), 'three');
 
+        test.done();
+    },
+
+    'instanceLocaleDoesntBreakGlobal': function (test) {
+        var m = moment();
+        m.locale('ru');
+
+        test.expect(2);
+        test.deepEqual(
+          m.localeData().months(),
+          'январь_февраль_март_апрель_май_июнь_июль_август_сентябрь_октябрь_ноябрь_декабрь'.split('_')
+        );
+        test.deepEqual(
+          moment.months(),
+          'January_February_March_April_May_June_July_August_September_October_November_December'.split('_')
+        );
         test.done();
     }
 };

--- a/test/moment/locale.js
+++ b/test/moment/locale.js
@@ -112,9 +112,9 @@ exports.locale = {
 
         var jan = moment([2000, 0]);
 
-        test.equal(moment.localeData().months(jan), 'January', 'no arguments returns global');
-        test.equal(moment.localeData('zh-cn').months(jan), '一月', 'a string returns the locale based on key');
-        test.equal(moment.localeData(moment().locale('es')).months(jan), 'enero', 'if you pass in a moment it uses the moment\'s locale');
+        test.equal(moment.localeData().month(jan), 'January', 'no arguments returns global');
+        test.equal(moment.localeData('zh-cn').month(jan), '一月', 'a string returns the locale based on key');
+        test.equal(moment.localeData(moment().locale('es')).month(jan), 'enero', 'if you pass in a moment it uses the moment\'s locale');
 
         test.done();
     },


### PR DESCRIPTION
Moved months(Short), weekdays(Short|Min) to localeData, made the originals
call the localeData methods. Renamed original methods that get single month or
weekdays names from plural to singular. Updated localeData set so that locale
definitions with months/weekdays would continue to work.

Fixes #1945 