### PR TITLE
generate stack trace when logging deprecation messages

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -328,6 +328,10 @@
     }
 
     function deprecate(msg, fn) {
+        // Build stack trace to help end users track down where the deprecated usage is coming from,
+        // and append it to the message.
+        msg += '\n' + (new Error()).stack;
+        
         var firstTime = true;
         return extend(function () {
             if (firstTime) {


### PR DESCRIPTION
note that if we wanted to get really fancy, we could unwind the first couple of items off the generated error stack to point at the exact line of code with usage that spawned the deprecation warning (didn't do that here)

> Original issue: https://github.com/moment/moment/issues/1407#issuecomment-71213788
>
> Just a thought- what about grabbing a stack trace with new Error() and stuffing it in the deprecation warning? It took me a while to hunt down where this was happening (it was one of our dependencies, https://github.com/urish/angular-moment). I've just started using the same approach in sails/node-machine and it's been pretty effective so far. I'll send a PR- feel free to close or accept, no pressure :+1: