### PR TITLE
included passed values in the range

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2432,6 +2432,11 @@
         },
 
         isBetween: function (from, to, units) {
+            
+            var value = ((this.isAfter(from, units) && this.isBefore(to, units)) || this.isSame(to, units) || this.isSame(from, units));
+
+            return value;
+
             return this.isAfter(from, units) && this.isBefore(to, units);
         },
 


### PR DESCRIPTION
The inBetween function doesn't check for the dates being passed, only dates between the dates being passed. It makes sense to check the actual dates too because they would be considered in the range passed.