### PR TITLE
Strip 'Uhr' suffix from localized formats (in german locales)

### DIFF
--- a/locale/de-at.js
+++ b/locale/de-at.js
@@ -34,19 +34,19 @@
         weekdaysShort : 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
         weekdaysMin : 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
         longDateFormat : {
-            LT: 'HH:mm [Uhr]',
+            LT: 'HH:mm',
             L : 'DD.MM.YYYY',
             LL : 'D. MMMM YYYY',
             LLL : 'D. MMMM YYYY LT',
             LLLL : 'dddd, D. MMMM YYYY LT'
         },
         calendar : {
-            sameDay: '[Heute um] LT',
+            sameDay: '[Heute um] LT [Uhr]',
             sameElse: 'L',
-            nextDay: '[Morgen um] LT',
-            nextWeek: 'dddd [um] LT',
-            lastDay: '[Gestern um] LT',
-            lastWeek: '[letzten] dddd [um] LT'
+            nextDay: '[Morgen um] LT [Uhr]',
+            nextWeek: 'dddd [um] LT [Uhr]',
+            lastDay: '[Gestern um] LT [Uhr]',
+            lastWeek: '[letzten] dddd [um] LT [Uhr]'
         },
         relativeTime : {
             future : 'in %s',

--- a/locale/de.js
+++ b/locale/de.js
@@ -33,19 +33,19 @@
         weekdaysShort : 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
         weekdaysMin : 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
         longDateFormat : {
-            LT: 'HH:mm [Uhr]',
+            LT: 'HH:mm',
             L : 'DD.MM.YYYY',
             LL : 'D. MMMM YYYY',
             LLL : 'D. MMMM YYYY LT',
             LLLL : 'dddd, D. MMMM YYYY LT'
         },
         calendar : {
-            sameDay: '[Heute um] LT',
+            sameDay: '[Heute um] LT [Uhr]',
             sameElse: 'L',
-            nextDay: '[Morgen um] LT',
-            nextWeek: 'dddd [um] LT',
-            lastDay: '[Gestern um] LT',
-            lastWeek: '[letzten] dddd [um] LT'
+            nextDay: '[Morgen um] LT [Uhr]',
+            nextWeek: 'dddd [um] LT [Uhr]',
+            lastDay: '[Gestern um] LT [Uhr]',
+            lastWeek: '[letzten] dddd [um] LT [Uhr]'
         },
         relativeTime : {
             future : 'in %s',

--- a/test/locale/de-at.js
+++ b/test/locale/de-at.js
@@ -62,12 +62,12 @@ exports['locale:de-at'] = {
                 ['[the] DDDo [day of the year]', 'the 45. day of the year'],
                 ['L', '14.02.2010'],
                 ['LL', '14. Februar 2010'],
-                ['LLL', '14. Februar 2010 15:25 Uhr'],
-                ['LLLL', 'Sonntag, 14. Februar 2010 15:25 Uhr'],
+                ['LLL', '14. Februar 2010 15:25'],
+                ['LLLL', 'Sonntag, 14. Februar 2010 15:25'],
                 ['l', '14.2.2010'],
                 ['ll', '14. Febr. 2010'],
-                ['lll', '14. Febr. 2010 15:25 Uhr'],
-                ['llll', 'So., 14. Febr. 2010 15:25 Uhr']
+                ['lll', '14. Febr. 2010 15:25'],
+                ['llll', 'So., 14. Febr. 2010 15:25']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;
@@ -203,11 +203,11 @@ exports['locale:de-at'] = {
         var i, m;
         for (i = 2; i < 7; i++) {
             m = moment().add({d: i});
-            test.equal(m.calendar(), m.format('dddd [um] LT'), 'Today + ' + i + ' days current time');
+            test.equal(m.calendar(), m.format('dddd [um] LT [Uhr]'), 'Today + ' + i + ' days current time');
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(), m.format('dddd [um] LT'), 'Today + ' + i + ' days beginning of day');
+            test.equal(m.calendar(), m.format('dddd [um] LT [Uhr]'), 'Today + ' + i + ' days beginning of day');
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(), m.format('dddd [um] LT'), 'Today + ' + i + ' days end of day');
+            test.equal(m.calendar(), m.format('dddd [um] LT [Uhr]'), 'Today + ' + i + ' days end of day');
         }
         test.done();
     },
@@ -218,11 +218,11 @@ exports['locale:de-at'] = {
         var i, m;
         for (i = 2; i < 7; i++) {
             m = moment().subtract({d: i});
-            test.equal(m.calendar(), m.format('[letzten] dddd [um] LT'), 'Today + ' + i + ' days current time');
+            test.equal(m.calendar(), m.format('[letzten] dddd [um] LT [Uhr]'), 'Today + ' + i + ' days current time');
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(), m.format('[letzten] dddd [um] LT'), 'Today + ' + i + ' days beginning of day');
+            test.equal(m.calendar(), m.format('[letzten] dddd [um] LT [Uhr]'), 'Today + ' + i + ' days beginning of day');
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(), m.format('[letzten] dddd [um] LT'), 'Today + ' + i + ' days end of day');
+            test.equal(m.calendar(), m.format('[letzten] dddd [um] LT [Uhr]'), 'Today + ' + i + ' days end of day');
         }
         test.done();
     },

