### PR TITLE
Remove periods from short days/months in Slovenian

### DIFF
--- a/locale/sl.js
+++ b/locale/sl.js
@@ -74,9 +74,9 @@
 
     return moment.defineLocale('sl', {
         months : 'januar_februar_marec_april_maj_junij_julij_avgust_september_oktober_november_december'.split('_'),
-        monthsShort : 'jan._feb._mar._apr._maj._jun._jul._avg._sep._okt._nov._dec.'.split('_'),
+        monthsShort : 'jan_feb_mar_apr_maj_jun_jul_avg_sep_okt_nov_dec'.split('_'),
         weekdays : 'nedelja_ponedeljek_torek_sreda_četrtek_petek_sobota'.split('_'),
-        weekdaysShort : 'ned._pon._tor._sre._čet._pet._sob.'.split('_'),
+        weekdaysShort : 'ned_pon_tor_sre_čet_pet_sob'.split('_'),
         weekdaysMin : 'ne_po_to_sr_če_pe_so'.split('_'),
         longDateFormat : {
             LT : 'H:mm',


### PR DESCRIPTION
Remove periods from short days/months in Slovenian so users can add them if they need them.