### PR TITLE
Include browser global for \'use strict\' environments (minifications)

### DIFF
--- a/locale/af.js
+++ b/locale/af.js
@@ -2,13 +2,13 @@
 // locale : afrikaans (af)
 // author : Werner Mollentze : https://github.com/wernerm
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('af', {
@@ -68,4 +68,4 @@
             doy : 4  // Die week wat die 4de Januarie bevat is die eerste week van die jaar.
         }
     });
-}));
+}, window));

--- a/locale/ar-ma.js
+++ b/locale/ar-ma.js
@@ -3,13 +3,13 @@
 // author : ElFadili Yassine : https://github.com/ElFadiliY
 // author : Abdel Said : https://github.com/abdelsaid
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ar-ma', {
@@ -54,4 +54,4 @@
             doy : 12  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ar-sa.js
+++ b/locale/ar-sa.js
@@ -2,13 +2,13 @@
 // locale : Arabic Saudi Arabia (ar-sa)
 // author : Suhail Alkowaileet : https://github.com/xsoh
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -98,4 +98,4 @@
             doy : 12  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ar-tn.js
+++ b/locale/ar-tn.js
@@ -1,13 +1,13 @@
 // moment.js locale configuration
 // locale  : Tunisian Arabic (ar-tn)
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ar-tn', {
@@ -52,4 +52,4 @@
             doy: 4 // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ar.js
+++ b/locale/ar.js
@@ -4,13 +4,13 @@
 // Changes in months, weekdays: Ahmed Elkhatib
 // Native plural forms: forabi https://github.com/forabi
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -131,4 +131,4 @@
             doy : 12  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/az.js
