### PR TITLE
Fixed week number calculation for non standard dow/doy combinations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sauce_connect.log
 .sauce-labs.creds
 npm-debug.log
 .build*
+*.iml

--- a/min/moment-with-locales.js
+++ b/min/moment-with-locales.js
@@ -1817,14 +1817,22 @@
 
     //http://en.wikipedia.org/wiki/ISO_week_date#Calculating_a_date_given_the_year.2C_week_number_and_weekday
     function dayOfYearFromWeeks(year, week, weekday, firstDayOfWeekOfYear, firstDayOfWeek) {
-        var d = makeUTCDate(year, 0, 1).getUTCDay(), daysToAdd, dayOfYear;
+      // var d = makeUTCDate(year, 0, 1).getUTCDay(), daysToAdd, dayOfYear;
+      var week1Jan = 6 + firstDayOfWeek - firstDayOfWeekOfYear, janX = makeUTCDate(year, 0, 1 + week1Jan), d = janX.getUTCDay(), dayOfYear;
+      if (d < firstDayOfWeek) {
+        d += 7;
+      }
 
-        d = d === 0 ? 7 : d;
-        weekday = weekday != null ? weekday : firstDayOfWeek;
-        daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0) - (d < firstDayOfWeek ? 7 : 0);
-        dayOfYear = 7 * (week - 1) + (weekday - firstDayOfWeek) + daysToAdd + 1;
+      weekday = weekday != null ? 1 * weekday : firstDayOfWeek;
 
