### PR TITLE
Talossan (tzl) translation

### DIFF
--- a/locale/tzl.js
+++ b/locale/tzl.js
@@ -23,7 +23,7 @@
             'M': ['\'n mes', '\'iens mes'],
             'MM': [number + ' mesen', ' ' + number + ' mesen'],
             'y': ['\'n ar', '\'iens ar'],
-            'yy': [number + ' ars', ' ' + number + ' ars'],
+            'yy': [number + ' ars', ' ' + number + ' ars']
         };
         return isFuture ? format[key][0] : format[key][1];
     }
@@ -41,6 +41,13 @@
             LL : 'D. MMMM [dallas] YYYY',
             LLL : 'D. MMMM [dallas] YYYY LT',
             LLLL : 'dddd, [li] D. MMMM [dallas] YYYY LT'
+        },
+        meridiem : function (hours, minutes, isLower) {
+            if (hours > 11) {
+                return isLower ? 'd\'o' : 'D\'O';
+            } else {
+                return isLower ? 'd\'a' : 'D\'A';
+            }
         },
         calendar : {
             sameDay : '[oxhi à] LT',

--- a/locale/tzl.js
+++ b/locale/tzl.js
@@ -11,6 +11,23 @@
         factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
     }
 }(function (moment) {
+    function processRelativeTime(number, withoutSuffix, key, isFuture) {
+        var format = {
+            's': ['viensas secunds', '\'iensas secunds'],
+            'm': ['\'n míut', '\'iens míut'],
+            'mm': [number + ' míuts', ' ' + number + ' míuts'],
+            'h': ['\'n þora', '\'iensa þora'],
+            'hh': [number + ' þoras', ' ' + number + ' þoras'],
+            'd': ['\'n ziua', '\'iensa ziua'],
+            'dd': [number + ' ziuas', ' ' + number + ' ziuas'],
+            'M': ['\'n mes', '\'iens mes'],
+            'MM': [number + ' mesen', ' ' + number + ' mesen'],
+            'y': ['\'n ar', '\'iens ar'],
+            'yy': [number + ' ars', ' ' + number + ' ars'],
+        };
+        return isFuture ? format[key][0] : format[key][1];
+    }
+
     return moment.defineLocale('tzl', {
         months : 'Januar_Fevraglh_Març_Avrïu_Mai_Gün_Julia_Guscht_Setemvar_Listopäts_Noemvar_Zecemvar'.split('_'),
         monthsShort : 'Jan_Fev_Mar_Avr_Mai_Gün_Jul_Gus_Set_Lis_Noe_Zec'.split('_'),
@@ -34,19 +51,19 @@
             sameElse : 'L'
         },
         relativeTime : {
-            future : 'in %s',
-            past : '%s ago',
-            s : 'a few seconds',
-            m : 'a minute',
-            mm : '%d minutes',
-            h : 'an hour',
-            hh : '%d hours',
-            d : 'a day',
-            dd : '%d days',
-            M : 'a month',
-            MM : '%d months',
-            y : 'a year',
-            yy : '%d years'
+            future : 'osprei %s',
+            past : 'ja%s',
+            s : processRelativeTime,
+            m : processRelativeTime,
+            mm : processRelativeTime,
+            h : processRelativeTime,
+            hh : processRelativeTime,
+            d : processRelativeTime,
+            dd : processRelativeTime,
+            M : processRelativeTime,
+            MM : processRelativeTime,
+            y : processRelativeTime,
+            yy : processRelativeTime
         },
         ordinalParse: /\d{1,2}\./,
         ordinal : '%d.',

--- a/locale/tzl.js
+++ b/locale/tzl.js
@@ -25,7 +25,7 @@
             'y': ['\'n ar', '\'iens ar'],
             'yy': [number + ' ars', ' ' + number + ' ars']
         };
-        return isFuture ? format[key][0] : format[key][1];
+        return isFuture ? format[key][0] : (withoutSuffix ? format[key][1] : format[key][1].trim());
     }
 
     // After the year there should be a slash and the amount of years since December 26, 1979 in Roman numerals.

--- a/locale/tzl.js
+++ b/locale/tzl.js
@@ -28,6 +28,8 @@
         return isFuture ? format[key][0] : format[key][1];
     }
 