+++ b/locale/az.js
@@ -2,13 +2,13 @@
 // locale : azerbaijani (az)
 // author : topchiyev : https://github.com/topchiyev
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var suffixes = {
@@ -104,4 +104,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/be.js
+++ b/locale/be.js
@@ -4,13 +4,13 @@
 // author: Praleska: http://praleska.pro/
 // Author : Menelion Elensúle : https://github.com/Oire
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function plural(word, num) {
@@ -151,4 +151,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/bg.js
+++ b/locale/bg.js
@@ -2,13 +2,13 @@
 // locale : bulgarian (bg)
 // author : Krasen Borisov : https://github.com/kraz
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('bg', {
@@ -85,4 +85,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/bn.js
+++ b/locale/bn.js
@@ -2,13 +2,13 @@
 // locale : Bengali (bn)
 // author : Kaushik Gandhi : https://github.com/kaushikgandhi
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -108,4 +108,4 @@
             doy : 6  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/bo.js
+++ b/locale/bo.js
@@ -2,13 +2,13 @@
 // locale : tibetan (bo)
 // author : Thupten N. Chakrishar : https://github.com/vajradog
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -105,4 +105,4 @@
             doy : 6  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/br.js
+++ b/locale/br.js
@@ -2,13 +2,13 @@
 // locale : breton (br)
 // author : Jean-Baptiste Le Duigou : https://github.com/jbleduigou
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function relativeTimeWithMutation(number, withoutSuffix, key) {
@@ -106,4 +106,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/bs.js
+++ b/locale/bs.js
@@ -3,13 +3,13 @@
 // author : Nedim Cholich : https://github.com/frontyard
 // based on (hr) translation by Bojan Marković
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function translate(number, withoutSuffix, key) {
@@ -137,4 +137,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ca.js
+++ b/locale/ca.js
@@ -2,13 +2,13 @@
 // locale : catalan (ca)
 // author : Juan G. Hurtado : https://github.com/juanghurtado
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ca', {
@@ -74,4 +74,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/cs.js
+++ b/locale/cs.js
@@ -2,13 +2,13 @@
 // locale : czech (cs)
 // author : petrbela : https://github.com/petrbela
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var months = 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split('_'),
@@ -154,4 +154,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/cv.js
+++ b/locale/cv.js
@@ -2,13 +2,13 @@
 // locale : chuvash (cv)
 // author : Anatoly Mironov : https://github.com/mirontoli
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('cv', {
@@ -58,4 +58,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/cy.js
+++ b/locale/cy.js
@@ -2,13 +2,13 @@
 // locale : Welsh (cy)
 // author : Robert Allen
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('cy', {
@@ -76,4 +76,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/da.js
+++ b/locale/da.js
@@ -2,13 +2,13 @@
 // locale : danish (da)
 // author : Ulrik Nielsen : https://github.com/mrbase
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('da', {
@@ -55,4 +55,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/de-at.js
+++ b/locale/de-at.js
@@ -4,13 +4,13 @@
 // author: Menelion Elensúle: https://github.com/Oire
 // author : Martin Groller : https://github.com/MadMG
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {
@@ -71,4 +71,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/de.js
+++ b/locale/de.js
@@ -3,13 +3,13 @@
 // author : lluchs : https://github.com/lluchs
 // author: Menelion Elensúle: https://github.com/Oire
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {
@@ -70,4 +70,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/el.js
+++ b/locale/el.js
@@ -2,13 +2,13 @@
 // locale : modern greek (el)
 // author : Aggelos Karalias : https://github.com/mehiel
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('el', {
@@ -91,4 +91,4 @@
             doy : 4  // The week that contains Jan 4st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/en-au.js
+++ b/locale/en-au.js
@@ -1,13 +1,13 @@
 // moment.js locale configuration
 // locale : australian english (en-au)
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('en-au', {
@@ -61,4 +61,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/en-ca.js
+++ b/locale/en-ca.js
@@ -2,13 +2,13 @@
 // locale : canadian english (en-ca)
 // author : Jonathan Abourbih : https://github.com/jonbca
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('en-ca', {
@@ -58,4 +58,4 @@
             return number + output;
         }
     });
-}));
+}, window));

--- a/locale/en-gb.js
+++ b/locale/en-gb.js
@@ -2,13 +2,13 @@
 // locale : great britain english (en-gb)
 // author : Chris Gedrim : https://github.com/chrisgedrim
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('en-gb', {
@@ -62,4 +62,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/eo.js
+++ b/locale/eo.js
@@ -4,13 +4,13 @@
 // komento: Mi estas malcerta se mi korekte traktis akuzativojn en tiu traduko.
 //          Se ne, bonvolu korekti kaj avizi min por ke mi povas lerni!
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('eo', {
@@ -68,4 +68,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/es.js
+++ b/locale/es.js
@@ -2,13 +2,13 @@
 // locale : spanish (es)
 // author : Julio Napurí : https://github.com/julionc
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
@@ -74,4 +74,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/et.js
+++ b/locale/et.js
@@ -3,13 +3,13 @@
 // author : Henry Kehlmann : https://github.com/madhenry
 // improvements : Illimar Tambek : https://github.com/ragulka
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {
@@ -75,4 +75,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/eu.js
+++ b/locale/eu.js
@@ -2,13 +2,13 @@
 // locale : euskara (eu)
 // author : Eneko Illarramendi : https://github.com/eillarra
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('eu', {
@@ -59,4 +59,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/fa.js
+++ b/locale/fa.js
@@ -2,13 +2,13 @@
 // locale : Persian (fa)
 // author : Ebrahim Byagowi : https://github.com/ebraminio
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -100,4 +100,4 @@
             doy : 12 // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/fi.js
+++ b/locale/fi.js
@@ -2,13 +2,13 @@
 // locale : finnish (fi)
 // author : Tarmo Aidantausta : https://github.com/bleadof
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var numbersPast = 'nolla yksi kaksi kolme neljä viisi kuusi seitsemän kahdeksan yhdeksän'.split(' '),
@@ -104,4 +104,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/fo.js
+++ b/locale/fo.js
@@ -2,13 +2,13 @@
 // locale : faroese (fo)
 // author : Ragnar Johannesen : https://github.com/ragnar123
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('fo', {
@@ -55,4 +55,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/fr-ca.js
+++ b/locale/fr-ca.js
@@ -2,13 +2,13 @@
 // locale : canadian french (fr-ca)
 // author : Jonathan Abourbih : https://github.com/jonbca
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('fr-ca', {
@@ -53,4 +53,4 @@
             return number + (number === 1 ? 'er' : '');
         }
     });
-}));
+}, window));

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -2,13 +2,13 @@
 // locale : french (fr)
 // author : John Fischer : https://github.com/jfroffice
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('fr', {
@@ -57,4 +57,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/fy.js
+++ b/locale/fy.js
@@ -2,13 +2,13 @@
 // locale : frisian (fy)
 // author : Robin van der Vliet : https://github.com/robin0van0der0v
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var monthsShortWithDots = 'jan._feb._mrt._apr._mai_jun._jul._aug._sep._okt._nov._des.'.split('_'),
@@ -66,4 +66,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/gl.js
+++ b/locale/gl.js
@@ -2,13 +2,13 @@
 // locale : galician (gl)
 // author : Juan G. Hurtado : https://github.com/juanghurtado
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('gl', {
@@ -70,4 +70,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/he.js
+++ b/locale/he.js
@@ -4,13 +4,13 @@
 // author : Moshe Simantov : https://github.com/DevelopmentIL
 // author : Tal Ater : https://github.com/TalAter
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('he', {
@@ -77,4 +77,4 @@
             }
         }
     });
-}));
+}, window));

--- a/locale/hi.js
+++ b/locale/hi.js
@@ -2,13 +2,13 @@
 // locale : hindi (hi)
 // author : Mayank Singhal : https://github.com/mayanksinghal
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -118,4 +118,4 @@
             doy : 6  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/hr.js
+++ b/locale/hr.js
@@ -4,13 +4,13 @@
 
 // based on (sl) translation by Robert Sedovšek
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function translate(number, withoutSuffix, key) {
@@ -138,4 +138,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/hu.js
+++ b/locale/hu.js
@@ -2,13 +2,13 @@
 // locale : hungarian (hu)
 // author : Adam Brunner : https://github.com/adambrunner
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var weekEndings = 'vasárnap hétfőn kedden szerdán csütörtökön pénteken szombaton'.split(' ');
@@ -108,4 +108,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/hy-am.js
+++ b/locale/hy-am.js
@@ -2,13 +2,13 @@
 // locale : Armenian (hy-am)
 // author : Armendarabyan : https://github.com/armendarabyan
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function monthsCaseReplace(m, format) {
@@ -115,4 +115,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/id.js
+++ b/locale/id.js
@@ -3,13 +3,13 @@
 // author : Mohammad Satrio Utomo : https://github.com/tyok
 // reference: http://id.wikisource.org/wiki/Pedoman_Umum_Ejaan_Bahasa_Indonesia_yang_Disempurnakan
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('id', {
@@ -78,4 +78,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/is.js
+++ b/locale/is.js
@@ -2,13 +2,13 @@
 // locale : icelandic (is)
 // author : Hinrik Örn Sigurðsson : https://github.com/hinrik
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function plural(n) {
@@ -123,4 +123,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/it.js
+++ b/locale/it.js
@@ -3,13 +3,13 @@
 // author : Lorenzo : https://github.com/aliem
 // author: Mattia Larentis: https://github.com/nostalgiaz
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('it', {
@@ -65,4 +65,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ja.js
+++ b/locale/ja.js
@@ -2,13 +2,13 @@
 // locale : japanese (ja)
 // author : LI Long : https://github.com/baryon
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ja', {
@@ -60,4 +60,4 @@
             yy : '%d年'
         }
     });
-}));
+}, window));

--- a/locale/ka.js
+++ b/locale/ka.js
@@ -2,13 +2,13 @@
 // locale : Georgian (ka)
 // author : Irakli Janiashvili : https://github.com/irakli-janiashvili
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function monthsCaseReplace(m, format) {
@@ -106,4 +106,4 @@
             doy : 7
         }
     });
-}));
+}, window));

