### PR TITLE
Locale export for meteor server environment

### DIFF
--- a/locale/af.js
+++ b/locale/af.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('af', {

--- a/locale/ar-ma.js
+++ b/locale/ar-ma.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ar-ma', {

--- a/locale/ar-sa.js
+++ b/locale/ar-sa.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/ar.js
+++ b/locale/ar.js
@@ -10,7 +10,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/az.js
+++ b/locale/az.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var suffixes = {

--- a/locale/be.js
+++ b/locale/be.js
@@ -10,7 +10,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function plural(word, num) {

--- a/locale/bg.js
+++ b/locale/bg.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('bg', {

--- a/locale/bn.js
+++ b/locale/bn.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/bo.js
+++ b/locale/bo.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/br.js
+++ b/locale/br.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function relativeTimeWithMutation(number, withoutSuffix, key) {

--- a/locale/bs.js
+++ b/locale/bs.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function translate(number, withoutSuffix, key) {

--- a/locale/ca.js
+++ b/locale/ca.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ca', {

--- a/locale/cs.js
+++ b/locale/cs.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var months = 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split('_'),

--- a/locale/cv.js
+++ b/locale/cv.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('cv', {

--- a/locale/cy.js
+++ b/locale/cy.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('cy', {

--- a/locale/da.js
+++ b/locale/da.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('da', {

--- a/locale/de-at.js
+++ b/locale/de-at.js
@@ -10,7 +10,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {

--- a/locale/de.js
+++ b/locale/de.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {

--- a/locale/el.js
+++ b/locale/el.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('el', {

--- a/locale/en-au.js
+++ b/locale/en-au.js
@@ -7,7 +7,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('en-au', {

--- a/locale/en-ca.js
+++ b/locale/en-ca.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('en-ca', {

--- a/locale/en-gb.js
+++ b/locale/en-gb.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('en-gb', {

--- a/locale/eo.js
+++ b/locale/eo.js
@@ -10,7 +10,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('eo', {

--- a/locale/es.js
+++ b/locale/es.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),

--- a/locale/et.js
+++ b/locale/et.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {

--- a/locale/eu.js
+++ b/locale/eu.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('eu', {

--- a/locale/fa.js
+++ b/locale/fa.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/fi.js
+++ b/locale/fi.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var numbersPast = 'nolla yksi kaksi kolme neljä viisi kuusi seitsemän kahdeksan yhdeksän'.split(' '),

--- a/locale/fo.js
+++ b/locale/fo.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('fo', {

--- a/locale/fr-ca.js
+++ b/locale/fr-ca.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('fr-ca', {

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('fr', {

--- a/locale/gl.js
+++ b/locale/gl.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('gl', {

--- a/locale/he.js
+++ b/locale/he.js
@@ -10,7 +10,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('he', {

--- a/locale/hi.js
+++ b/locale/hi.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/hr.js
+++ b/locale/hr.js
@@ -10,7 +10,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function translate(number, withoutSuffix, key) {

--- a/locale/hu.js
+++ b/locale/hu.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var weekEndings = 'vasárnap hétfőn kedden szerdán csütörtökön pénteken szombaton'.split(' ');

--- a/locale/hy-am.js
+++ b/locale/hy-am.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function monthsCaseReplace(m, format) {

--- a/locale/id.js
+++ b/locale/id.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('id', {

--- a/locale/is.js
+++ b/locale/is.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function plural(n) {

--- a/locale/it.js
+++ b/locale/it.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('it', {

--- a/locale/ja.js
+++ b/locale/ja.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ja', {

--- a/locale/ka.js
+++ b/locale/ka.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function monthsCaseReplace(m, format) {

--- a/locale/km.js
+++ b/locale/km.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('km', {

--- a/locale/ko.js
+++ b/locale/ko.js
@@ -11,7 +11,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ko', {

--- a/locale/lb.js
+++ b/locale/lb.js
@@ -12,7 +12,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {

--- a/locale/lt.js
+++ b/locale/lt.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var units = {

--- a/locale/lv.js
+++ b/locale/lv.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var units = {

--- a/locale/mk.js
+++ b/locale/mk.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('mk', {

--- a/locale/ml.js
+++ b/locale/ml.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ml', {

--- a/locale/mr.js
+++ b/locale/mr.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/ms-my.js
+++ b/locale/ms-my.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ms-my', {

--- a/locale/my.js
+++ b/locale/my.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/nb.js
+++ b/locale/nb.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('nb', {

--- a/locale/ne.js
+++ b/locale/ne.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {

--- a/locale/nl.js
+++ b/locale/nl.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var monthsShortWithDots = 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split('_'),

--- a/locale/nn.js
+++ b/locale/nn.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('nn', {

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var monthsNominative = 'styczeń_luty_marzec_kwiecień_maj_czerwiec_lipiec_sierpień_wrzesień_październik_listopad_grudzień'.split('_'),

--- a/locale/pt-br.js
+++ b/locale/pt-br.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('pt-br', {

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('pt', {

--- a/locale/ro.js
+++ b/locale/ro.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function relativeTimeWithPlural(number, withoutSuffix, key) {

--- a/locale/ru.js
+++ b/locale/ru.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function plural(word, num) {

--- a/locale/sk.js
+++ b/locale/sk.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var months = 'január_február_marec_apríl_máj_jún_júl_august_september_október_november_december'.split('_'),

--- a/locale/sl.js
+++ b/locale/sl.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function translate(number, withoutSuffix, key) {

--- a/locale/sq.js
+++ b/locale/sq.js
@@ -10,7 +10,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('sq', {

--- a/locale/sr-cyrl.js
+++ b/locale/sr-cyrl.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var translator = {

--- a/locale/sr.js
+++ b/locale/sr.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var translator = {

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('sv', {

--- a/locale/ta.js
+++ b/locale/ta.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     /*var symbolMap = {

--- a/locale/th.js
+++ b/locale/th.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('th', {

--- a/locale/tl-ph.js
+++ b/locale/tl-ph.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('tl-ph', {

--- a/locale/tr.js
+++ b/locale/tr.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     var suffixes = {

--- a/locale/tzm-latn.js
+++ b/locale/tzm-latn.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('tzm-latn', {

--- a/locale/tzm.js
+++ b/locale/tzm.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('tzm', {

--- a/locale/uk.js
+++ b/locale/uk.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     function plural(word, num) {

--- a/locale/uz.js
+++ b/locale/uz.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('uz', {

--- a/locale/vi.js
+++ b/locale/vi.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('vi', {

--- a/locale/zh-cn.js
+++ b/locale/zh-cn.js
@@ -9,7 +9,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('zh-cn', {

--- a/locale/zh-tw.js
+++ b/locale/zh-tw.js
@@ -8,7 +8,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== undefined ? global : this).moment); // Browser global
+        factory((typeof global !== undefined ? global : this).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('zh-tw', {


### PR DESCRIPTION
The global scope might be node (`global`) or `this` (window or other), so detect in all language files. Implements #1946.