--- a/test/locale/de.js
+++ b/test/locale/de.js
@@ -56,12 +56,12 @@ exports['locale:de'] = {
                 ['[the] DDDo [day of the year]',       'the 45. day of the year'],
                 ['L',                                  '14.02.2010'],
                 ['LL',                                 '14. Februar 2010'],
-                ['LLL',                                '14. Februar 2010 15:25 Uhr'],
-                ['LLLL',                               'Sonntag, 14. Februar 2010 15:25 Uhr'],
+                ['LLL',                                '14. Februar 2010 15:25'],
+                ['LLLL',                               'Sonntag, 14. Februar 2010 15:25'],
                 ['l',                                  '14.2.2010'],
                 ['ll',                                 '14. Febr. 2010'],
-                ['lll',                                '14. Febr. 2010 15:25 Uhr'],
-                ['llll',                               'So., 14. Febr. 2010 15:25 Uhr']
+                ['lll',                                '14. Febr. 2010 15:25'],
+                ['llll',                               'So., 14. Febr. 2010 15:25']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;
@@ -186,11 +186,11 @@ exports['locale:de'] = {
         var i, m;
         for (i = 2; i < 7; i++) {
             m = moment().add({d: i});
-            test.equal(m.calendar(),       m.format('dddd [um] LT'),  'Today + ' + i + ' days current time');
+            test.equal(m.calendar(),       m.format('dddd [um] LT [Uhr]'),  'Today + ' + i + ' days current time');
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('dddd [um] LT'),  'Today + ' + i + ' days beginning of day');
+            test.equal(m.calendar(),       m.format('dddd [um] LT [Uhr]'),  'Today + ' + i + ' days beginning of day');
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('dddd [um] LT'),  'Today + ' + i + ' days end of day');
+            test.equal(m.calendar(),       m.format('dddd [um] LT [Uhr]'),  'Today + ' + i + ' days end of day');
         }
         test.done();
     },
@@ -199,11 +199,11 @@ exports['locale:de'] = {
         var i, m;
         for (i = 2; i < 7; i++) {
             m = moment().subtract({d: i});
-            test.equal(m.calendar(),       m.format('[letzten] dddd [um] LT'),  'Today + ' + i + ' days current time');
+            test.equal(m.calendar(),       m.format('[letzten] dddd [um] LT [Uhr]'),  'Today + ' + i + ' days current time');
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[letzten] dddd [um] LT'),  'Today + ' + i + ' days beginning of day');
+            test.equal(m.calendar(),       m.format('[letzten] dddd [um] LT [Uhr]'),  'Today + ' + i + ' days beginning of day');
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[letzten] dddd [um] LT'),  'Today + ' + i + ' days end of day');
+            test.equal(m.calendar(),       m.format('[letzten] dddd [um] LT [Uhr]'),  'Today + ' + i + ' days end of day');
         }
         test.done();
     },


### PR DESCRIPTION
The 'Uhr' suffix is not as part of a time string as 'AM'/'PM' would be.
So remove it from the localized formats (LT, LLL and LLLL) but keep it
in calendar time.
Also update the tests.

closes issue #2006
