### PR TITLE
Create valid duration object when null is passed to moment.duration()

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -1958,6 +1958,8 @@
                 s: parseIso(match[7]),
                 w: parseIso(match[8])
             };
+        } else if (duration == null) {// checks for null or undefined
+            duration = {};
         } else if (typeof duration === 'object' &&
                 ('from' in duration || 'to' in duration)) {
             diffRes = momentsDifference(moment(duration.from), moment(duration.to));

--- a/test/moment/duration.js
+++ b/test/moment/duration.js
@@ -62,6 +62,18 @@ exports.duration = {
         test.done();
     },
 
+    'undefined instantiation' : function (test) {
+        test.expect(1);
+        test.equal(moment.duration(undefined).milliseconds(), 0, 'milliseconds');
+        test.done();
+    },
+
+    'null instantiation' : function (test) {
+        test.expect(1);
+        test.equal(moment.duration(null).milliseconds(), 0, 'milliseconds');
+        test.done();
+    },
+
     'instantiation by type' : function (test) {
         test.expect(16);
         test.equal(moment.duration(1, 'years').years(),                 1, 'years');


### PR DESCRIPTION
Fixes https://github.com/moment/moment/issues/2101.
