### PR TITLE
Use native toISOString when we can

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2091,7 +2091,12 @@
         toISOString : function () {
             var m = moment(this).utc();
             if (0 < m.year() && m.year() <= 9999) {
-                return formatMoment(m, 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
+                if ('function' === typeof Date.prototype.toISOString) {
+                    // native implementation is ~50x faster, use it when we can
+                    return this.toDate().toISOString();
+                } else {
+                    return formatMoment(m, 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
+                }
             } else {
                 return formatMoment(m, 'YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
             }


### PR DESCRIPTION
The main idea is to take advantage of the speed in the native .toISOString when possible.

The node tests pass and I hope that there is CI coverage of browsers.  Please let me now if you'd like anything more or if you'd like anything different.

Related to issue #1999 
