### PR TITLE
adding Duration.preciseHumanize to return precise human-readable duration

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2666,6 +2666,40 @@
             return this.localeData().postformat(output);
         },
 
+        preciseHumanize : function (withSuffix) {
+            var isFuture = this._milliseconds < 0,
+                duration = this.abs()._data,
+                locale = this.localeData(),
+                addRelative = function (number, string) {
+                    if (number === 0) {
+                        return;
+                    }
+                    output.push(locale.relativeTime(
+                        number,
+                        !withSuffix,
+                        number > 1 ? (string + string) : string,
+                        isFuture
+                    ));
+                },
+                output = [];
+
+            addRelative(duration.years, 'y');
+            addRelative(duration.months, 'M');
+            addRelative(duration.days, 'd');
+            addRelative(duration.hours, 'h');
+            addRelative(duration.minutes, 'm');
+            if (duration.seconds > 0) {
+                output.push(locale.relativeTime(duration.seconds, !withSuffix, 's', isFuture));
+            }
+            output = output.join(' ');
+
+            if (withSuffix) {
+                output = this.localeData().pastFuture(isFuture ? -1 : 1, output);
+            }
+
+            return this.localeData().postformat(output);
+        },
+
         add : function (input, val) {
             // supports only 2.0-style add(1, 's') or add(moment)
             var dur = moment.duration(input, val);

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -397,6 +397,30 @@ exports.duration = {
         test.done();
     },
 
+    'preciseHumanize' : function (test) {
+        test.expect(9);
+        moment.locale('en');
+        test.equal(moment.duration({seconds: 1}).preciseHumanize(),   'a few seconds',          '1 seconds = a few seconds');
+        test.equal(moment.duration({seconds: 89}).preciseHumanize(),  'a minute a few seconds', '89 seconds = a minute a few seconds');
+        test.equal(moment.duration({seconds: 180}).preciseHumanize(), '3 minutes',              '180 seconds = 3 minutes');
+        test.equal(moment.duration({minutes: 98}).preciseHumanize(),  'an hour 38 minutes',     '98 minutes = an hour 38 minutes');
+        test.equal(moment.duration({hours: 50}).preciseHumanize(),    '2 days 2 hours',         '50 hours = 2 days 2 hours');
+        test.equal(moment.duration({days: 31}).preciseHumanize(),     'a month a day',          '31 days = a month a day');
+        test.equal(moment.duration({weeks: 5}).preciseHumanize(),     'a month 5 days',         '5 weeks = a month 5 days');
+        test.equal(moment.duration({months: 18}).preciseHumanize(),   'a year 6 months',        '18 months = a year 6 months');
+        test.equal(moment.duration({milliseconds: 34218070000}).preciseHumanize(), 'a year a month a day an hour a minute a few seconds',  '34218070000 milliseconds = a year a month a day an hour a minute a few seconds');
+        // 34218070000 = ((((365+30+1)*24 + 1)*60 + 1)*60 + 10)*1E3
+        test.done();
+    },
+
+    'preciseHumanize duration with suffix' : function (test) {
+        test.expect(2);
+        moment.locale('en');
+        test.equal(moment.duration({minutes:  89}).preciseHumanize(true),  'in an hour 29 minutes',  '89 seconds = in an hour 29 minutes');
+        test.equal(moment.duration({minutes: -89}).preciseHumanize(true),  'an hour 29 minutes ago', '-89 seconds = an hour 29 minutes ago');
+        test.done();
+    },
+
     'bubble value up' : function (test) {
         test.expect(5);
         test.equal(moment.duration({milliseconds: 61001}).milliseconds(), 1, '61001 milliseconds has 1 millisecond left over');


### PR DESCRIPTION
inspired by http://codebox.org.uk/pages/moment-date-range-plugin but with better fitting into the existing code
