### PR TITLE
Standard nomenclature (pt, pt-br, es)

### DIFF
--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -4,11 +4,11 @@
 
 import moment from '../moment';
 
-var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
-    monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');
+var monthsShortDot = 'Ene._Feb._Mar._Abr._May._Jun._Jul._Ago._Sep._Oct._Nov._Dic.'.split('_'),
+    monthsShort = 'Ene_Feb_Mar_Abr_May_Jun_Jul_Ago_Sep_Oct_Nov_Dic'.split('_');
 
 export default moment.defineLocale('es', {
-    months : 'enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre'.split('_'),
+    months : 'Enero_Febrero_Marzo_Abril_Mayo_Junio_Julio_Agosto_Septiembre_Octubre_Noviembre_Diciembre'.split('_'),
     monthsShort : function (m, format) {
         if (/-MMM-/.test(format)) {
             return monthsShort[m.month()];
@@ -16,8 +16,8 @@ export default moment.defineLocale('es', {
             return monthsShortDot[m.month()];
         }
     },
-    weekdays : 'domingo_lunes_martes_miércoles_jueves_viernes_sábado'.split('_'),
-    weekdaysShort : 'dom._lun._mar._mié._jue._vie._sáb.'.split('_'),
+    weekdays : 'Domingo_Lunes_Martes_Miércoles_Jueves_Viernes_Sábado'.split('_'),
+    weekdaysShort : 'Dom._Lun._Mar._Mié._Jue._Vie._Sáb.'.split('_'),
     weekdaysMin : 'Do_Lu_Ma_Mi_Ju_Vi_Sá'.split('_'),
     longDateFormat : {
         LT : 'H:mm',

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -6,7 +6,7 @@ import moment from '../moment';
 
 export default moment.defineLocale('pt-br', {
     months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-    monthsShort : 'Jan_Fev_Mar_abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+    monthsShort : 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
     weekdays : 'Domingo_Segunda-Feira_Terça-Feira_Quarta-Feira_Quinta-Feira_Sexta-Feira_Sábado'.split('_'),
     weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
     weekdaysMin : 'Dom_2ª_3ª_4ª_5ª_6ª_Sáb'.split('_'),

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -5,11 +5,11 @@
 import moment from '../moment';
 
 export default moment.defineLocale('pt-br', {
-    months : 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
-    monthsShort : 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
-    weekdays : 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
-    weekdaysShort : 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
-    weekdaysMin : 'dom_2ª_3ª_4ª_5ª_6ª_sáb'.split('_'),
+    months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
+    monthsShort : 'Jan_Fev_Mar_abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+    weekdays : 'Domingo_Segunda-Feira_Terça-Feira_Quarta-Feira_Quinta-Feira_Sexta-Feira_Sábado'.split('_'),
+    weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
+    weekdaysMin : 'Dom_2ª_3ª_4ª_5ª_6ª_Sáb'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'LT:ss',

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -5,11 +5,11 @@
 import moment from '../moment';
 
 export default moment.defineLocale('pt', {
-    months : 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
-    monthsShort : 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
-    weekdays : 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
-    weekdaysShort : 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
-    weekdaysMin : 'dom_2ª_3ª_4ª_5ª_6ª_sáb'.split('_'),
+    months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
+    monthsShort : 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+    weekdays : 'Domingo_Segunda-Feira_Terça-Feira_Quarta-Feira_Quinta-Feira_Sexta-Feira_Sábado'.split('_'),
+    weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
+    weekdaysMin : 'Dom_2ª_3ª_4ª_5ª_6ª_Sáb'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'LT:ss',

--- a/src/test/locale/es.js
+++ b/src/test/locale/es.js
@@ -22,15 +22,15 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'domingo, febrero 14º 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'dom., 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2º 02 febrero feb.'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Domingo, Febrero 14º 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Dom., 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2º 02 Febrero Feb.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14º 14'],
-            ['d do dddd ddd dd',                   '0 0º domingo dom. Do'],
+            ['d do dddd ddd dd',                   '0 0º Domingo Dom. Do'],
             ['DDD DDDo DDDD',                      '45 45º 045'],
             ['w wo ww',                            '6 6º 06'],
-            ['YYYY-MMM-DD',                        '2010-feb-14'],
+            ['YYYY-MMM-DD',                        '2010-Feb-14'],
             ['h hh',                               '3 03'],
             ['H HH',                               '15 15'],
             ['m mm',                               '25 25'],
@@ -39,13 +39,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45º day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 de febrero de 2010'],
-            ['LLL',                                '14 de febrero de 2010 15:25'],
-            ['LLLL',                               'domingo, 14 de febrero de 2010 15:25'],
+            ['LL',                                 '14 de Febrero de 2010'],
+            ['LLL',                                '14 de Febrero de 2010 15:25'],
+            ['LLLL',                               'Domingo, 14 de Febrero de 2010 15:25'],
             ['l',                                  '14/2/2010'],
-            ['ll',                                 '14 de feb. de 2010'],
-            ['lll',                                '14 de feb. de 2010 15:25'],
-            ['llll',                               'dom., 14 de feb. de 2010 15:25']
+            ['ll',                                 '14 de Feb. de 2010'],
+            ['lll',                                '14 de Feb. de 2010 15:25'],
+            ['llll',                               'Dom., 14 de Feb. de 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -92,14 +92,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'enero ene._febrero feb._marzo mar._abril abr._mayo may._junio jun._julio jul._agosto ago._septiembre sep._octubre oct._noviembre nov._diciembre dic.'.split('_'), i;
+    var expected = 'Enero Ene._Febrero Feb._Marzo Mar._Abril Abr._Mayo May._Junio Jun._Julio Jul._Agosto Ago._Septiembre Sep._Octubre Oct._Noviembre Nov._Diciembre Dic.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'domingo dom. Do_lunes lun. Lu_martes mar. Ma_miércoles mié. Mi_jueves jue. Ju_viernes vie. Vi_sábado sáb. Sá'.split('_'), i;
+    var expected = 'Domingo Dom. Do_Lunes Lun. Lu_Martes Mar. Ma_Miércoles Mié. Mi_Jueves Jue. Ju_Viernes Vie. Vi_Sábado Sáb. Sá'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/locale/pt-br.js
+++ b/src/test/locale/pt-br.js
@@ -24,12 +24,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'domingo, fevereiro 14º 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'dom, 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2º 02 fevereiro fev'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Domingo, Fevereiro 14º 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Dom, 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2º 02 Fevereiro Fev'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14º 14'],
-            ['d do dddd ddd',                      '0 0º domingo dom'],
+            ['d do dddd ddd',                      '0 0º Domingo Dom'],
             ['DDD DDDo DDDD',                      '45 45º 045'],
             ['w wo ww',                            '8 8º 08'],
             ['h hh',                               '3 03'],
@@ -40,13 +40,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45º day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 de fevereiro de 2010'],
-            ['LLL',                                '14 de fevereiro de 2010 às 15:25'],
-            ['LLLL',                               'domingo, 14 de fevereiro de 2010 às 15:25'],
+            ['LL',                                 '14 de Fevereiro de 2010'],
+            ['LLL',                                '14 de Fevereiro de 2010 às 15:25'],
+            ['LLLL',                               'Domingo, 14 de Fevereiro de 2010 às 15:25'],
             ['l',                                  '14/2/2010'],
-            ['ll',                                 '14 de fev de 2010'],
-            ['lll',                                '14 de fev de 2010 às 15:25'],
-            ['llll',                               'dom, 14 de fev de 2010 às 15:25']
+            ['ll',                                 '14 de Fev de 2010'],
+            ['lll',                                '14 de Fev de 2010 às 15:25'],
+            ['llll',                               'Dom, 14 de Fev de 2010 às 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -93,14 +93,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'janeiro jan_fevereiro fev_março mar_abril abr_maio mai_junho jun_julho jul_agosto ago_setembro set_outubro out_novembro nov_dezembro dez'.split('_'), i;
+    var expected = 'Janeiro Jan_Fevereiro Fev_Março Mar_Abril Abr_Maio Mai_Junho Jun_Julho Jul_Agosto Ago_Setembro Set_Outubro Out_Novembro Nov_Dezembro Dez'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'domingo dom_segunda-feira seg_terça-feira ter_quarta-feira qua_quinta-feira qui_sexta-feira sex_sábado sáb'.split('_'), i;
+    var expected = 'Domingo Dom_Segunda-Feira Seg_Terça-Feira Ter_Quarta-Feira Qua_Quinta-Feira Qui_Sexta-Feira Sex_Sábado Sáb'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd'), expected[i], expected[i]);
     }

--- a/src/test/locale/pt.js
+++ b/src/test/locale/pt.js
@@ -22,12 +22,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'domingo, fevereiro 14º 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'dom, 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2º 02 fevereiro fev'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Domingo, Fevereiro 14º 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Dom, 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2º 02 Fevereiro Fev'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14º 14'],
-            ['d do dddd ddd dd',                   '0 0º domingo dom dom'],
+            ['d do dddd ddd',                      '0 0º Domingo Dom'],
             ['DDD DDDo DDDD',                      '45 45º 045'],
             ['w wo ww',                            '6 6º 06'],
             ['h hh',                               '3 03'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45º day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 de fevereiro de 2010'],
-            ['LLL',                                '14 de fevereiro de 2010 15:25'],
-            ['LLLL',                               'domingo, 14 de fevereiro de 2010 15:25'],
+            ['LL',                                 '14 de Fevereiro de 2010'],
+            ['LLL',                                '14 de Fevereiro de 2010 15:25'],
+            ['LLLL',                               'Domingo, 14 de Fevereiro de 2010 15:25'],
             ['l',                                  '14/2/2010'],
-            ['ll',                                 '14 de fev de 2010'],
-            ['lll',                                '14 de fev de 2010 15:25'],
-            ['llll',                               'dom, 14 de fev de 2010 15:25']
+            ['ll',                                 '14 de Fev de 2010'],
+            ['lll',                                '14 de Fev de 2010 15:25'],
+            ['llll',                               'Dom, 14 de Fev de 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,14 +91,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'janeiro jan_fevereiro fev_março mar_abril abr_maio mai_junho jun_julho jul_agosto ago_setembro set_outubro out_novembro nov_dezembro dez'.split('_'), i;
+    var expected = 'Janeiro Jan_Fevereiro Fev_Março Mar_Abril Abr_Maio Mai_Junho Jun_Julho Jul_Agosto Ago_Setembro Set_Outubro Out_Novembro Nov_Dezembro Dez'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'domingo dom dom_segunda-feira seg 2ª_terça-feira ter 3ª_quarta-feira qua 4ª_quinta-feira qui 5ª_sexta-feira sex 6ª_sábado sáb sáb'.split('_'), i;
+    var expected = 'Domingo Dom Dom_Segunda-Feira Seg 2ª_Terça-Feira Ter 3ª_Quarta-Feira Qua 4ª_Quinta-Feira Qui 5ª_Sexta-Feira Sex 6ª_Sábado Sáb Sáb'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -135,7 +135,7 @@ test('library localeData', function (assert) {
 
     assert.equal(moment.localeData().months(jan), 'January', 'no arguments returns global');
     assert.equal(moment.localeData('zh-cn').months(jan), '一月', 'a string returns the locale based on key');
-    assert.equal(moment.localeData(moment().locale('es')).months(jan), 'enero', 'if you pass in a moment it uses the moment\'s locale');
+    assert.equal(moment.localeData(moment().locale('es')).months(jan), 'Enero', 'if you pass in a moment it uses the moment\'s locale');
 });
 
 test('library deprecations', function (assert) {
@@ -169,7 +169,7 @@ test('instance locale method', function (assert) {
     moment.locale('en');
 
     assert.equal(moment([2012, 5, 6]).format('MMMM'), 'June', 'Normally default to global');
-    assert.equal(moment([2012, 5, 6]).locale('es').format('MMMM'), 'junio', 'Use the instance specific locale');
+    assert.equal(moment([2012, 5, 6]).locale('es').format('MMMM'), 'Junio', 'Use the instance specific locale');
     assert.equal(moment([2012, 5, 6]).format('MMMM'), 'June', 'Using an instance specific locale does not affect other moments');
 });
 
@@ -193,9 +193,9 @@ test('instance getter locale substrings', function (assert) {
 test('instance locale persists with manipulation', function (assert) {
     moment.locale('en');
 
-    assert.equal(moment([2012, 5, 6]).locale('es').add({days: 1}).format('MMMM'), 'junio', 'With addition');
-    assert.equal(moment([2012, 5, 6]).locale('es').day(0).format('MMMM'), 'junio', 'With day getter');
-    assert.equal(moment([2012, 5, 6]).locale('es').endOf('day').format('MMMM'), 'junio', 'With endOf');
+    assert.equal(moment([2012, 5, 6]).locale('es').add({days: 1}).format('MMMM'), 'Junio', 'With addition');
+    assert.equal(moment([2012, 5, 6]).locale('es').day(0).format('MMMM'), 'Junio', 'With day getter');
+    assert.equal(moment([2012, 5, 6]).locale('es').endOf('day').format('MMMM'), 'Junio', 'With endOf');
 });
 
 test('instance locale persists with cloning', function (assert) {
@@ -205,8 +205,8 @@ test('instance locale persists with cloning', function (assert) {
         b = a.clone(),
         c = moment(a);
 
-    assert.equal(b.format('MMMM'), 'junio', 'using moment.fn.clone()');
-    assert.equal(b.format('MMMM'), 'junio', 'using moment()');
+    assert.equal(b.format('MMMM'), 'Junio', 'using moment.fn.clone()');
+    assert.equal(b.format('MMMM'), 'Junio', 'using moment()');
 });
 
 test('duration locale method', function (assert) {


### PR DESCRIPTION
I realized in pt and pt-br have some different things than others. In english and some other languages, the first of the characters is in uppercase. So why is different in pt and pt-br?

I started to implement the change, missing the tests yet and adjust in locale/pt. But I wonder if I can adjust.

**Note: DON'T merge this PR yet. Tests Failing.**