### PR TITLE
Fix makeAs to work with zoned moments

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -776,8 +776,18 @@
 
     // Return a moment from input, that is local/utc/zone equivalent to model.
     function makeAs(input, model) {
-        return model._isUTC ? moment(input).zone(model._offset || 0) :
-            moment(input).local();
+        var res, diff;
+        if (model._isUTC) {
+            res = model.clone();
+            diff = (moment.isMoment(input) || isDate(input) ?
+                    +input : +moment(input)) - (+res);
+            // Use low-level api, because this fn is low-level api.
+            res._d.setTime(+res._d + diff);
+            moment.updateOffset(res, false);
+            return res;
+        } else {
+            return moment(input).local();
+        }
     }
 
     /************************************


### PR DESCRIPTION
Clone the model to get all plugin data (like zones), than move the time so that
it matches the input and recompute the timezone.

Closes #1952, #1956, #1772
