### PR TITLE
Fix test that fails at the end of the year

### DIFF
--- a/test/moment/create.js
+++ b/test/moment/create.js
@@ -908,7 +908,7 @@ exports.create = {
 
         test.equal(moment('22', 'WW').isoWeek(), 22, 'iso week sets the week by itself');
         test.equal(moment('2012 22', 'YYYY WW').weekYear(), 2012, 'iso week keeps parsed year');
-        test.equal(moment('22', 'WW').weekYear(), moment().weekYear(), 'iso week keeps this year');
+        test.equal(moment('22', 'WW').weekYear(), moment().year(), 'iso week keeps this year');
 
         // order
         ver('6 2013 2', 'e gggg w', '2013 01 12', 'order doesn\'t matter');


### PR DESCRIPTION
Fixes failing test because it's expectation isn't met at the end of the year.