-        return {
+      //d = d === 0 ? 7 : d;
+      //  weekday = weekday != null ? weekday : firstDayOfWeek;
+      //  daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0) - (d < firstDayOfWeek ? 7 : 0);
+      //  dayOfYear = 7 * (week - 1) + (weekday - firstDayOfWeek) + daysToAdd + 1;
+
+      dayOfYear = 1 + week1Jan + 7 * (week - 1) - d + weekday;
+
+      return {
             year: dayOfYear > 0 ? year : year - 1,
             dayOfYear: dayOfYear > 0 ?  dayOfYear : daysInYear(year - 1) + dayOfYear
         };

--- a/moment.js
+++ b/moment.js
@@ -1817,22 +1817,16 @@
 
     //http://en.wikipedia.org/wiki/ISO_week_date#Calculating_a_date_given_the_year.2C_week_number_and_weekday
     function dayOfYearFromWeeks(year, week, weekday, firstDayOfWeekOfYear, firstDayOfWeek) {
-      // var d = makeUTCDate(year, 0, 1).getUTCDay(), daysToAdd, dayOfYear;
-      var week1Jan = 6 + firstDayOfWeek - firstDayOfWeekOfYear, janX = makeUTCDate(year, 0, 1 + week1Jan), d = janX.getUTCDay(), dayOfYear;
-      if (d < firstDayOfWeek) {
-        d += 7;
-      }
+        var week1Jan = 6 + firstDayOfWeek - firstDayOfWeekOfYear, janX = makeUTCDate(year, 0, 1 + week1Jan), d = janX.getUTCDay(), dayOfYear;
+        if (d < firstDayOfWeek) {
+            d += 7;
+        }
 
-      weekday = weekday != null ? 1 * weekday : firstDayOfWeek;
+        weekday = weekday != null ? 1 * weekday : firstDayOfWeek;
 
-      //d = d === 0 ? 7 : d;
-      //  weekday = weekday != null ? weekday : firstDayOfWeek;
-      //  daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0) - (d < firstDayOfWeek ? 7 : 0);
-      //  dayOfYear = 7 * (week - 1) + (weekday - firstDayOfWeek) + daysToAdd + 1;
+        dayOfYear = 1 + week1Jan + 7 * (week - 1) - d + weekday;
 
-      dayOfYear = 1 + week1Jan + 7 * (week - 1) - d + weekday;
-
-      return {
+        return {
             year: dayOfYear > 0 ? year : year - 1,
             dayOfYear: dayOfYear > 0 ?  dayOfYear : daysInYear(year - 1) + dayOfYear
         };

--- a/moment.js
+++ b/moment.js
@@ -1817,14 +1817,22 @@
 
     //http://en.wikipedia.org/wiki/ISO_week_date#Calculating_a_date_given_the_year.2C_week_number_and_weekday
     function dayOfYearFromWeeks(year, week, weekday, firstDayOfWeekOfYear, firstDayOfWeek) {
-        var d = makeUTCDate(year, 0, 1).getUTCDay(), daysToAdd, dayOfYear;
+      // var d = makeUTCDate(year, 0, 1).getUTCDay(), daysToAdd, dayOfYear;
+      var week1Jan = 6 + firstDayOfWeek - firstDayOfWeekOfYear, janX = makeUTCDate(year, 0, 1 + week1Jan), d = janX.getUTCDay(), dayOfYear;
+      if (d < firstDayOfWeek) {
+        d += 7;
+      }
 
-        d = d === 0 ? 7 : d;
-        weekday = weekday != null ? weekday : firstDayOfWeek;
-        daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0) - (d < firstDayOfWeek ? 7 : 0);
-        dayOfYear = 7 * (week - 1) + (weekday - firstDayOfWeek) + daysToAdd + 1;
+      weekday = weekday != null ? 1 * weekday : firstDayOfWeek;
 
-        return {
+      //d = d === 0 ? 7 : d;
+      //  weekday = weekday != null ? weekday : firstDayOfWeek;
+      //  daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0) - (d < firstDayOfWeek ? 7 : 0);
+      //  dayOfYear = 7 * (week - 1) + (weekday - firstDayOfWeek) + daysToAdd + 1;
+
+      dayOfYear = 1 + week1Jan + 7 * (week - 1) - d + weekday;
+
+      return {
             year: dayOfYear > 0 ? year : year - 1,
             dayOfYear: dayOfYear > 0 ?  dayOfYear : daysInYear(year - 1) + dayOfYear
         };

--- a/test/moment/week_year_roundtrip.js
+++ b/test/moment/week_year_roundtrip.js
@@ -1,0 +1,32 @@
+var moment = require('../../moment');
+
+exports.weekYearRoundtrip = {
+    setUp : function (done) {
+        moment.createFromInputFallback = function () {
+            throw new Error('input not handled by moment');
+        };
+        done();
+    },
+
+
+    // Verifies that the week number, week day computation is correct for all dow, doy combinations
+    'week year roundtrip': function (test) {
+        test.expect(7*7*7*2);
+
+        var dow, doy, wd, m;
+        for (dow = 0; dow < 7; ++dow) {
+          for (doy = dow; doy < dow + 7; ++doy) {
+            for (wd = 0; wd < 7; ++wd) {
+              moment.locale('dow: ' + dow + ', doy: ' + doy, {week: {dow: dow, doy: doy}});
+              // We use the 10th week as the 1st one can spill to the previous year
+              m = moment('2015 10 ' + wd, 'gggg w d', true);
+              test.equal(m.format('gggg w d'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+              m = moment('2015 10 ' + wd, 'gggg w e', true);
+              test.equal(m.format('gggg w e'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+            }
+          }
+        }
+
+        test.done();
+    }
+};

--- a/test/moment/week_year_roundtrip.js
+++ b/test/moment/week_year_roundtrip.js
@@ -28,5 +28,18 @@ exports.weekYearRoundtrip = {
         }
 
         test.done();
+    },
+
+    'week numbers 2012/2013': function (test) {
+        test.expect(7);
+        moment.locale(moment.locale(), {week: {dow: 6, doy: 12}});
+        test.equal(52, moment('2012-12-28', 'YYYY-MM-DD').week()); // 51 -- should be 52?
+        test.equal(1, moment('2012-12-29', 'YYYY-MM-DD').week()); // 52 -- should be 1
+        test.equal(1, moment('2013-01-01', 'YYYY-MM-DD').week()); // 52 -- should be 1
+        test.equal(2, moment('2013-01-08', 'YYYY-MM-DD').week()); // 53 -- should be 2
+        test.equal(2, moment('2013-01-11', 'YYYY-MM-DD').week()); // 53 -- should be 2
+        test.equal(3, moment('2013-01-12', 'YYYY-MM-DD').week()); // 1 -- should be 3
+        test.equal(52, moment().weeksInYear(2012)); // 52
+        test.done();
     }
 };

--- a/test/moment/week_year_roundtrip.js
+++ b/test/moment/week_year_roundtrip.js
@@ -11,20 +11,20 @@ exports.weekYearRoundtrip = {
 
     // Verifies that the week number, week day computation is correct for all dow, doy combinations
     'week year roundtrip': function (test) {
-        test.expect(7*7*7*2);
+        test.expect(7 * 7 * 7 * 2);
 
         var dow, doy, wd, m;
         for (dow = 0; dow < 7; ++dow) {
-          for (doy = dow; doy < dow + 7; ++doy) {
-            for (wd = 0; wd < 7; ++wd) {
-              moment.locale('dow: ' + dow + ', doy: ' + doy, {week: {dow: dow, doy: doy}});
-              // We use the 10th week as the 1st one can spill to the previous year
-              m = moment('2015 10 ' + wd, 'gggg w d', true);
-              test.equal(m.format('gggg w d'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
-              m = moment('2015 10 ' + wd, 'gggg w e', true);
-              test.equal(m.format('gggg w e'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+            for (doy = dow; doy < dow + 7; ++doy) {
+                for (wd = 0; wd < 7; ++wd) {
+                    moment.locale('dow: ' + dow + ', doy: ' + doy, {week: {dow: dow, doy: doy}});
+                    // We use the 10th week as the 1st one can spill to the previous year
+                    m = moment('2015 10 ' + wd, 'gggg w d', true);
+                    test.equal(m.format('gggg w d'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+                    m = moment('2015 10 ' + wd, 'gggg w e', true);
+                    test.equal(m.format('gggg w e'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+                }
             }
-          }
         }
 
         test.done();


### PR DESCRIPTION
For some non standard combination of dow and doy the computation of the week number would return a wrong week number. This pull request fixes the problem.

Also added tests for all 7*7 dow/doy combinations.