### PR TITLE
Handle moment.utc(s) fallback

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1779,7 +1779,7 @@
         'release. Please refer to ' +
         'https://github.com/moment/moment/issues/1407 for more info.',
         function (config) {
-            config._d = new Date(config._i);
+            config._d = new Date(config._i + (config._useUTC ? ' UTC' : ''));
         }
     );
 


### PR DESCRIPTION
Fixes #1983

Note - I attempted to write a test for this, but it's difficult since we normally swap out the `createFromInputFallback` function in the unit tests.
