### PR TITLE
Support Django DurationField de-serialization.

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -8,6 +8,9 @@ import { createLocal } from '../create/local';
 // ASP.NET json date format regex
 var aspNetRegex = /(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
 
+// Django json date format regex
+var djangoRegex = /(\-)?(?:(\d*) )?(\d\d)\:(\d\d)\:(\d\d)(?:\.(\d{6}))?/;
+
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
 var isoRegex = /^(-)?P(?:(?:([0-9,.]*)Y)?(?:([0-9,.]*)M)?(?:([0-9,.]*)D)?(?:T(?:([0-9,.]*)H)?(?:([0-9,.]*)M)?(?:([0-9,.]*)S)?)?|([0-9,.]*)W)$/;
@@ -34,6 +37,16 @@ export function createDuration (input, key) {
             duration.milliseconds = input;
         }
     } else if (!!(match = aspNetRegex.exec(input))) {
+        sign = (match[1] === '-') ? -1 : 1;
+        duration = {
+            y  : 0,
+            d  : toInt(match[DATE])        * sign,
+            h  : toInt(match[HOUR])        * sign,
+            m  : toInt(match[MINUTE])      * sign,
+            s  : toInt(match[SECOND])      * sign,
+            ms : toInt(match[MILLISECOND]) * sign
+        };
+    } else if (!!(match = djangoRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : 1;
         duration = {
             y  : 0,

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -9,7 +9,7 @@ import { createLocal } from '../create/local';
 var aspNetRegex = /(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
 
 // Django json date format regex
-var djangoRegex = /(\-)?(?:(\d*) )?(\d\d)\:(\d\d)\:(\d\d)(?:\.(\d{6}))?/;
+var djangoRegex = /(\-)?(?:(\d*) )?(\d\d)\:(\d\d)\:(\d\d)(?:\.(\d{3})\d{3})?/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere


### PR DESCRIPTION
I haven't included tests yet because I'm not sure if you will support adding this. You might not believe it's a common enough use-case. Source of the string is [here](https://github.com/django/django/blob/0ed7d155635da9f79d4dd67e4889087d3673c6da/django/utils/duration.py). Examples are [here](http://www.regexr.com/3asci). This could be incorporated into the `aspNetRegex` if that would be preferrable.
Current:
```javascript
/(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/
```
12 13:22:45.334~~021~~ Currently looses the last three characters but that's changeable ofc.
```javascript
/(\-)?(?:(\d*)[\. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d{0,3})?/
```