### PR TITLE
Add globalScope hack to more reliably distinguish Node vs browser

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -12,7 +12,7 @@
     var moment,
         VERSION = '2.8.4',
         // the global-scope this is NOT the global object in Node.js
-        globalScope = typeof global !== 'undefined' ? global : this,
+        globalScope = (typeof global !== 'undefined' && (typeof window === 'undefined' || window === global.window)) ? global : this,
         oldGlobalMoment,
         round = Math.round,
         hasOwnProperty = Object.prototype.hasOwnProperty,


### PR DESCRIPTION
Browser-based apps that have DOM nodes with the id "global" were being detected as Node apps for purposes of assigning moment to the runtime's global namespace.  This change is intended to fix that issue for most practical use cases, hopefully without breaking anyone's existing usage.

Algorithm:  If `global` is not defined, then we want to use `window`.  If `global` is defined but `window` is not, then we want to use `global`.  If both `global` and `window` are defined, then we want to assign to `global` if `window === global.window` -- otherwise we assume that `global === window.global`, in which case we want to assign to `window`.

This is an actually working version of my suggestion from #2092.
