### PR TITLE
Fixes year/week parsing for non-standard dow/doy combinations

### DIFF
--- a/src/lib/units/day-of-year.js
+++ b/src/lib/units/day-of-year.js
@@ -26,18 +26,18 @@ addParseToken(['DDD', 'DDDD'], function (input, array, config) {
 
 //http://en.wikipedia.org/wiki/ISO_week_date#Calculating_a_date_given_the_year.2C_week_number_and_weekday
 export function dayOfYearFromWeeks(year, week, weekday, firstDayOfWeekOfYear, firstDayOfWeek) {
-    var d = createUTCDate(year, 0, 1).getUTCDay();
-    var daysToAdd;
-    var dayOfYear;
+    var week1Jan = 6 + firstDayOfWeek - firstDayOfWeekOfYear, janX = createUTCDate(year, 0, 1 + week1Jan), d = janX.getUTCDay(), dayOfYear;
+    if (d < firstDayOfWeek) {
+        d += 7;
+    }
 
-    d = d === 0 ? 7 : d;
-    weekday = weekday != null ? weekday : firstDayOfWeek;
-    daysToAdd = firstDayOfWeek - d + (d > firstDayOfWeekOfYear ? 7 : 0) - (d < firstDayOfWeek ? 7 : 0);
-    dayOfYear = 7 * (week - 1) + (weekday - firstDayOfWeek) + daysToAdd + 1;
+    weekday = weekday != null ? 1 * weekday : firstDayOfWeek;
+
+    dayOfYear = 1 + week1Jan + 7 * (week - 1) - d + weekday;
 
     return {
-        year      : dayOfYear > 0 ? year      : year - 1,
-        dayOfYear : dayOfYear > 0 ? dayOfYear : daysInYear(year - 1) + dayOfYear
+        year: dayOfYear > 0 ? year : year - 1,
+        dayOfYear: dayOfYear > 0 ?  dayOfYear : daysInYear(year - 1) + dayOfYear
     };
 }
 

--- a/src/test/moment/week_year.js
+++ b/src/test/moment/week_year.js
@@ -63,3 +63,31 @@ test('week year', function (assert) {
     assert.equal(moment([2009, 11, 27]).weekYear(), 2009);
     assert.equal(moment([2009, 11, 28]).weekYear(), 2010);
 });
+
+// Verifies that the week number, week day computation is correct for all dow, doy combinations
+test('week year roundtrip', function (assert) {
+    var dow, doy, wd, m;
+    for (dow = 0; dow < 7; ++dow) {
+        for (doy = dow; doy < dow + 7; ++doy) {
+            for (wd = 0; wd < 7; ++wd) {
+                moment.locale('dow: ' + dow + ', doy: ' + doy, {week: {dow: dow, doy: doy}});
+                // We use the 10th week as the 1st one can spill to the previous year
+                m = moment('2015 10 ' + wd, 'gggg w d', true);
+                assert.equal(m.format('gggg w d'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+                m = moment('2015 10 ' + wd, 'gggg w e', true);
+                assert.equal(m.format('gggg w e'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+            }
+        }
+    }
+});
+
+test('week numbers 2012/2013', function (assert) {
+    moment.locale('dow: 6, doy: 12', {week: {dow: 6, doy: 12}});
+    assert.equal(52, moment('2012-12-28', 'YYYY-MM-DD').week()); // 51 -- should be 52?
+    assert.equal(1, moment('2012-12-29', 'YYYY-MM-DD').week()); // 52 -- should be 1
+    assert.equal(1, moment('2013-01-01', 'YYYY-MM-DD').week()); // 52 -- should be 1
+    assert.equal(2, moment('2013-01-08', 'YYYY-MM-DD').week()); // 53 -- should be 2
+    assert.equal(2, moment('2013-01-11', 'YYYY-MM-DD').week()); // 53 -- should be 2
+    assert.equal(3, moment('2013-01-12', 'YYYY-MM-DD').week()); // 1 -- should be 3
+    assert.equal(52, moment().weeksInYear(2012)); // 52
+});


### PR DESCRIPTION
Fixes incorrect year/week parsing for non standard dow/doy combinations. Replaces the pull request #2188. See also the issue #2115. 