### PR TITLE
Patch to regular expression that was causing a lint warning

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -872,7 +872,7 @@
             }
             // Lenient ordinal parsing accepts just a number in addition to
             // number + (possibly) stuff coming from _ordinalParseLenient.
-            this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + /\d{1,2}/.source);
+            this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + (/\d{1,2}/).source);
         },
 
         _months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),


### PR DESCRIPTION
*Lint Warning: regular expressions should be preceded by a left parenthesis, assignment, colon, or comma.*

This warning was causing errors while trying to minify 'moment.js' using 'JSMin'.
With this patch, the problem is solved.