### PR TITLE
Add the minute unit of time for zh-cn and zh-tw locales and update tests.

### DIFF
--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -12,7 +12,7 @@ export default moment.defineLocale('zh-cn', {
     weekdaysShort : '周日_周一_周二_周三_周四_周五_周六'.split('_'),
     weekdaysMin : '日_一_二_三_四_五_六'.split('_'),
     longDateFormat : {
-        LT : 'Ah点mm',
+        LT : 'Ah点mm分',
         LTS : 'Ah点m分s秒',
         L : 'YYYY-MM-DD',
         LL : 'YYYY年MMMD日',

--- a/src/locale/zh-tw.js
+++ b/src/locale/zh-tw.js
@@ -11,7 +11,7 @@ export default moment.defineLocale('zh-tw', {
     weekdaysShort : '週日_週一_週二_週三_週四_週五_週六'.split('_'),
     weekdaysMin : '日_一_二_三_四_五_六'.split('_'),
     longDateFormat : {
-        LT : 'Ah點mm',
+        LT : 'Ah點mm分',
         LTS : 'Ah點m分s秒',
         L : 'YYYY年MMMD日',
         LL : 'YYYY年MMMD日',
@@ -89,4 +89,3 @@ export default moment.defineLocale('zh-tw', {
         yy : '%d年'
     }
 });
-

--- a/src/test/locale/zh-cn.js
+++ b/src/test/locale/zh-cn.js
@@ -41,12 +41,12 @@ test('format', function (assert) {
             ['LTS',                                '下午3点25分50秒'],
             ['L',                                  '2010-02-14'],
             ['LL',                                 '2010年2月14日'],
-            ['LLL',                                '2010年2月14日下午3点25'],
-            ['LLLL',                               '2010年2月14日星期日下午3点25'],
+            ['LLL',                                '2010年2月14日下午3点25分'],
+            ['LLLL',                               '2010年2月14日星期日下午3点25分'],
             ['l',                                  '2010-02-14'],
             ['ll',                                 '2010年2月14日'],
-            ['lll',                                '2010年2月14日下午3点25'],
-            ['llll',                               '2010年2月14日星期日下午3点25']
+            ['lll',                                '2010年2月14日下午3点25分'],
+            ['llll',                               '2010年2月14日星期日下午3点25分']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -121,8 +121,8 @@ test('fromNow', function (assert) {
 test('calendar day', function (assert) {
     var a = moment().hours(2).minutes(0).seconds(0);
 
-    assert.equal(moment(a).calendar(),                     '今天凌晨2点整',     'today at the same time');
-    assert.equal(moment(a).add({m: 25}).calendar(),      '今天凌晨2点25',     'Now plus 25 min');
+    assert.equal(moment(a).calendar(),                   '今天凌晨2点整',     'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(),      '今天凌晨2点25分',   'Now plus 25 min');
     assert.equal(moment(a).add({h: 1}).calendar(),       '今天凌晨3点整',     'Now plus 1 hour');
     assert.equal(moment(a).add({d: 1}).calendar(),       '明天凌晨2点整',     'tomorrow at the same time');
     assert.equal(moment(a).subtract({h: 1}).calendar(),  '今天凌晨1点整',     'Now minus 1 hour');

--- a/src/test/locale/zh-tw.js
+++ b/src/test/locale/zh-tw.js
@@ -39,12 +39,12 @@ test('format', function (assert) {
             ['LTS',                                '下午3點25分50秒'],
             ['L',                                  '2010年2月14日'],
             ['LL',                                 '2010年2月14日'],
-            ['LLL',                                '2010年2月14日下午3點25'],
-            ['LLLL',                               '2010年2月14日星期日下午3點25'],
+            ['LLL',                                '2010年2月14日下午3點25分'],
+            ['LLLL',                               '2010年2月14日星期日下午3點25分'],
             ['l',                                  '2010年2月14日'],
             ['ll',                                 '2010年2月14日'],
-            ['lll',                                '2010年2月14日下午3點25'],
-            ['llll',                               '2010年2月14日星期日下午3點25']
+            ['lll',                                '2010年2月14日下午3點25分'],
+            ['llll',                               '2010年2月14日星期日下午3點25分']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -119,12 +119,12 @@ test('fromNow', function (assert) {
 test('calendar day', function (assert) {
     var a = moment().hours(2).minutes(0).seconds(0);
 
-    assert.equal(moment(a).calendar(),                     '今天早上2點00',     'today at the same time');
-    assert.equal(moment(a).add({m: 25}).calendar(),      '今天早上2點25',     'Now plus 25 min');
-    assert.equal(moment(a).add({h: 1}).calendar(),       '今天早上3點00',     'Now plus 1 hour');
-    assert.equal(moment(a).add({d: 1}).calendar(),       '明天早上2點00',     'tomorrow at the same time');
-    assert.equal(moment(a).subtract({h: 1}).calendar(),  '今天早上1點00',     'Now minus 1 hour');
-    assert.equal(moment(a).subtract({d: 1}).calendar(),  '昨天早上2點00',     'yesterday at the same time');
+    assert.equal(moment(a).calendar(),                   '今天早上2點00分',     'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(),      '今天早上2點25分',     'Now plus 25 min');
+    assert.equal(moment(a).add({h: 1}).calendar(),       '今天早上3點00分',     'Now plus 1 hour');
+    assert.equal(moment(a).add({d: 1}).calendar(),       '明天早上2點00分',     'tomorrow at the same time');
+    assert.equal(moment(a).subtract({h: 1}).calendar(),  '今天早上1點00分',     'Now minus 1 hour');
+    assert.equal(moment(a).subtract({d: 1}).calendar(),  '昨天早上2點00分',     'yesterday at the same time');
 });
 
 test('calendar next week', function (assert) {


### PR DESCRIPTION
The translation team I'm working with for a project is interested in the unit addition for minute.

This wraps up the work discussed in this PR #2107 by applying the change to zh-cn and zh-tw respectively.

Either PR is fine with me (if the other one is updated) from a merge standpoint :smile: