### PR TITLE
Fix 0 hour checking in strict parsing.

### DIFF
--- a/src/lib/create/from-string-and-format.js
+++ b/src/lib/create/from-string-and-format.js
@@ -62,7 +62,9 @@ export function configFromStringAndFormat(config) {
     }
 
     // clear _12h flag if hour is <= 12
-    if (config._pf.bigHour === true && config._a[HOUR] <= 12) {
+    if (config._pf.bigHour === true &&
+        config._a[HOUR] <= 12 &&
+        config._a[HOUR] > 0) {
         config._pf.bigHour = undefined;
     }
     // handle meridiem

--- a/src/test/moment/is_valid.js
+++ b/src/test/moment/is_valid.js
@@ -243,3 +243,10 @@ test('oddball permissiveness', function (assert) {
     //https://github.com/moment/moment/issues/1122
     assert.ok(moment('3:25', ['h:mma', 'hh:mma', 'H:mm', 'HH:mm']).isValid());
 });
+
+test('0 hour is invalid in strict', function (assert) {
+    assert.equal(moment('00:01', 'hh:mm', true).isValid(), false, '00 hour is invalid in strict');
+    assert.equal(moment('00:01', 'hh:mm').isValid(), true, '00 hour is valid in normal');
+    assert.equal(moment('0:01', 'h:mm', true).isValid(), false, '0 hour is invalid in strict');
+    assert.equal(moment('0:01', 'h:mm').isValid(), true, '0 hour is valid in normal');
+});


### PR DESCRIPTION
Basically augments the `bigHour` check to see if, in addition to the hour being less than 12, it's also greater than 0.

This should fix [#2140](https://github.com/moment/moment/issues/2140).
