### PR TITLE
Performance: improve parsing of moments from valid Date objects

### DIFF
--- a/benchmarks/fromDate.js
+++ b/benchmarks/fromDate.js
@@ -1,0 +1,12 @@
+var Benchmark = require('benchmark'),
+    moment = require('./../moment.js'),
+    base = new Date();
+
+module.exports = {
+  name: 'fromDate',
+  onComplete: function(){console.log('done');},
+  fn: function(){
+      moment(base);
+  },
+  async: true
+};

--- a/benchmarks/fromDateUtc.js
+++ b/benchmarks/fromDateUtc.js
@@ -1,0 +1,12 @@
+var Benchmark = require('benchmark'),
+    moment = require('./../moment.js'),
+    base = new Date();
+
+module.exports = {
+  name: 'fromDateUtc',
+  onComplete: function(){console.log('done');},
+  fn: function(){
+      moment.utc(base);
+  },
+  async: true
+};

--- a/src/lib/create/check-overflow.js
+++ b/src/lib/create/check-overflow.js
@@ -1,11 +1,12 @@
 import { daysInMonth } from '../units/month';
 import { YEAR, MONTH, DATE, HOUR, MINUTE, SECOND, MILLISECOND } from '../units/constants';
+import getParsingFlags from '../create/parsing-flags';
 
 export default function checkOverflow (m) {
     var overflow;
     var a = m._a;
 
-    if (a && m._pf.overflow === -2) {
+    if (a && getParsingFlags(m).overflow === -2) {
         overflow =
             a[MONTH]       < 0 || a[MONTH]       > 11  ? MONTH :
             a[DATE]        < 1 || a[DATE]        > daysInMonth(a[YEAR], a[MONTH]) ? DATE :
@@ -15,11 +16,11 @@ export default function checkOverflow (m) {
             a[MILLISECOND] < 0 || a[MILLISECOND] > 999 ? MILLISECOND :
             -1;
 
-        if (m._pf._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
+        if (getParsingFlags(m)._overflowDayOfYear && (overflow < YEAR || overflow > DATE)) {
             overflow = DATE;
         }
 
-        m._pf.overflow = overflow;
+        getParsingFlags(m).overflow = overflow;
     }
 
     return m;

--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -1,4 +1,3 @@
-import defaultParsingFlags from './default-parsing-flags';
 import isArray from '../utils/is-array';
 import isDate from '../utils/is-date';
 import map from '../utils/map';
@@ -87,7 +86,6 @@ export function createLocalOrUTC (input, format, locale, strict, isUTC) {
     c._i = input;
     c._f = format;
     c._strict = strict;
-    c._pf = defaultParsingFlags();
 
     return createFromConfig(c);
 }

--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -34,6 +34,8 @@ function createFromConfig (config) {
         configFromStringAndArray(config);
     } else if (format) {
         configFromStringAndFormat(config);
+    } else if (isDate(input)) {
+        config._d = input;
     } else {
         configFromInput(config);
     }

--- a/src/lib/create/from-array.js
+++ b/src/lib/create/from-array.js
@@ -5,6 +5,7 @@ import { dayOfYearFromWeeks } from '../units/day-of-year';
 import { YEAR, MONTH, DATE, HOUR, MINUTE, SECOND, MILLISECOND } from '../units/constants';
 import { createLocal } from './local';
 import defaults from '../utils/defaults';
+import getParsingFlags from './parsing-flags';
 
 function currentDateArray(config) {
     var now = new Date();
@@ -37,7 +38,7 @@ export function configFromArray (config) {
         yearToUse = defaults(config._a[YEAR], currentDate[YEAR]);
 
         if (config._dayOfYear > daysInYear(yearToUse)) {
-            config._pf._overflowDayOfYear = true;
+            getParsingFlags(config)._overflowDayOfYear = true;
         }
 
         date = createUTCDate(yearToUse, 0, config._dayOfYear);

--- a/src/lib/create/from-string-and-array.js
+++ b/src/lib/create/from-string-and-array.js
@@ -1,6 +1,6 @@
 import { copyConfig } from '../moment/constructor';
 import { configFromStringAndFormat } from './from-string-and-format';
-import defaultParsingFlags from './default-parsing-flags';
+import getParsingFlags from './parsing-flags';
 import { isValid } from './valid';
 import extend from '../utils/extend';
 
@@ -14,7 +14,7 @@ export function configFromStringAndArray(config) {
         currentScore;
 
     if (config._f.length === 0) {
-        config._pf.invalidFormat = true;
+        getParsingFlags(config).invalidFormat = true;
         config._d = new Date(NaN);
         return;
     }
@@ -25,7 +25,6 @@ export function configFromStringAndArray(config) {
         if (config._useUTC != null) {
             tempConfig._useUTC = config._useUTC;
         }
-        tempConfig._pf = defaultParsingFlags();
         tempConfig._f = config._f[i];
         configFromStringAndFormat(tempConfig);
 
@@ -34,12 +33,12 @@ export function configFromStringAndArray(config) {
         }
 
         // if there is any input that was not parsed add a penalty for that format
-        currentScore += tempConfig._pf.charsLeftOver;
+        currentScore += getParsingFlags(tempConfig).charsLeftOver;
 
         //or tokens
-        currentScore += tempConfig._pf.unusedTokens.length * 10;
+        currentScore += getParsingFlags(tempConfig).unusedTokens.length * 10;
 
-        tempConfig._pf.score = currentScore;
+        getParsingFlags(tempConfig).score = currentScore;
 
         if (scoreToBeat == null || currentScore < scoreToBeat) {
             scoreToBeat = currentScore;

--- a/src/lib/create/from-string-and-format.js
+++ b/src/lib/create/from-string-and-format.js
@@ -6,6 +6,7 @@ import { expandFormat, formatTokenFunctions, formattingTokens } from '../format/
 import checkOverflow from './check-overflow';
 import { HOUR } from '../units/constants';
 import { hooks } from '../utils/hooks';
+import getParsingFlags from './parsing-flags';
 
 // constant that refers to the ISO standard
 hooks.ISO_8601 = function () {};
@@ -19,7 +20,7 @@ export function configFromStringAndFormat(config) {
     }
 
     config._a = [];
-    config._pf.empty = true;
+    getParsingFlags(config).empty = true;
 
     // This array is used to make a Date, either with `new Date` or `Date.UTC`
     var string = '' + config._i,
@@ -35,7 +36,7 @@ export function configFromStringAndFormat(config) {
         if (parsedInput) {
             skipped = string.substr(0, string.indexOf(parsedInput));
             if (skipped.length > 0) {
-                config._pf.unusedInput.push(skipped);
+                getParsingFlags(config).unusedInput.push(skipped);
             }
             string = string.slice(string.indexOf(parsedInput) + parsedInput.length);
             totalParsedInputLength += parsedInput.length;
@@ -43,27 +44,27 @@ export function configFromStringAndFormat(config) {
         // don't parse if it's not a known token
         if (formatTokenFunctions[token]) {
             if (parsedInput) {
-                config._pf.empty = false;
+                getParsingFlags(config).empty = false;
             }
             else {
-                config._pf.unusedTokens.push(token);
+                getParsingFlags(config).unusedTokens.push(token);
             }
             addTimeToArrayFromToken(token, parsedInput, config);
         }
         else if (config._strict && !parsedInput) {
-            config._pf.unusedTokens.push(token);
+            getParsingFlags(config).unusedTokens.push(token);
         }
     }
 
     // add remaining unparsed input length to the string
-    config._pf.charsLeftOver = stringLength - totalParsedInputLength;
+    getParsingFlags(config).charsLeftOver = stringLength - totalParsedInputLength;
     if (string.length > 0) {
-        config._pf.unusedInput.push(string);
+        getParsingFlags(config).unusedInput.push(string);
     }
 
     // clear _12h flag if hour is <= 12
-    if (config._pf.bigHour === true && config._a[HOUR] <= 12) {
-        config._pf.bigHour = undefined;
+    if (getParsingFlags(config).bigHour === true && config._a[HOUR] <= 12) {
+        getParsingFlags(config).bigHour = undefined;
     }
     // handle meridiem
     config._a[HOUR] = meridiemFixWrap(config._locale, config._a[HOUR], config._meridiem);

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -2,6 +2,7 @@ import { matchOffset } from '../parse/regex';
 import { configFromStringAndFormat } from './from-string-and-format';
 import { hooks } from '../utils/hooks';
 import { deprecate } from '../utils/deprecate';
+import getParsingFlags from './parsing-flags';
 
 // iso 8601 regex
 // 0000-00-00 0000-W00 or 0000-W00-0 + T + 00 or 00:00 or 00:00:00 or 00:00:00.000 + +00:00 or +0000 or +00)
@@ -32,7 +33,7 @@ export function configFromISO(config) {
         match = isoRegex.exec(string);
 
     if (match) {
-        config._pf.iso = true;
+        getParsingFlags(config).iso = true;
         for (i = 0, l = isoDates.length; i < l; i++) {
             if (isoDates[i][1].exec(string)) {
                 // match[5] should be 'T' or undefined

--- a/src/lib/create/parsing-flags.js
+++ b/src/lib/create/parsing-flags.js
@@ -1,4 +1,4 @@
-export default function defaultParsingFlags() {
+function defaultParsingFlags() {
     // We need to deep clone this object.
     return {
         empty           : false,
@@ -12,4 +12,11 @@ export default function defaultParsingFlags() {
         userInvalidated : false,
         iso             : false
     };
+}
+
+export default function getParsingFlags(m) {
+    if (m._pf == null) {
+        m._pf = defaultParsingFlags();
+    }
+    return m._pf;
 }

--- a/src/lib/create/valid.js
+++ b/src/lib/create/valid.js
@@ -1,21 +1,23 @@
 import extend from '../utils/extend';
 import { createUTC } from './utc';
+import getParsingFlags from '../create/parsing-flags';
 
 export function isValid(m) {
     if (m._isValid == null) {
+        var flags = getParsingFlags(m);
         m._isValid = !isNaN(m._d.getTime()) &&
-            m._pf.overflow < 0 &&
-            !m._pf.empty &&
-            !m._pf.invalidMonth &&
-            !m._pf.nullInput &&
-            !m._pf.invalidFormat &&
-            !m._pf.userInvalidated;
+            flags.overflow < 0 &&
+            !flags.empty &&
+            !flags.invalidMonth &&
+            !flags.nullInput &&
+            !flags.invalidFormat &&
+            !flags.userInvalidated;
 
         if (m._strict) {
             m._isValid = m._isValid &&
-                m._pf.charsLeftOver === 0 &&
-                m._pf.unusedTokens.length === 0 &&
-                m._pf.bigHour === undefined;
+                flags.charsLeftOver === 0 &&
+                flags.unusedTokens.length === 0 &&
+                flags.bigHour === undefined;
         }
     }
     return m._isValid;
@@ -24,10 +26,10 @@ export function isValid(m) {
 export function createInvalid (flags) {
     var m = createUTC(NaN);
     if (flags != null) {
-        extend(m._pf, flags);
+        extend(getParsingFlags(m), flags);
     }
     else {
-        m._pf.userInvalidated = true;
+        getParsingFlags(m).userInvalidated = true;
     }
 
     return m;

--- a/src/lib/moment/constructor.js
+++ b/src/lib/moment/constructor.js
@@ -69,5 +69,5 @@ export function Moment(config) {
 }
 
 export function isMoment (obj) {
-    return obj instanceof Moment || (obj != null && hasOwnProp(obj, '_isAMomentObject'));
+    return obj instanceof Moment || (obj != null && obj._isAMomentObject != null);
 }

--- a/src/lib/moment/constructor.js
+++ b/src/lib/moment/constructor.js
@@ -1,5 +1,6 @@
 import { hooks } from '../utils/hooks';
 import hasOwnProp from '../utils/has-own-prop';
+import getParsingFlags from '../create/parsing-flags';
 
 // Plugins that add properties should also add the key here (null value),
 // so we can properly clone ourselves.
@@ -33,7 +34,7 @@ export function copyConfig(to, from) {
         to._offset = from._offset;
     }
     if (typeof from._pf !== 'undefined') {
-        to._pf = from._pf;
+        to._pf = getParsingFlags(from);
     }
     if (typeof from._locale !== 'undefined') {
         to._locale = from._locale;

--- a/src/lib/moment/valid.js
+++ b/src/lib/moment/valid.js
@@ -1,14 +1,15 @@
 import { isValid as _isValid } from '../create/valid';
 import extend from '../utils/extend';
+import getParsingFlags from '../create/parsing-flags';
 
 export function isValid () {
     return _isValid(this);
 }
 
 export function parsingFlags () {
-    return extend({}, this._pf);
+    return extend({}, getParsingFlags(this));
 }
 
 export function invalidAt () {
-    return this._pf.overflow;
+    return getParsingFlags(this).overflow;
 }

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -4,6 +4,7 @@ import { addRegexToken, match1to2, matchWord } from '../parse/regex';
 import { addWeekParseToken } from '../parse/token';
 import toInt from '../utils/to-int';
 import { createLocal } from '../create/local';
+import getParsingFlags from '../create/parsing-flags';
 
 // FORMATTING
 
@@ -45,7 +46,7 @@ addWeekParseToken(['dd', 'ddd', 'dddd'], function (input, week, config) {
     if (weekday != null) {
         week.d = weekday;
     } else {
-        config._pf.invalidWeekday = input;
+        getParsingFlags(config).invalidWeekday = input;
     }
 });
 

--- a/src/lib/units/hour.js
+++ b/src/lib/units/hour.js
@@ -5,6 +5,7 @@ import { addRegexToken, match1to2, match2 } from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { HOUR } from './constants';
 import toInt from '../utils/to-int';
+import getParsingFlags from '../create/parsing-flags';
 
 // FORMATTING
 
@@ -46,7 +47,7 @@ addParseToken(['a', 'A'], function (input, array, config) {
 });
 addParseToken(['h', 'hh'], function (input, array, config) {
     array[HOUR] = toInt(input);
-    config._pf.bigHour = true;
+    getParsingFlags(config).bigHour = true;
 });
 
 // LOCALES

--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -7,6 +7,7 @@ import { hooks } from '../utils/hooks';
 import { MONTH } from './constants';
 import toInt from '../utils/to-int';
 import { createUTC } from '../create/utc';
+import getParsingFlags from '../create/parsing-flags';
 
 export function daysInMonth(year, month) {
     return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
@@ -47,7 +48,7 @@ addParseToken(['MMM', 'MMMM'], function (input, array, config, token) {
     if (month != null) {
         array[MONTH] = month;
     } else {
-        config._pf.invalidMonth = input;
+        getParsingFlags(config).invalidMonth = input;
     }
 });
 

--- a/src/lib/utils/is-date.js
+++ b/src/lib/utils/is-date.js
@@ -1,3 +1,3 @@
 export default function isDate(input) {
-    return Object.prototype.toString.call(input) === '[object Date]' || input instanceof Date;
+    return input instanceof Date || Object.prototype.toString.call(input) === '[object Date]';
 }


### PR DESCRIPTION
EDIT: es6 stuff is merged, so this PR needs to get rewritten.  I do plan on getting to it, but not immediately.

For explanation of some of these changes, I'll discuss my numbers.  I'm doing this from memory and can re-measure if necessary, but...  My CPU profile in Chrome started at 400ms, and after this suite of changes, the profile was reduced to 200ms.

* https://github.com/brianwyantora/moment/commit/6bc5d2e075b0cad32083ea5209bb6ac695029aa7
  - This change resulted in a reduction of about 70ms on my profile.
  - Basically, in my use case, I never send invalid dates from server to client.  So while I might do some work on the first date sent from the server to make sure the browser can parse it, once I've done that, I won't call `moment.fn.isValid()`.  Generating the parsing flags takes a notable amount of time, so deferring that generation is a significant help.
* https://github.com/brianwyantora/moment/commit/928e068349c10d90bceb5266727e016f0cda1259
  - This change resulted in a reduction of about 60ms on my profile.
  - This change might look wrong on first glance, but notice - `makeMoment` is only called from two places (the public constructors), and will pass the config object through `new Moment(config)`.  `Moment` already clones the date, so doing the same in `makeMoment` is just duplicating work unnecessarily.