### PR TITLE
Fix internal makeAs function to work properly for different time zones

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -776,8 +776,16 @@
 
     // Return a moment from input, that is local/utc/zone equivalent to model.
     function makeAs(input, model) {
-        return model._isUTC ? moment(input).zone(model._offset || 0) :
-            moment(input).local();
+        if (model._isUTC) {
+            var result = model.clone();
+            result._d.setTime(moment(input).valueOf());
+            result._offset = 0;
+            result.zone(model._offset || 0);
+            moment.updateOffset(result);
+            return result;
+        } else {
+            return moment(input).local();
+        }
     }
 
     /************************************


### PR DESCRIPTION
Fix internal makeAs function to work properly for different time zones moment/moment-timezone#127

`makeAs` function didn't change the timezone of `input` to match `model`. Instead, it just updated the `offset`, but with different time zone `offset` will be restored with any subsequent call to `updateOffset`.
Correct behavior should be creading a copy of `model` (it will be with proper time zone) and set timestamp from `input`.
Then, we need to update offset from `model` (it is firstly set to zero, and then updated by call to `zone` function to preserve correct timestamp).
And finally, call to `updateOffset` is needed for moment-timezone to update offset in case of different offset in the same time zone for `input` and `model` moments.