--- a/locale/km.js
+++ b/locale/km.js
@@ -2,13 +2,13 @@
 // locale : khmer (km)
 // author : Kruy Vanna : https://github.com/kruyvanna
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('km', {
@@ -53,4 +53,4 @@
             doy: 4 // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ko.js
+++ b/locale/ko.js
@@ -5,13 +5,13 @@
 //
 // - Kyungwook, Park : https://github.com/kyungw00k
 // - Jeeeyul Lee <jeeeyul@gmail.com>
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ko', {
@@ -62,4 +62,4 @@
             return hour < 12 ? '오전' : '오후';
         }
     });
-}));
+}, window));

--- a/locale/lb.js
+++ b/locale/lb.js
@@ -6,13 +6,13 @@
 // deletion of the final 'n' in certain contexts. That's what the 'eifelerRegelAppliesToWeekday'
 // and 'eifelerRegelAppliesToNumber' methods are meant for
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function processRelativeTime(number, withoutSuffix, key, isFuture) {
@@ -136,4 +136,4 @@
             doy: 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/lt.js
+++ b/locale/lt.js
@@ -2,13 +2,13 @@
 // locale : Lithuanian (lt)
 // author : Mindaugas Mozūras : https://github.com/mmozuras
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var units = {
@@ -117,4 +117,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/lv.js
+++ b/locale/lv.js
@@ -2,13 +2,13 @@
 // locale : latvian (lv)
 // author : Kristaps Karlsons : https://github.com/skakri
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var units = {
@@ -76,4 +76,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/mk.js
+++ b/locale/mk.js
@@ -2,13 +2,13 @@
 // locale : macedonian (mk)
 // author : Borislav Mickov : https://github.com/B0k0
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('mk', {
@@ -85,4 +85,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ml.js
+++ b/locale/ml.js
@@ -2,13 +2,13 @@
 // locale : malayalam (ml)
 // author : Floyd Pink : https://github.com/floydpink
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ml', {
@@ -66,4 +66,4 @@
             }
         }
     });
-}));
+}, window));

--- a/locale/mr.js
+++ b/locale/mr.js
@@ -2,13 +2,13 @@
 // locale : Marathi (mr)
 // author : Harshad Kale : https://github.com/kalehv
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -117,4 +117,4 @@
             doy : 6  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ms-my.js
+++ b/locale/ms-my.js
@@ -2,13 +2,13 @@
 // locale : Bahasa Malaysia (ms-MY)
 // author : Weldan Jamili : https://github.com/weldan
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('ms-my', {
@@ -77,4 +77,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/my.js
+++ b/locale/my.js
@@ -2,13 +2,13 @@
 // locale : Burmese (my)
 // author : Squar team, mysquar.com
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -86,4 +86,4 @@
             doy: 4 // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/nb.js
+++ b/locale/nb.js
@@ -3,13 +3,13 @@
 // authors : Espen Hovlandsdal : https://github.com/rexxars
 //           Sigurd Gartmann : https://github.com/sigurdga
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('nb', {
@@ -56,4 +56,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ne.js
+++ b/locale/ne.js
@@ -2,13 +2,13 @@
 // locale : nepali/nepalese
 // author : suvash : https://github.com/suvash
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var symbolMap = {
@@ -118,4 +118,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/nl.js
+++ b/locale/nl.js
@@ -2,13 +2,13 @@
 // locale : dutch (nl)
 // author : Joris Röling : https://github.com/jjupiter
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var monthsShortWithDots = 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split('_'),
@@ -66,4 +66,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/nn.js
+++ b/locale/nn.js
@@ -2,13 +2,13 @@
 // locale : norwegian nynorsk (nn)
 // author : https://github.com/mechuwind
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('nn', {
@@ -55,4 +55,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/pl.js
+++ b/locale/pl.js
@@ -2,13 +2,13 @@
 // locale : polish (pl)
 // author : Rafal Hirsz : https://github.com/evoL
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var monthsNominative = 'styczeń_luty_marzec_kwiecień_maj_czerwiec_lipiec_sierpień_wrzesień_październik_listopad_grudzień'.split('_'),
@@ -97,4 +97,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/pt-br.js
+++ b/locale/pt-br.js
@@ -2,13 +2,13 @@
 // locale : brazilian portuguese (pt-br)
 // author : Caio Ribeiro Pereira : https://github.com/caio-ribeiro-pereira
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('pt-br', {
@@ -55,4 +55,4 @@
         ordinalParse: /\d{1,2}º/,
         ordinal : '%dº'
     });
-}));
+}, window));

--- a/locale/pt.js
+++ b/locale/pt.js
@@ -2,13 +2,13 @@
 // locale : portuguese (pt)
 // author : Jefferson : https://github.com/jalex79
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('pt', {
@@ -59,4 +59,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ro.js
+++ b/locale/ro.js
@@ -3,13 +3,13 @@
 // author : Vlad Gurdiga : https://github.com/gurdiga
 // author : Valentin Agachi : https://github.com/avaly
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function relativeTimeWithPlural(number, withoutSuffix, key) {
@@ -70,4 +70,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ru.js
+++ b/locale/ru.js
@@ -3,13 +3,13 @@
 // author : Viktorminator : https://github.com/Viktorminator
 // Author : Menelion Elensúle : https://github.com/Oire
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function plural(word, num) {
@@ -173,4 +173,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/sk.js
+++ b/locale/sk.js
@@ -3,13 +3,13 @@
 // author : Martin Minka : https://github.com/k2s
 // based on work of petrbela : https://github.com/petrbela
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var months = 'január_február_marec_apríl_máj_jún_júl_august_september_október_november_december'.split('_'),
@@ -155,4 +155,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/sl.js
+++ b/locale/sl.js
@@ -2,13 +2,13 @@
 // locale : slovenian (sl)
 // author : Robert Sedovšek : https://github.com/sedovsek
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function translate(number, withoutSuffix, key) {
@@ -143,4 +143,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/sq.js
+++ b/locale/sq.js
@@ -4,13 +4,13 @@
 // author: Menelion Elensúle: https://github.com/Oire (tests)
 // author : Oerd Cukalla : https://github.com/oerd (fixes)
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('sq', {
@@ -64,4 +64,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/sr-cyrl.js
+++ b/locale/sr-cyrl.js
@@ -2,13 +2,13 @@
 // locale : Serbian-cyrillic (sr-cyrl)
 // author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var translator = {
@@ -104,4 +104,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/sr.js
+++ b/locale/sr.js
@@ -2,13 +2,13 @@
 // locale : Serbian-latin (sr)
 // author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var translator = {
@@ -104,4 +104,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/sv.js
+++ b/locale/sv.js
@@ -2,13 +2,13 @@
 // locale : swedish (sv)
 // author : Jens Alm : https://github.com/ulmus
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('sv', {
@@ -62,4 +62,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/ta.js
+++ b/locale/ta.js
@@ -2,13 +2,13 @@
 // locale : tamil (ta)
 // author : Arjunkumar Krishnamoorthy : https://github.com/tk120404
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     /*var symbolMap = {
@@ -127,4 +127,4 @@
             doy : 6  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/th.js
+++ b/locale/th.js
@@ -2,13 +2,13 @@
 // locale : thai (th)
 // author : Kridsada Thanabulpong : https://github.com/sirn
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('th', {
@@ -60,4 +60,4 @@
             yy : '%d ปี'
         }
     });
-}));
+}, window));

--- a/locale/tl-ph.js
+++ b/locale/tl-ph.js
@@ -2,13 +2,13 @@
 // locale : Tagalog/Filipino (tl-ph)
 // author : Dan Hagman
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('tl-ph', {
@@ -57,4 +57,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/tr.js
+++ b/locale/tr.js
@@ -3,13 +3,13 @@
 // authors : Erhan Gundogan : https://github.com/erhangundogan,
 //           Burak Yiğit Kaya: https://github.com/BYK
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     var suffixes = {
@@ -91,4 +91,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/tzm-latn.js
+++ b/locale/tzm-latn.js
@@ -2,13 +2,13 @@
 // locale : Morocco Central Atlas Tamaziɣt in Latin (tzm-latn)
 // author : Abdel Said : https://github.com/abdelsaid
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('tzm-latn', {
@@ -53,4 +53,4 @@
             doy : 12  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/tzm.js
+++ b/locale/tzm.js
@@ -2,13 +2,13 @@
 // locale : Morocco Central Atlas Tamaziɣt (tzm)
 // author : Abdel Said : https://github.com/abdelsaid
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('tzm', {
@@ -53,4 +53,4 @@
             doy : 12  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/uk.js
+++ b/locale/uk.js
@@ -3,13 +3,13 @@
 // author : zemlanin : https://github.com/zemlanin
 // Author : Menelion Elensúle : https://github.com/Oire
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     function plural(word, num) {
@@ -160,4 +160,4 @@
             doy : 7  // The week that contains Jan 1st is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/uz.js
+++ b/locale/uz.js
@@ -2,13 +2,13 @@
 // locale : uzbek (uz)
 // author : Sardor Muminov : https://github.com/muminoff
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('uz', {
@@ -53,4 +53,4 @@
             doy : 7  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/vi.js
+++ b/locale/vi.js
@@ -2,13 +2,13 @@
 // locale : vietnamese (vi)
 // author : Bang Nguyen : https://github.com/bangnk
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('vi', {
@@ -61,4 +61,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/zh-cn.js
+++ b/locale/zh-cn.js
@@ -3,13 +3,13 @@
 // author : suupic : https://github.com/suupic
 // author : Zeno Zeng : https://github.com/zenozeng
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('zh-cn', {
@@ -122,4 +122,4 @@
             doy : 4  // The week that contains Jan 4th is the first week of the year.
         }
     });
-}));
+}, window));

--- a/locale/zh-tw.js
+++ b/locale/zh-tw.js
@@ -2,13 +2,13 @@
 // locale : traditional chinese (zh-tw)
 // author : Ben : https://github.com/ben-lin
 
-(function (factory) {
+(function (factory, browserGlobal) {
     if (typeof define === 'function' && define.amd) {
         define(['moment'], factory); // AMD
     } else if (typeof exports === 'object') {
         module.exports = factory(require('../moment')); // Node
     } else {
-        factory((typeof global !== 'undefined' ? global : this).moment); // node or other global
+        factory((typeof global !== 'undefined' ? global : browserGlobal).moment); // node or other global
     }
 }(function (moment) {
     return moment.defineLocale('zh-tw', {
@@ -96,4 +96,4 @@
             yy : '%d年'
         }
     });
-}));
+}, window));


### PR DESCRIPTION
The locale/*js files in moment.js are not 'use strict'. Some projects will only include some of the locale files (as opposed to loading all the 80 translations in moment-with-locales.min.js). When minified, the locale/*js files might often be placed in a 'use strict' environment resulting in the 'this' object to be undefined. This fix adds 'window' as a paramter to the IIFE's in locale/*js files.