### PR TITLE
Same length for weekdaysMin parts (Italian)

### DIFF
--- a/locale/it.js
+++ b/locale/it.js
@@ -17,7 +17,7 @@
         monthsShort : 'gen_feb_mar_apr_mag_giu_lug_ago_set_ott_nov_dic'.split('_'),
         weekdays : 'Domenica_Lunedì_Martedì_Mercoledì_Giovedì_Venerdì_Sabato'.split('_'),
         weekdaysShort : 'Dom_Lun_Mar_Mer_Gio_Ven_Sab'.split('_'),
-        weekdaysMin : 'D_L_Ma_Me_G_V_S'.split('_'),
+        weekdaysMin : 'Do_Lu_Ma_Me_Gi_Ve_Sa'.split('_'),
         longDateFormat : {
             LT : 'HH:mm',
             LTS : 'LT:ss',


### PR DESCRIPTION
I'm making timetables with weekdaysMin particles, but they look weird, since not all the days are same-sized.
I'm making all of them two-chars long.