### PR TITLE
Remove ['client','server'] from meteor/package.js

### DIFF
--- a/meteor/package.js
+++ b/meteor/package.js
@@ -9,13 +9,12 @@ Package.onUse(function (api) {
   api.versionsFrom('0.9.0');
   api.addFiles([
     'moment.js'
-  ], ['client', 'server']
-  );
+  ]);
 });
 
 Package.onTest(function (api) {
-  api.use('moment', ['client', 'server']);
-  api.use('tinytest', ['client', 'server']);
+  api.use('moment');
+  api.use('tinytest');
 
-  api.addFiles('meteor/test.js', ['client', 'server']);
+  api.addFiles('meteor/test.js');
 });


### PR DESCRIPTION
Architecture is only necessary if you want only client or server or if you want to use the third options argument.
