### PR TITLE
Pass duration to relativeTime's formatting handlers

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -2602,10 +2602,10 @@
         yy : '%d years'
     };
 
-    function relative__relativeTime (number, withoutSuffix, string, isFuture) {
+    function relative__relativeTime (number, withoutSuffix, string, isFuture, duration) {
         var output = this._relativeTime[string];
         return (typeof output === 'function') ?
-            output(number, withoutSuffix, string, isFuture) :
+            output(number, withoutSuffix, string, isFuture, duration) :
             output.replace(/%d/i, number);
     }
 
@@ -2913,8 +2913,8 @@
     };
 
     // helper function for moment.fn.from, moment.fn.fromNow, and moment.duration.fn.humanize
-    function substituteTimeAgo(string, number, withoutSuffix, isFuture, locale) {
-        return locale.relativeTime(number || 1, !!withoutSuffix, string, isFuture);
+    function substituteTimeAgo(string, number, withoutSuffix, isFuture, locale, duration) {
+        return locale.relativeTime(number || 1, !!withoutSuffix, string, isFuture, duration);
     }
 
     function duration_humanize__relativeTime (posNegDuration, withoutSuffix, locale) {
@@ -2940,6 +2940,7 @@
         a[2] = withoutSuffix;
         a[3] = +posNegDuration > 0;
         a[4] = locale;
+        a[5] = duration;
         return substituteTimeAgo.apply(null, a);
     }
 

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -10,8 +10,8 @@ var thresholds = {
 };
 
 // helper function for moment.fn.from, moment.fn.fromNow, and moment.duration.fn.humanize
-function substituteTimeAgo(string, number, withoutSuffix, isFuture, locale) {
-    return locale.relativeTime(number || 1, !!withoutSuffix, string, isFuture);
+function substituteTimeAgo(string, number, withoutSuffix, isFuture, locale, duration) {
+    return locale.relativeTime(number || 1, !!withoutSuffix, string, isFuture, duration);
 }
 
 function relativeTime (posNegDuration, withoutSuffix, locale) {
@@ -37,6 +37,7 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
     a[2] = withoutSuffix;
     a[3] = +posNegDuration > 0;
     a[4] = locale;
+    a[5] = duration;
     return substituteTimeAgo.apply(null, a);
 }
 

--- a/src/lib/locale/relative.js
+++ b/src/lib/locale/relative.js
@@ -14,10 +14,10 @@ export var defaultRelativeTime = {
     yy : '%d years'
 };
 
-export function relativeTime (number, withoutSuffix, string, isFuture) {
+export function relativeTime (number, withoutSuffix, string, isFuture, duration) {
     var output = this._relativeTime[string];
     return (typeof output === 'function') ?
-        output(number, withoutSuffix, string, isFuture) :
+        output(number, withoutSuffix, string, isFuture, duration) :
         output.replace(/%d/i, number);
 }
 


### PR DESCRIPTION
This gives more flexibility to do things like "2 days and 6 hours ago" for example instead of the current "2 days ago".

Of course the parameter is completely optional and doesn't disturb anything else. 

Thank you in advance.