### PR TITLE
Same length for weekdaysMin parts (Polish)

### DIFF
--- a/locale/pl.js
+++ b/locale/pl.js
@@ -47,7 +47,7 @@
         monthsShort : 'sty_lut_mar_kwi_maj_cze_lip_sie_wrz_paź_lis_gru'.split('_'),
         weekdays : 'niedziela_poniedziałek_wtorek_środa_czwartek_piątek_sobota'.split('_'),
         weekdaysShort : 'nie_pon_wt_śr_czw_pt_sb'.split('_'),
-        weekdaysMin : 'N_Pn_Wt_Śr_Cz_Pt_So'.split('_'),
+        weekdaysMin : 'Nd_Pn_Wt_Śr_Cz_Pt_So'.split('_'),
         longDateFormat : {
             LT : 'HH:mm',
             LTS : 'LT:ss',


### PR DESCRIPTION
I just tried to use the short Polish names and I noticed that "min" Polish weekday names haven't the same length (six of them are two-chars long, while "sunday" corresponds to "N"). Polish colleagues say there should be one more "d".
I'd also make all "short" names 3-chars long, agree?