### PR TITLE
fix seconds in relative time in pt-br locale

### DIFF
--- a/locale/pt-br.js
+++ b/locale/pt-br.js
@@ -40,7 +40,7 @@
         relativeTime : {
             future : 'em %s',
             past : '%s atrás',
-            s : 'segundos',
+            s : 'poucos segundos',
             m : 'um minuto',
             mm : '%d minutos',
             h : 'uma hora',


### PR DESCRIPTION
fix relative time so that 's' means 'a few seconds' instead of  just 'seconds' in pt-br locale.