### PR TITLE
ignore files in packages

### DIFF
--- a/.spmignore
+++ b/.spmignore
@@ -1,4 +1,8 @@
+benchmarks
+bower_components
+meteor
+min
+node_modules
+scripts
 tasks
 test
-min
-benchmarks

--- a/bower.json
+++ b/bower.json
@@ -4,16 +4,19 @@
   "main": "moment.js",
   "ignore": [
     "**/.*",
-    "node_modules",
+    "benchmarks",
     "bower_components",
-    "test",
-    "tests",
+    "meteor",
+    "node_modules",
+    "scripts",
     "tasks",
+    "test",
     "component.json",
     "composer.json",
     "CONTRIBUTING.md",
     "ender.js",
     "Gruntfile.js",
+    "Moment.js.nuspec",
     "package.js",
     "package.json"
   ]


### PR DESCRIPTION
- sort patterns
- use same ignored patterns between bower and spm (except min)