### PR TITLE
Update nb.js locale's time format for LT and LTS

### DIFF
--- a/locale/nb.js
+++ b/locale/nb.js
@@ -19,8 +19,8 @@
         weekdaysShort : 'søn_man_tirs_ons_tors_fre_lør'.split('_'),
         weekdaysMin : 'sø_ma_ti_on_to_fr_lø'.split('_'),
         longDateFormat : {
-            LT : 'H.mm',
-            LTS : 'LT.ss',
+            LT : 'H:mm',
+            LTS : 'LT:ss',
             L : 'DD.MM.YYYY',
             LL : 'D. MMMM YYYY',
             LLL : 'D. MMMM YYYY [kl.] LT',


### PR DESCRIPTION
The time format for LT and LTS do not align with what is the default time settings in Windows for locale Norwegian Bokmål and what most people use. Propose H:mm instead of H.mm and LT:ss instead of LT.ss. Most norwegians do not use a 13.37 time format, but rather 13:37.