### PR TITLE
Merge date and time

### DIFF
--- a/src/lib/create/merge.js
+++ b/src/lib/create/merge.js
@@ -1,0 +1,11 @@
+import { createLocalOrUTC } from '../create/from-anything.js';
+
+export function merge (datePart, timePart) {
+    var input = [
+        datePart.getFullYear(), datePart.getMonth(), datePart.getDate(),
+        timePart.getHours(), timePart.getMinutes(), timePart.getSeconds()
+    ];
+
+    var output = createLocalOrUTC(input);
+    return output;
+}

--- a/src/lib/create/merge.js
+++ b/src/lib/create/merge.js
@@ -1,10 +1,22 @@
 import { createLocalOrUTC } from '../create/from-anything.js';
+import { isMoment } from '../moment/constructor.js';
+import isDate from '../utils/is-date.js';
 
 export function merge (datePart, timePart) {
-    var input = [
-        datePart.getFullYear(), datePart.getMonth(), datePart.getDate(),
-        timePart.getHours(), timePart.getMinutes(), timePart.getSeconds()
-    ];
+    var input;
+
+    if(isMoment(datePart) && isMoment(timePart)) {
+        input = [
+            datePart.year(), datePart.month(), datePart.date(),
+            timePart.hour(), timePart.minute(), timePart.second()
+        ];
+    }
+    else if(isDate(datePart) && isDate(timePart)) {
+        input = [
+            datePart.getFullYear(), datePart.getMonth(), datePart.getDate(),
+            timePart.getHours(), timePart.getMinutes(), timePart.getSeconds()
+        ];
+    }
 
     var output = createLocalOrUTC(input);
     return output;

--- a/src/lib/create/merge.js
+++ b/src/lib/create/merge.js
@@ -3,20 +3,14 @@ import { isMoment } from '../moment/constructor.js';
 import isDate from '../utils/is-date.js';
 
 export function merge (datePart, timePart) {
-    var input;
+    datePart = createLocalOrUTC(datePart);
+    timePart = createLocalOrUTC(timePart);
 
-    if(isMoment(datePart) && isMoment(timePart)) {
-        input = [
-            datePart.year(), datePart.month(), datePart.date(),
-            timePart.hour(), timePart.minute(), timePart.second()
-        ];
-    }
-    else if(isDate(datePart) && isDate(timePart)) {
-        input = [
-            datePart.getFullYear(), datePart.getMonth(), datePart.getDate(),
-            timePart.getHours(), timePart.getMinutes(), timePart.getSeconds()
-        ];
-    }
+    var input;
+    input = [
+        datePart.year(), datePart.month(), datePart.date(),
+        timePart.hour(), timePart.minute(), timePart.second()
+    ];
 
     var output = createLocalOrUTC(input);
     return output;

--- a/src/lib/create/merge.js
+++ b/src/lib/create/merge.js
@@ -1,6 +1,4 @@
 import { createLocalOrUTC } from '../create/from-anything.js';
-import { isMoment } from '../moment/constructor.js';
-import isDate from '../utils/is-date.js';
 
 export function merge (datePart, timePart) {
     datePart = createLocalOrUTC(datePart);

--- a/src/lib/moment/moment.js
+++ b/src/lib/moment/moment.js
@@ -3,6 +3,7 @@ import { createUTC } from '../create/utc';
 import { createInvalid } from '../create/valid';
 import { isMoment } from './constructor';
 import { min, max } from './min-max';
+import { merge} from '../create/merge.js';
 import momentPrototype from './prototype';
 
 function createUnix (input) {
@@ -16,6 +17,7 @@ function createInZone () {
 export {
     min,
     max,
+    merge,
     isMoment,
     createUTC,
     createUnix,

--- a/src/moment.js
+++ b/src/moment.js
@@ -11,6 +11,7 @@ moment.version = '2.10.2';
 import {
     min,
     max,
+    merge,
     isMoment,
     momentPrototype as fn,
     createUTC       as utc,
@@ -48,6 +49,7 @@ moment.min                   = min;
 moment.max                   = max;
 moment.utc                   = utc;
 moment.unix                  = unix;
+moment.merge                 = merge;
 moment.months                = months;
 moment.isDate                = isDate;
 moment.locale                = locale;

--- a/src/test/moment/merge.js
+++ b/src/test/moment/merge.js
@@ -1,0 +1,16 @@
+import { module, test } from '../qunit';
+import moment from '../../moment';
+
+module('merge');
+
+test('merge two Date objects', function (assert) {
+    var year = 2010, month = 5, day = 3,
+        hour = 10, minute = 20, second = 30,
+        datePart = new Date(year, month, day),
+        timePart = new Date(0, 0, 0, hour, minute, second),
+        expected = moment([year, month, day, hour, minute, second]);
+
+    var merged = moment.merge(datePart, timePart);
+
+    assert.equal(merged.isSame(expected), true, 'merge(datePart, timePart)');
+});

--- a/src/test/moment/merge.js
+++ b/src/test/moment/merge.js
@@ -3,26 +3,26 @@ import moment from '../../moment';
 
 module('merge');
 
-test('merge two Date objects', function (assert) {
+test('merge', function (assert) {
     var year = 2010, month = 5, day = 3,
         hour = 10, minute = 20, second = 30,
-        datePart = new Date(year, month, day),
-        timePart = new Date(0, 0, 0, hour, minute, second),
-        expected = moment([year, month, day, hour, minute, second]);
+        dateDate = new Date(year, month, day),
+        timeDate = new Date(0, 0, 0, hour, minute, second),
+        dateMoment = moment([year, month, day]),
+        timeMoment = moment([0, 0, 0, hour, minute, second]);
 
-    var merged = moment.merge(datePart, timePart);
+    var expected = moment([year, month, day, hour, minute, second]);
 
-    assert.equal(merged.isSame(expected), true, 'merge(datePart, timePart)');
-});
+    var combinations = [
+        {date: dateDate, time: timeDate, desc: 'merge(date, date)'},
+        {date: dateMoment, time: timeMoment, desc: 'merge(moment, moment)'},
+        {date: dateDate, time: timeMoment, desc: 'merge(date, moment)'},
+        {date: dateMoment, time: timeDate, desc: 'merge(moment, date)'}
+    ];
 
-test('merge two Moment objects', function (assert) {
-    var year = 2010, month = 5, day = 3,
-        hour = 10, minute = 20, second = 30,
-        datePart = moment([year, month, day]),
-        timePart = moment([0, 0, 0, hour, minute, second]),
-        expected = moment([year, month, day, hour, minute, second]);
+    combinations.forEach(function (combination) {
+        var merged = moment.merge(combination.date, combination.time);
 
-    var merged = moment.merge(datePart, timePart);
-
-    assert.equal(merged.isSame(expected), true, 'merge(datePart, timePart), merged: ' + merged.format() + ', expected: ' + expected.format() + ', datePart: ' + datePart.format() + ', timePart: ' + timePart.format());
+        assert.equal(merged.isSame(expected), true, combination.desc);
+    });
 });

--- a/src/test/moment/merge.js
+++ b/src/test/moment/merge.js
@@ -14,3 +14,15 @@ test('merge two Date objects', function (assert) {
 
     assert.equal(merged.isSame(expected), true, 'merge(datePart, timePart)');
 });
+
+test('merge two Moment objects', function (assert) {
+    var year = 2010, month = 5, day = 3,
+        hour = 10, minute = 20, second = 30,
+        datePart = moment([year, month, day]),
+        timePart = moment([0, 0, 0, hour, minute, second]),
+        expected = moment([year, month, day, hour, minute, second]);
+
+    var merged = moment.merge(datePart, timePart);
+
+    assert.equal(merged.isSame(expected), true, 'merge(datePart, timePart), merged: ' + merged.format() + ', expected: ' + expected.format() + ', datePart: ' + datePart.format() + ', timePart: ' + timePart.format());
+});


### PR DESCRIPTION
I added a new merge method that combines date and time components from different sources.

This simplifies common use cases, such as one in which forms display separate date and time fields whose values then have to be merged before sending or processing the data.

The purpose is to be able to do something along these lines (pseudocode):

    var fullDateTime = moment.merge(dateField.value, timeField.value);
    var forDisplay = fullDateTime.format();
    sendToServer(fullDateTime.toDate());

The implementation allows the date and time components to be specified separately, in different ways. For example, the date could be a Date object and the time could be a string or a Moment object.