### PR TITLE
Adding moment.to (similar to moment.from)

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2260,6 +2260,10 @@
             return moment.duration({to: this, from: time}).locale(this.locale()).humanize(!withoutSuffix);
         },
 
+        to : function (time, withoutSuffix) {
+            return moment.duration({from: this, to: time}).locale(this.locale()).humanize(!withoutSuffix);
+        },
+
         fromNow : function (withoutSuffix) {
             return this.from(moment(), withoutSuffix);
         },


### PR DESCRIPTION
Newly added `moment.to` is similar to `moment.from`, but the result is reversed as the relativity of dates are considered.

```
var today = moment();
var dayafter = moment(today).add(2, 'd');

console.log(today.from(dayafter));       // 2 days ago
console.log(today.to(dayafter));         // in 2 days
console.log(today.to(dayafter, true));   // 2 days
```