### PR TITLE
No relative require in locales

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
     else if (embedOption) {
         embedLocaleSrc = 'locale/' + embedOption + '.js';
     }
-
+    require('load-grunt-tasks')(grunt);
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         concat : {
@@ -195,6 +195,14 @@ module.exports = function (grunt) {
             all: {
                 src: ['benchmarks/*.js']
             }
+        },
+        shell: {
+            multiple: {
+                command: [
+                    'npm link',
+                    'npm link moment'
+                ].join('&&')
+            }
         }
     });
 
@@ -204,11 +212,11 @@ module.exports = function (grunt) {
     require('load-grunt-tasks')(grunt);
 
     // Default task.
-    grunt.registerTask('default', ['jshint', 'jscs', 'nodeunit']);
+    grunt.registerTask('default', ['jshint', 'jscs', 'shell', 'nodeunit']);
 
     // test tasks
     grunt.registerTask('test', ['test:node', 'test:browser']);
-    grunt.registerTask('test:node', ['nodeunit']);
+    grunt.registerTask('test:node', ['shell', 'nodeunit']);
     grunt.registerTask('test:server', ['concat', 'embedLocales', 'karma:server']);
     grunt.registerTask('test:browser', ['concat', 'embedLocales', 'karma:chrome', 'karma:firefox']);
     grunt.registerTask('test:sauce-browser', ['concat', 'embedLocales', 'env:sauceLabs', 'karma:sauce']);
@@ -224,7 +232,7 @@ module.exports = function (grunt) {
 
     // Task to be run when releasing a new version
     grunt.registerTask('release', [
-        'jshint', 'nodeunit', 'concat', 'embedLocales',
+        'jshint', 'shell', 'nodeunit', 'concat', 'embedLocales',
         'component', 'uglify:main'
     ]);
 };

--- a/locale/af.js
+++ b/locale/af.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ar-ma.js
+++ b/locale/ar-ma.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ar-sa.js
+++ b/locale/ar-sa.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ar.js
+++ b/locale/ar.js
@@ -8,7 +8,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/az.js
+++ b/locale/az.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/be.js
+++ b/locale/be.js
@@ -8,7 +8,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/bg.js
+++ b/locale/bg.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/bn.js
+++ b/locale/bn.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/bo.js
+++ b/locale/bo.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/br.js
+++ b/locale/br.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/bs.js
+++ b/locale/bs.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ca.js
+++ b/locale/ca.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/cs.js
+++ b/locale/cs.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/cv.js
+++ b/locale/cv.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/cy.js
+++ b/locale/cy.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/da.js
+++ b/locale/da.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/de-at.js
+++ b/locale/de-at.js
@@ -8,7 +8,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/de.js
+++ b/locale/de.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/el.js
+++ b/locale/el.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/en-au.js
+++ b/locale/en-au.js
@@ -5,7 +5,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/en-ca.js
+++ b/locale/en-ca.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/en-gb.js
+++ b/locale/en-gb.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/eo.js
+++ b/locale/eo.js
@@ -8,7 +8,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/es.js
+++ b/locale/es.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/et.js
+++ b/locale/et.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/eu.js
+++ b/locale/eu.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/fa.js
+++ b/locale/fa.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/fi.js
+++ b/locale/fi.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/fo.js
+++ b/locale/fo.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/fr-ca.js
+++ b/locale/fr-ca.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/gl.js
+++ b/locale/gl.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/he.js
+++ b/locale/he.js
@@ -8,7 +8,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/hi.js
+++ b/locale/hi.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/hr.js
+++ b/locale/hr.js
@@ -8,7 +8,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/hu.js
+++ b/locale/hu.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/hy-am.js
+++ b/locale/hy-am.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/id.js
+++ b/locale/id.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/is.js
+++ b/locale/is.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/it.js
+++ b/locale/it.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ja.js
+++ b/locale/ja.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ka.js
+++ b/locale/ka.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/km.js
+++ b/locale/km.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ko.js
+++ b/locale/ko.js
@@ -9,7 +9,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/lb.js
+++ b/locale/lb.js
@@ -10,7 +10,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/lt.js
+++ b/locale/lt.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/lv.js
+++ b/locale/lv.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/mk.js
+++ b/locale/mk.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ml.js
+++ b/locale/ml.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/mr.js
+++ b/locale/mr.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ms-my.js
+++ b/locale/ms-my.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/my.js
+++ b/locale/my.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/nb.js
+++ b/locale/nb.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ne.js
+++ b/locale/ne.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/nl.js
+++ b/locale/nl.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/nn.js
+++ b/locale/nn.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/pt-br.js
+++ b/locale/pt-br.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ro.js
+++ b/locale/ro.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ru.js
+++ b/locale/ru.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/sk.js
+++ b/locale/sk.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/sl.js
+++ b/locale/sl.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/sq.js
+++ b/locale/sq.js
@@ -8,7 +8,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/sr-cyrl.js
+++ b/locale/sr-cyrl.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/sr.js
+++ b/locale/sr.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/ta.js
+++ b/locale/ta.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/th.js
+++ b/locale/th.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/tl-ph.js
+++ b/locale/tl-ph.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/tr.js
+++ b/locale/tr.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/tzm-latn.js
+++ b/locale/tzm-latn.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/tzm.js
+++ b/locale/tzm.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/uk.js
+++ b/locale/uk.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/uz.js
+++ b/locale/uz.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/vi.js
+++ b/locale/vi.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/zh-cn.js
+++ b/locale/zh-cn.js
@@ -7,7 +7,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/locale/zh-tw.js
+++ b/locale/zh-tw.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('../moment')); // Node
+        module.exports = factory(require('moment')); // Node
     } else {
         factory(window.moment); // Browser global
     }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
         "karma-chrome-launcher": "latest",
         "karma-firefox-launcher": "latest",
         "karma-nodeunit": "latest",
-        "karma-sauce-launcher": "latest"
+        "karma-sauce-launcher": "latest",
+        "grunt-shell": "latest"
     },
     "scripts": {
         "test": "grunt test:node"


### PR DESCRIPTION
This PR rewrote all `require('../moment')` to `require('moment')`

The reason is to decouple the locales from the moment.js file. 
This could cause problems in browser environment, because locale files are not always bundled with moment.js, so there should be no relative relation anymore.

In Node.js envirnoment this works fine, because node will lookup moment in the node_modules directory. Also browserify still works.

This makes it easier for tools which use `require` in browser environment to load moment. To get it working the namespace/path `moment` must be registered, instead of `../moment`