### PR TITLE
Explicit dependency array to make AMD definition Dojo-Loader-compatible

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2921,7 +2921,7 @@
     if (hasModule) {
         module.exports = moment;
     } else if (typeof define === 'function' && define.amd) {
-        define('moment', function (require, exports, module) {
+        define('moment', ['require', 'exports', 'module'], function (require, exports, module) {
             if (module.config && module.config() && module.config().noGlobal === true) {
                 // release the global variable
                 globalScope.moment = oldGlobalMoment;


### PR DESCRIPTION
Dojo Loader doesn't like the explicit module name syntax with implicit dependencies:

```
define('moment', function (require, exports, module) { 
```

It's however OK when everything is implicit:

```
define(function (require, exports, module) { 
```

But, then the implicit module name could cause problems with Moment plugins if the path to Moment is mapped to a module other than 'moment'. So, a more compatible fix would be to declare the dependencies explicitly (both RequireJS and Dojo Loader are OK with this syntax):

```
define('moment', ['require', 'exports', 'module'], function (require, exports, module) {
```
