### PR TITLE
Update deprecation warning for moment().lang()

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2485,7 +2485,7 @@
         },
 
         lang : deprecate(
-            'moment().lang() is deprecated. Use moment().localeData() instead.',
+            'moment().lang() is deprecated. Instead, use moment().localeData() to get the language configuration. Use moment().locale() to change languages.',
             function (key) {
                 if (key === undefined) {
                     return this.localeData();


### PR DESCRIPTION
Our advice for users should match our implementation of the compatibility shim, which uses `moment().localeData()` as a getter and `moment().locale()` as a setter.

Based on discussion in #1879.
