### PR TITLE
Changed Swedish locale.

### DIFF
--- a/locale/sv.js
+++ b/locale/sv.js
@@ -30,7 +30,7 @@
             nextDay: '[Imorgon] LT',
             lastDay: '[Igår] LT',
             nextWeek: 'dddd LT',
-            lastWeek: '[Förra] dddd[en] LT',
+            lastWeek: '[I] dddd[s] LT',
             sameElse: 'L'
         },
         relativeTime : {

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -29,7 +29,7 @@
             sameDay: '[Idag] LT',
             nextDay: '[Imorgon] LT',
             lastDay: '[Igår] LT',
-            nextWeek: 'dddd LT',
+            nextWeek: '[På] dddd LT',
             lastWeek: '[I] dddd[s] LT',
             sameElse: 'L'
         },

--- a/test/locale/sv.js
+++ b/test/locale/sv.js
@@ -204,11 +204,11 @@ exports['locale:sv'] = {
         var i, m;
         for (i = 2; i < 7; i++) {
             m = moment().subtract({d: i});
-            test.equal(m.calendar(),       m.format('[Förra] dddd[en] LT'),  'Today - ' + i + ' days current time');
+            test.equal(m.calendar(),       m.format('[I] dddd[s] LT'),  'Today - ' + i + ' days current time');
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('[Förra] dddd[en] LT'),  'Today - ' + i + ' days beginning of day');
+            test.equal(m.calendar(),       m.format('[I] dddd[s] LT'),  'Today - ' + i + ' days beginning of day');
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('[Förra] dddd[en] LT'),  'Today - ' + i + ' days end of day');
+            test.equal(m.calendar(),       m.format('[I] dddd[s] LT'),  'Today - ' + i + ' days end of day');
         }
         test.done();
     },

--- a/test/locale/sv.js
+++ b/test/locale/sv.js
@@ -127,7 +127,7 @@ exports['locale:sv'] = {
 
     'from' : function (test) {
         var start = moment([2007, 1, 28]);
-        test.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true),  'några sekunder', '44 sekunder = a few seconds');
+        test.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true),  'några sekunder', '44 seconds = a few seconds');
         test.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  'en minut',      '45 seconds = a minute');
         test.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  'en minut',      '89 seconds = a minute');
         test.equal(start.from(moment([2007, 1, 28]).add({s: 90}), true),  '2 minuter',     '90 seconds = 2 minutes');
@@ -191,11 +191,11 @@ exports['locale:sv'] = {
         var i, m;
         for (i = 2; i < 7; i++) {
             m = moment().add({d: i});
-            test.equal(m.calendar(),       m.format('dddd LT'),  'Today + ' + i + ' days current time');
+            test.equal(m.calendar(),       m.format('[På] dddd LT'),  'Today + ' + i + ' days current time');
             m.hours(0).minutes(0).seconds(0).milliseconds(0);
-            test.equal(m.calendar(),       m.format('dddd LT'),  'Today + ' + i + ' days beginning of day');
+            test.equal(m.calendar(),       m.format('[På] dddd LT'),  'Today + ' + i + ' days beginning of day');
             m.hours(23).minutes(59).seconds(59).milliseconds(999);
-            test.equal(m.calendar(),       m.format('dddd LT'),  'Today + ' + i + ' days end of day');
+            test.equal(m.calendar(),       m.format('[På] dddd LT'),  'Today + ' + i + ' days end of day');
         }
         test.done();
     },


### PR DESCRIPTION
Changed the Swedish locale for lastWeek to something more like what one
would say. As it was before with for instance "Förra söndagen" (Last
Sunday) while referring to the closest passed Sunday is not what is used
in language, last Sunday refers to the Sunday before the closest passed
one, so I changed it to that.