### PR TITLE
Quarter diff

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2162,7 +2162,7 @@
 
             units = normalizeUnits(units);
 
-            if (units === 'year' || units === 'month') {
+            if (units === 'year' || units === 'month' || units === 'quarter') {
                 // average number of days in the months in the given dates
                 diff = (this.daysInMonth() + that.daysInMonth()) * 432e5; // 24 * 60 * 60 * 1000 / 2
                 // difference in months
@@ -2177,6 +2177,8 @@
                 output += daysAdjust / diff;
                 if (units === 'year') {
                     output = output / 12;
+                } else if (units === 'quarter') {
+                    output = output / 4;
                 }
             } else {
                 diff = (this - that);

--- a/test/moment/diff.js
+++ b/test/moment/diff.js
@@ -32,6 +32,15 @@ function dstForYear(year) {
     }
 }
 
+function forEachMonthPair(callback) {
+    var m1, m2;
+    for (m1 = 0; m1 < 12; ++m1) {
+        for (m2 = m1; m2 < 12; ++m2) {
+            callback(m1, m2);
+        }
+    }
+}
+
 exports.diff = {
     setUp : function (done) {
         moment.createFromInputFallback = function () {
@@ -227,16 +236,20 @@ exports.diff = {
     },
 
     'exact month diffs' : function (test) {
-        // generate all pairs of months and compute month diff, with fixed day
-        // of month = 15.
+        forEachMonthPair(function (m1, m2) {
+            test.equal(moment([2013, m2, 15]).diff(moment([2013, m1, 15]), 'months', true), m2 - m1,
+                    'month diff from 2013-' + m1 + '-15 to 2013-' + m2 + '-15');
+        });
 
-        var m1, m2;
-        for (m1 = 0; m1 < 12; ++m1) {
-            for (m2 = m1; m2 < 12; ++m2) {
-                test.equal(moment([2013, m2, 15]).diff(moment([2013, m1, 15]), 'months', true), m2 - m1,
-                        'month diff from 2013-' + m1 + '-15 to 2013-' + m2 + '-15');
-            }
-        }
+        test.done();
+    },
+
+    'quarter diffs' : function (test) {
+        forEachMonthPair(function (m1, m2) {
+            test.equal(moment([2013, m2, 15]).diff(moment([2013, m1, 15]), 'quarter'), Math.floor((m2 - m1) / 4),
+                    'quarter diff from 2013-' + m1 + '-15 to 2013-' + m2 + '-15');
+        });
+
         test.done();
     },
 


### PR DESCRIPTION
Possible fix for #1991. ALTHOUGH, this is the most naive solution for a quarter diff. But I think there are two ways to do a "quarter diff" that make sense.

* Two dates are a quarter apart if they're four months apart (the one implemented in this PR).
* Two dates are a quarter apart if they're in different quarters (e.g. March 31st and April 1st are one quarter apart since they are on the first and second quarters of the year). This one is probably marginally more complex to implement, and also wouldn't have a sensible result when the third parameter for `diff` is `true`.