+    // After the year there should be a slash and the amount of years since December 26, 1979 in Roman numerals.
+    // This is currently too difficult (maybe even impossible) to add.
     return moment.defineLocale('tzl', {
         months : 'Januar_Fevraglh_Març_Avrïu_Mai_Gün_Julia_Guscht_Setemvar_Listopäts_Noemvar_Zecemvar'.split('_'),
         monthsShort : 'Jan_Fev_Mar_Avr_Mai_Gün_Jul_Gus_Set_Lis_Noe_Zec'.split('_'),

--- a/locale/tzl.js
+++ b/locale/tzl.js
@@ -1,0 +1,58 @@
+// moment.js locale configuration
+// locale : talossan (tzl)
+// author : Robin van der Vliet : https://github.com/robin0van0der0v with the help of Iustì Canun
+
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['moment'], factory); // AMD
+    } else if (typeof exports === 'object') {
+        module.exports = factory(require('../moment')); // Node
+    } else {
+        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+    }
+}(function (moment) {
+    return moment.defineLocale('tzl', {
+        months : 'Januar_Fevraglh_Març_Avrïu_Mai_Gün_Julia_Guscht_Setemvar_Listopäts_Noemvar_Zecemvar'.split('_'),
+        monthsShort : 'Jan_Fev_Mar_Avr_Mai_Gün_Jul_Gus_Set_Lis_Noe_Zec'.split('_'),
+        weekdays : 'Súladi_Lúneçi_Maitzi_Márcuri_Xhúadi_Viénerçi_Sáturi'.split('_'),
+        weekdaysShort : 'Súl_Lún_Mai_Már_Xhú_Vié_Sát'.split('_'),
+        weekdaysMin : 'Sú_Lú_Ma_Má_Xh_Vi_Sá'.split('_'),
+        longDateFormat : {
+            LT : 'HH.mm',
+            LTS : 'LT.ss',
+            L : 'DD.MM.YYYY',
+            LL : 'D. MMMM [dallas] YYYY',
+            LLL : 'D. MMMM [dallas] YYYY LT',
+            LLLL : 'dddd, [li] D. MMMM [dallas] YYYY LT'
+        },
+        calendar : {
+            sameDay : '[oxhi à] LT',
+            nextDay : '[demà à] LT',
+            nextWeek : 'dddd [à] LT',
+            lastDay : '[ieiri à] LT',
+            lastWeek : '[sür el] dddd [lasteu à] LT',
+            sameElse : 'L'
+        },
+        relativeTime : {
+            future : 'in %s',
+            past : '%s ago',
+            s : 'a few seconds',
+            m : 'a minute',
+            mm : '%d minutes',
+            h : 'an hour',
+            hh : '%d hours',
+            d : 'a day',
+            dd : '%d days',
+            M : 'a month',
+            MM : '%d months',
+            y : 'a year',
+            yy : '%d years'
+        },
+        ordinalParse: /\d{1,2}\./,
+        ordinal : '%d.',
+        week : {
+            dow : 1, // Monday is the first day of the week.
+            doy : 4  // The week that contains Jan 4th is the first week of the year.
+        }
+    });
+}));

--- a/test/locale/tzl.js
+++ b/test/locale/tzl.js
@@ -5,9 +5,9 @@ var moment = require('../../moment');
       Talossan
      *************************************************/
 
-exports['locale:tlz'] = {
+exports['locale:tzl'] = {
     setUp : function (cb) {
-        moment.locale('tlz');
+        moment.locale('tzl');
         moment.createFromInputFallback = function () {
             throw new Error('input not handled by moment');
         };

--- a/test/locale/tzl.js
+++ b/test/locale/tzl.js
@@ -40,29 +40,29 @@ exports['locale:tzl'] = {
 
     'format' : function (test) {
         var a = [
-                ['dddd, MMMM Do YYYY, h:mm:ss a',      'Súladi, Súl 14th 2010, 3:25:50 pm'],
+                ['dddd, MMMM Do YYYY, h:mm:ss a',      'Súladi, Súl 14. 2010, 3.25.50 pm'],
                 ['ddd, hA',                            'Súl, 3D\'O'],
                 ['M Mo MM MMMM MMM',                   '2 2nd 02 Fevraglh Fev'],
                 ['YYYY YY',                            '2010 10'],
-                ['D Do DD',                            '14 14th 14'],
-                ['d do dddd ddd dd',                   '0 0th Súladi Súl Sú'],
-                ['DDD DDDo DDDD',                      '45 45th 045'],
-                ['w wo ww',                            '6 6th 06'],
+                ['D Do DD',                            '14 14. 14'],
+                ['d do dddd ddd dd',                   '0 0. Súladi Súl Sú'],
+                ['DDD DDDo DDDD',                      '45 45. 045'],
+                ['w wo ww',                            '6 6. 06'],
                 ['h hh',                               '3 03'],
                 ['H HH',                               '15 15'],
                 ['m mm',                               '25 25'],
                 ['s ss',                               '50 50'],
                 ['a A',                                'd\'o D\'O'],
-                ['[the] DDDo [day of the year]',       'the 45th day of the year'],
-                ['LTS',                                '15:25:50'],
-                ['L',                                  '14/02/2010'],
-                ['LL',                                 '14 Fevraglh 2010'],
-                ['LLL',                                '14 Fevraglh 2010 15:25'],
-                ['LLLL',                               'Súladi, 14 Fevraglh 2010 15:25'],
-                ['l',                                  '14/2/2010'],
-                ['ll',                                 '14 Fev 2010'],
-                ['lll',                                '14 Fev 2010 15:25'],
-                ['llll',                               'Súl, 14 Fev 2010 15:25']
+                ['[the] DDDo [day of the year]',       'the 45. day of the year'],
+                ['LTS',                                '15.25.50'],
+                ['L',                                  '14.02.2010'],
+                ['LL',                                 '14. Fevraglh 2010'],
+                ['LLL',                                '14. Fevraglh 2010 15.25'],
+                ['LLLL',                               'Súladi, li 14. Fevraglh 2010 15.25'],
+                ['l',                                  '14.2.2010'],
+                ['ll',                                 '14. Fev dallas 2010'],
+                ['lll',                                '14. Fev dallas 2010 15.25'],
+                ['llll',                               'Súl, 14. Fev dallas 2010 15.25']
             ],
             b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
             i;
@@ -179,12 +179,12 @@ exports['locale:tzl'] = {
     'calendar day' : function (test) {
         var a = moment().hours(2).minutes(0).seconds(0);
 
-        test.equal(moment(a).calendar(),                     'oxhi à 02:00',      'today at the same time');
-        test.equal(moment(a).add({m: 25}).calendar(),      'oxhi à 02:25',      'Now plus 25 min');
-        test.equal(moment(a).add({h: 1}).calendar(),       'oxhi à 03:00',      'Now plus 1 hour');
-        test.equal(moment(a).add({d: 1}).calendar(),       'demà à 02:00',   'tomorrow at the same time');
-        test.equal(moment(a).subtract({h: 1}).calendar(),  'oxhi à 01:00',      'Now minus 1 hour');
-        test.equal(moment(a).subtract({d: 1}).calendar(),  'ieiri à 02:00',  'yesterday at the same time');
+        test.equal(moment(a).calendar(),                     'oxhi à 02.00',      'today at the same time');
+        test.equal(moment(a).add({m: 25}).calendar(),      'oxhi à 02.25',      'Now plus 25 min');
+        test.equal(moment(a).add({h: 1}).calendar(),       'oxhi à 03.00',      'Now plus 1 hour');
+        test.equal(moment(a).add({d: 1}).calendar(),       'demà à 02.00',   'tomorrow at the same time');
+        test.equal(moment(a).subtract({h: 1}).calendar(),  'oxhi à 01.00',      'Now minus 1 hour');
+        test.equal(moment(a).subtract({d: 1}).calendar(),  'ieiri à 02.00',  'yesterday at the same time');
         test.done();
     },
 
@@ -206,11 +206,11 @@ exports['locale:tzl'] = {
 
         for (i = 2; i < 7; i++) {
             m = moment().subtract({d: i});
-            test.equal(m.calendar(),       m.format('[sür el] dddd [à] LT'),  'Today - ' + i + ' days current time');
+            test.equal(m.calendar(),       m.format('[sür el] dddd [lasteu à] LT'),  'Today - ' + i + ' days current time');
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[sür el] dddd [à] LT'),  'Today - ' + i + ' days beginning of day');
+            test.equal(m.calendar(),       m.format('[sür el] dddd [lasteu à] LT'),  'Today - ' + i + ' days beginning of day');
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[sür el] dddd [à] LT'),  'Today - ' + i + ' days end of day');
+            test.equal(m.calendar(),       m.format('[sür el] dddd [lasteu à] LT'),  'Today - ' + i + ' days end of day');
         }
         test.done();
     },
@@ -310,11 +310,11 @@ exports['locale:tzl'] = {
     },
 
     'weeks year starting sunday formatted' : function (test) {
-        test.equal(moment([2012, 0,  1]).format('w ww wo'), '52 52 52nd', 'Jan  1 2012 should be week 52');
-        test.equal(moment([2012, 0,  2]).format('w ww wo'),   '1 01 1st', 'Jan  2 2012 should be week 1');
-        test.equal(moment([2012, 0,  8]).format('w ww wo'),   '1 01 1st', 'Jan  8 2012 should be week 1');
-        test.equal(moment([2012, 0,  9]).format('w ww wo'),   '2 02 2nd', 'Jan  9 2012 should be week 2');
-        test.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2nd', 'Jan 15 2012 should be week 2');
+        test.equal(moment([2012, 0,  1]).format('w ww wo'), '52 52 52.', 'Jan  1 2012 should be week 52');
+        test.equal(moment([2012, 0,  2]).format('w ww wo'),   '1 01 1.', 'Jan  2 2012 should be week 1');
+        test.equal(moment([2012, 0,  8]).format('w ww wo'),   '1 01 1.', 'Jan  8 2012 should be week 1');
+        test.equal(moment([2012, 0,  9]).format('w ww wo'),   '2 02 2.', 'Jan  9 2012 should be week 2');
+        test.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2.', 'Jan 15 2012 should be week 2');
 
         test.done();
     },

--- a/test/locale/tzl.js
+++ b/test/locale/tzl.js
@@ -1,0 +1,360 @@
+var moment = require('../../moment');
+
+
+    /**************************************************
+      Talossan
+     *************************************************/
+
+exports['locale:tlz'] = {
+    setUp : function (cb) {
+        moment.locale('tlz');
+        moment.createFromInputFallback = function () {
+            throw new Error('input not handled by moment');
+        };
+        cb();
+    },
+
+    tearDown : function (cb) {
+        moment.locale('en');
+        cb();
+    },
+
+    'parse' : function (test) {
+        var tests = 'Januar Jan_Fevraglh Fev_Març Mar_Avrïu Avr_Mai Mai_Gün Gün_Julia Jul_Guscht Gus_Setemvar Set_Listopäts Lis_Noemvar Noe_Zecemvar Zec'.split('_'), i;
+        function equalTest(input, mmm, i) {
+            test.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
+        }
+        for (i = 0; i < 12; i++) {
+            tests[i] = tests[i].split(' ');
+            equalTest(tests[i][0], 'MMM', i);
+            equalTest(tests[i][1], 'MMM', i);
+            equalTest(tests[i][0], 'MMMM', i);
+            equalTest(tests[i][1], 'MMMM', i);
+            equalTest(tests[i][0].toLocaleLowerCase(), 'MMMM', i);
+            equalTest(tests[i][1].toLocaleLowerCase(), 'MMMM', i);
+            equalTest(tests[i][0].toLocaleUpperCase(), 'MMMM', i);
+            equalTest(tests[i][1].toLocaleUpperCase(), 'MMMM', i);
+        }
+        test.done();
+    },
+
+    'format' : function (test) {
+        var a = [
+                ['dddd, MMMM Do YYYY, h:mm:ss a',      'Súladi, Súl 14th 2010, 3:25:50 pm'],
+                ['ddd, hA',                            'Súl, 3D\'O'],
+                ['M Mo MM MMMM MMM',                   '2 2nd 02 Fevraglh Fev'],
+                ['YYYY YY',                            '2010 10'],
+                ['D Do DD',                            '14 14th 14'],
+                ['d do dddd ddd dd',                   '0 0th Súladi Súl Sú'],
+                ['DDD DDDo DDDD',                      '45 45th 045'],
+                ['w wo ww',                            '6 6th 06'],
+                ['h hh',                               '3 03'],
+                ['H HH',                               '15 15'],
+                ['m mm',                               '25 25'],
+                ['s ss',                               '50 50'],
+                ['a A',                                'd\'o D\'O'],
+                ['[the] DDDo [day of the year]',       'the 45th day of the year'],
+                ['LTS',                                '15:25:50'],
+                ['L',                                  '14/02/2010'],
+                ['LL',                                 '14 Fevraglh 2010'],
+                ['LLL',                                '14 Fevraglh 2010 15:25'],
+                ['LLLL',                               'Súladi, 14 Fevraglh 2010 15:25'],
+                ['l',                                  '14/2/2010'],
+                ['ll',                                 '14 Fev 2010'],
+                ['lll',                                '14 Fev 2010 15:25'],
+                ['llll',                               'Súl, 14 Fev 2010 15:25']
+            ],
+            b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
+            i;
+        for (i = 0; i < a.length; i++) {
+            test.equal(b.format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
+        }
+        test.done();
+    },
+
+    'format ordinal' : function (test) {
+        test.equal(moment([2011, 0, 1]).format('DDDo'), '1.', '1.');
+        test.equal(moment([2011, 0, 2]).format('DDDo'), '2.', '2.');
+        test.equal(moment([2011, 0, 3]).format('DDDo'), '3.', '3.');
+        test.equal(moment([2011, 0, 4]).format('DDDo'), '4.', '4.');
+        test.equal(moment([2011, 0, 5]).format('DDDo'), '5.', '5.');
+        test.equal(moment([2011, 0, 6]).format('DDDo'), '6.', '6.');
+        test.equal(moment([2011, 0, 7]).format('DDDo'), '7.', '7.');
+        test.equal(moment([2011, 0, 8]).format('DDDo'), '8.', '8.');
+        test.equal(moment([2011, 0, 9]).format('DDDo'), '9.', '9.');
+        test.equal(moment([2011, 0, 10]).format('DDDo'), '10.', '10.');
+
+        test.equal(moment([2011, 0, 11]).format('DDDo'), '11.', '11.');
+        test.equal(moment([2011, 0, 12]).format('DDDo'), '12.', '12.');
+        test.equal(moment([2011, 0, 13]).format('DDDo'), '13.', '13.');
+        test.equal(moment([2011, 0, 14]).format('DDDo'), '14.', '14.');
+        test.equal(moment([2011, 0, 15]).format('DDDo'), '15.', '15.');
+        test.equal(moment([2011, 0, 16]).format('DDDo'), '16.', '16.');
+        test.equal(moment([2011, 0, 17]).format('DDDo'), '17.', '17.');
+        test.equal(moment([2011, 0, 18]).format('DDDo'), '18.', '18.');
+        test.equal(moment([2011, 0, 19]).format('DDDo'), '19.', '19.');
+        test.equal(moment([2011, 0, 20]).format('DDDo'), '20.', '20.');
+
+        test.equal(moment([2011, 0, 21]).format('DDDo'), '21.', '21.');
+        test.equal(moment([2011, 0, 22]).format('DDDo'), '22.', '22.');
+        test.equal(moment([2011, 0, 23]).format('DDDo'), '23.', '23.');
+        test.equal(moment([2011, 0, 24]).format('DDDo'), '24.', '24.');
+        test.equal(moment([2011, 0, 25]).format('DDDo'), '25.', '25.');
+        test.equal(moment([2011, 0, 26]).format('DDDo'), '26.', '26.');
+        test.equal(moment([2011, 0, 27]).format('DDDo'), '27.', '27.');
+        test.equal(moment([2011, 0, 28]).format('DDDo'), '28.', '28.');
+        test.equal(moment([2011, 0, 29]).format('DDDo'), '29.', '29.');
+        test.equal(moment([2011, 0, 30]).format('DDDo'), '30.', '30.');
+
+        test.equal(moment([2011, 0, 31]).format('DDDo'), '31.', '31.');
+        test.done();
+    },
+
+    'format month' : function (test) {
+        var expected = 'Januar Jan_Fevraglh Fev_Març Mar_Avrïu Avr_Mai Mai_Gün Gün_Julia Jul_Guscht Gus_Setemvar Set_Listopäts Lis_Noemvar Noe_Zecemvar Zec'.split('_'), i;
+        for (i = 0; i < expected.length; i++) {
+            test.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
+        }
+        test.done();
+    },
+
+    'format week' : function (test) {
+        var expected = 'Súladi Súl Sú_Lúneçi Lún Lú_Maitzi Mai Ma_Márcuri Már Má_Xhúadi Xhú Xh_Viénerçi Vié Vi_Sáturi Sát Sá'.split('_'), i;
+        for (i = 0; i < expected.length; i++) {
+            test.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
+        }
+        test.done();
+    },
+
+    'from' : function (test) {
+        var start = moment([2007, 1, 28]);
+        test.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true),  'viensas secunds', '44 seconds = a few seconds');
+        test.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  '\'n míut',      '45 seconds = a minute');
+        test.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  '\'n míut',      '89 seconds = a minute');
+        test.equal(start.from(moment([2007, 1, 28]).add({s: 90}), true),  '2 míuts',     '90 seconds = 2 minutes');
+        test.equal(start.from(moment([2007, 1, 28]).add({m: 44}), true),  '44 míuts',    '44 minutes = 44 minutes');
+        test.equal(start.from(moment([2007, 1, 28]).add({m: 45}), true),  '\'n þora',       '45 minutes = an hour');
+        test.equal(start.from(moment([2007, 1, 28]).add({m: 89}), true),  '\'n þora',       '89 minutes = an hour');
+        test.equal(start.from(moment([2007, 1, 28]).add({m: 90}), true),  '2 þoras',       '90 minutes = 2 hours');
+        test.equal(start.from(moment([2007, 1, 28]).add({h: 5}), true),   '5 þoras',       '5 hours = 5 hours');
+        test.equal(start.from(moment([2007, 1, 28]).add({h: 21}), true),  '21 þoras',      '21 hours = 21 hours');
+        test.equal(start.from(moment([2007, 1, 28]).add({h: 22}), true),  '\'n ziua',         '22 hours = a day');
+        test.equal(start.from(moment([2007, 1, 28]).add({h: 35}), true),  '\'n ziua',         '35 hours = a day');
+        test.equal(start.from(moment([2007, 1, 28]).add({h: 36}), true),  '2 ziuas',        '36 hours = 2 days');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 1}), true),   '\'n ziua',         '1 day = a day');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 5}), true),   '5 ziuas',        '5 days = 5 days');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 25}), true),  '25 ziuas',       '25 days = 25 days');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 26}), true),  '\'n mes',       '26 days = a month');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 30}), true),  '\'n mes',       '30 days = a month');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 43}), true),  '\'n mes',       '43 days = a month');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 46}), true),  '2 mesen',      '46 days = 2 months');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 74}), true),  '2 mesen',      '75 days = 2 months');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 76}), true),  '3 mesen',      '76 days = 3 months');
+        test.equal(start.from(moment([2007, 1, 28]).add({M: 1}), true),   '\'n mes',       '1 month = a month');
+        test.equal(start.from(moment([2007, 1, 28]).add({M: 5}), true),   '5 mesen',      '5 months = 5 months');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 345}), true), '\'n ar',        '345 days = a year');
+        test.equal(start.from(moment([2007, 1, 28]).add({d: 548}), true), '2 ars',       '548 days = 2 years');
+        test.equal(start.from(moment([2007, 1, 28]).add({y: 1}), true),   '\'n ar',        '1 year = a year');
+        test.equal(start.from(moment([2007, 1, 28]).add({y: 5}), true),   '5 ars',       '5 years = 5 years');
+        test.done();
+    },
+
+    'suffix' : function (test) {
+        test.equal(moment(30000).from(0), 'osprei viensas secunds',  'prefix');
+        test.equal(moment(0).from(30000), 'ja\'iensas secunds', 'suffix');
+        test.done();
+    },
+
+    'now from now' : function (test) {
+        test.equal(moment().fromNow(), 'ja\'iensas secunds',  'now from now should display as in the past');
+        test.done();
+    },
+
+    'fromNow' : function (test) {
+        test.equal(moment().add({s: 30}).fromNow(), 'osprei viensas secunds', 'in a few seconds');
+        test.equal(moment().add({d: 5}).fromNow(), 'osprei 5 ziuas', 'in 5 days');
+        test.done();
+    },
+
+    'calendar day' : function (test) {
+        var a = moment().hours(2).minutes(0).seconds(0);
+
+        test.equal(moment(a).calendar(),                     'oxhi à 02:00',      'today at the same time');
+        test.equal(moment(a).add({m: 25}).calendar(),      'oxhi à 02:25',      'Now plus 25 min');
+        test.equal(moment(a).add({h: 1}).calendar(),       'oxhi à 03:00',      'Now plus 1 hour');
+        test.equal(moment(a).add({d: 1}).calendar(),       'demà à 02:00',   'tomorrow at the same time');
+        test.equal(moment(a).subtract({h: 1}).calendar(),  'oxhi à 01:00',      'Now minus 1 hour');
+        test.equal(moment(a).subtract({d: 1}).calendar(),  'ieiri à 02:00',  'yesterday at the same time');
+        test.done();
+    },
+
+    'calendar next week' : function (test) {
+        var i, m;
+        for (i = 2; i < 7; i++) {
+            m = moment().add({d: i});
+            test.equal(m.calendar(),       m.format('dddd [à] LT'),  'Today + ' + i + ' days current time');
+            m.hours(0).minutes(0).seconds(0).milliseconds(0);
+            test.equal(m.calendar(),       m.format('dddd [à] LT'),  'Today + ' + i + ' days beginning of day');
+            m.hours(23).minutes(59).seconds(59).milliseconds(999);
+            test.equal(m.calendar(),       m.format('dddd [à] LT'),  'Today + ' + i + ' days end of day');
+        }
+        test.done();
+    },
+
+    'calendar last week' : function (test) {
+        var i, m;
+
+        for (i = 2; i < 7; i++) {
+            m = moment().subtract({d: i});
+            test.equal(m.calendar(),       m.format('[sür el] dddd [à] LT'),  'Today - ' + i + ' days current time');
+            m.hours(0).minutes(0).seconds(0).milliseconds(0);
+            test.equal(m.calendar(),       m.format('[sür el] dddd [à] LT'),  'Today - ' + i + ' days beginning of day');
+            m.hours(23).minutes(59).seconds(59).milliseconds(999);
+            test.equal(m.calendar(),       m.format('[sür el] dddd [à] LT'),  'Today - ' + i + ' days end of day');
+        }
+        test.done();
+    },
+
+    'calendar all else' : function (test) {
+        var weeksAgo = moment().subtract({w: 1}),
+            weeksFromNow = moment().add({w: 1});
+
+        test.equal(weeksAgo.calendar(),       weeksAgo.format('L'),  '1 week ago');
+        test.equal(weeksFromNow.calendar(),   weeksFromNow.format('L'),  'in 1 week');
+
+        weeksAgo = moment().subtract({w: 2});
+        weeksFromNow = moment().add({w: 2});
+
+        test.equal(weeksAgo.calendar(),       weeksAgo.format('L'),  '2 weeks ago');
+        test.equal(weeksFromNow.calendar(),   weeksFromNow.format('L'),  'in 2 weeks');
+
+        test.done();
+    },
+
+    // Monday is the first day of the week.
+    // The week that contains Jan 4th is the first week of the year.
+
+    'weeks year starting sunday' : function (test) {
+        test.equal(moment([2012, 0, 1]).week(), 52, 'Jan  1 2012 should be week 52');
+        test.equal(moment([2012, 0, 2]).week(),  1, 'Jan  2 2012 should be week 1');
+        test.equal(moment([2012, 0, 8]).week(),  1, 'Jan  8 2012 should be week 1');
+        test.equal(moment([2012, 0, 9]).week(),  2, 'Jan  9 2012 should be week 2');
+        test.equal(moment([2012, 0, 15]).week(), 2, 'Jan 15 2012 should be week 2');
+
+        test.done();
+    },
+
+    'weeks year starting monday' : function (test) {
+        test.equal(moment([2007, 0, 1]).week(),  1, 'Jan  1 2007 should be week 1');
+        test.equal(moment([2007, 0, 7]).week(),  1, 'Jan  7 2007 should be week 1');
+        test.equal(moment([2007, 0, 8]).week(),  2, 'Jan  8 2007 should be week 2');
+        test.equal(moment([2007, 0, 14]).week(), 2, 'Jan 14 2007 should be week 2');
+        test.equal(moment([2007, 0, 15]).week(), 3, 'Jan 15 2007 should be week 3');
+
+        test.done();
+    },
+
+    'weeks year starting tuesday' : function (test) {
+        test.equal(moment([2007, 11, 31]).week(), 1, 'Dec 31 2007 should be week 1');
+        test.equal(moment([2008,  0,  1]).week(), 1, 'Jan  1 2008 should be week 1');
+        test.equal(moment([2008,  0,  6]).week(), 1, 'Jan  6 2008 should be week 1');
+        test.equal(moment([2008,  0,  7]).week(), 2, 'Jan  7 2008 should be week 2');
+        test.equal(moment([2008,  0, 13]).week(), 2, 'Jan 13 2008 should be week 2');
+        test.equal(moment([2008,  0, 14]).week(), 3, 'Jan 14 2008 should be week 3');
+
+        test.done();
+    },
+
+    'weeks year starting wednesday' : function (test) {
+        test.equal(moment([2002, 11, 30]).week(), 1, 'Dec 30 2002 should be week 1');
+        test.equal(moment([2003,  0,  1]).week(), 1, 'Jan  1 2003 should be week 1');
+        test.equal(moment([2003,  0,  5]).week(), 1, 'Jan  5 2003 should be week 1');
+        test.equal(moment([2003,  0,  6]).week(), 2, 'Jan  6 2003 should be week 2');
+        test.equal(moment([2003,  0, 12]).week(), 2, 'Jan 12 2003 should be week 2');
+        test.equal(moment([2003,  0, 13]).week(), 3, 'Jan 13 2003 should be week 3');
+
+        test.done();
+    },
+
+    'weeks year starting thursday' : function (test) {
+        test.equal(moment([2008, 11, 29]).week(), 1, 'Dec 29 2008 should be week 1');
+        test.equal(moment([2009,  0,  1]).week(), 1, 'Jan  1 2009 should be week 1');
+        test.equal(moment([2009,  0,  4]).week(), 1, 'Jan  4 2009 should be week 1');
+        test.equal(moment([2009,  0,  5]).week(), 2, 'Jan  5 2009 should be week 2');
+        test.equal(moment([2009,  0, 11]).week(), 2, 'Jan 11 2009 should be week 2');
+        test.equal(moment([2009,  0, 13]).week(), 3, 'Jan 12 2009 should be week 3');
+
+        test.done();
+    },
+
+    'weeks year starting friday' : function (test) {
+        test.equal(moment([2009, 11, 28]).week(), 53, 'Dec 28 2009 should be week 53');
+        test.equal(moment([2010,  0,  1]).week(), 53, 'Jan  1 2010 should be week 53');
+        test.equal(moment([2010,  0,  3]).week(), 53, 'Jan  3 2010 should be week 53');
+        test.equal(moment([2010,  0,  4]).week(),  1, 'Jan  4 2010 should be week 1');
+        test.equal(moment([2010,  0, 10]).week(),  1, 'Jan 10 2010 should be week 1');
+        test.equal(moment([2010,  0, 11]).week(),  2, 'Jan 11 2010 should be week 2');
+
+        test.done();
+    },
+
+    'weeks year starting saturday' : function (test) {
+        test.equal(moment([2010, 11, 27]).week(), 52, 'Dec 27 2010 should be week 52');
+        test.equal(moment([2011,  0,  1]).week(), 52, 'Jan  1 2011 should be week 52');
+        test.equal(moment([2011,  0,  2]).week(), 52, 'Jan  2 2011 should be week 52');
+        test.equal(moment([2011,  0,  3]).week(),  1, 'Jan  3 2011 should be week 1');
+        test.equal(moment([2011,  0,  9]).week(),  1, 'Jan  9 2011 should be week 1');
+        test.equal(moment([2011,  0, 10]).week(),  2, 'Jan 10 2011 should be week 2');
+
+        test.done();
+    },
+
+    'weeks year starting sunday formatted' : function (test) {
+        test.equal(moment([2012, 0,  1]).format('w ww wo'), '52 52 52nd', 'Jan  1 2012 should be week 52');
+        test.equal(moment([2012, 0,  2]).format('w ww wo'),   '1 01 1st', 'Jan  2 2012 should be week 1');
+        test.equal(moment([2012, 0,  8]).format('w ww wo'),   '1 01 1st', 'Jan  8 2012 should be week 1');
+        test.equal(moment([2012, 0,  9]).format('w ww wo'),   '2 02 2nd', 'Jan  9 2012 should be week 2');
+        test.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2nd', 'Jan 15 2012 should be week 2');
+
+        test.done();
+    },
+
+    'lenient ordinal parsing' : function (test) {
+        var i, ordinalStr, testMoment;
+        for (i = 1; i <= 31; ++i) {
+            ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
+            testMoment = moment(ordinalStr, 'YYYY MM Do');
+            test.equal(testMoment.year(), 2014,
+                    'lenient ordinal parsing ' + i + ' year check');
+            test.equal(testMoment.month(), 0,
+                    'lenient ordinal parsing ' + i + ' month check');
+            test.equal(testMoment.date(), i,
+                    'lenient ordinal parsing ' + i + ' date check');
+        }
+        test.done();
+    },
+
+    'lenient ordinal parsing of number' : function (test) {
+        var i, testMoment;
+        for (i = 1; i <= 31; ++i) {
+            testMoment = moment('2014 01 ' + i, 'YYYY MM Do');
+            test.equal(testMoment.year(), 2014,
+                    'lenient ordinal parsing of number ' + i + ' year check');
+            test.equal(testMoment.month(), 0,
+                    'lenient ordinal parsing of number ' + i + ' month check');
+            test.equal(testMoment.date(), i,
+                    'lenient ordinal parsing of number ' + i + ' date check');
+        }
+        test.done();
+    },
+
+    'strict ordinal parsing' : function (test) {
+        var i, ordinalStr, testMoment;
+        for (i = 1; i <= 31; ++i) {
+            ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
+            testMoment = moment(ordinalStr, 'YYYY MM Do', true);
+            test.ok(testMoment.isValid(), 'strict ordinal parsing ' + i);
+        }
+        test.done();
+    }
+};


### PR DESCRIPTION
Hello, together with Iustì Canun I created a Talossan (tzl) translation of Moment.js.
It is almost finished, but there is one problem.
The relative time sentences don't fit in the variables, they differ per time (future/past).
Could somebody explain to me how I can implement the time sentences?

The missing future sentences:
in a few seconds => osprei viensas secunds
in a minute => osprei 'n míut
in % minutes => osprei % míuts
in an hour => osprei 'n þora
in % hours => osprei % þoras
in a day => osprei 'n ziua
in % days => osprei % ziuas
in a month => osprei 'n mes
in % months => osprei % mesen
in a year => osprei 'n ar
in % years => osprei % ars

The missing past sentences:
a few seconds ago => ja'iensas secunds
a minute ago => ja'iens míut
% minutes ago => ja % míuts
an hour ago => ja'iensa þora
% hours ago => ja % þoras
a day ago => ja'iensa ziua
% days ago => ja % ziuas
a month ago => ja'iens mes
% months ago => ja % mesen
a year ago => ja'iens ar
% years ago => ja % ars