### PR TITLE
Add support for U format, for 2 or 4 digit years

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -1,6 +1,6 @@
 import zeroFill from '../utils/zero-fill';
 
-export var formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Q|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,4}|x|X|zz?|ZZ?|.)/g;
+export var formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Q|YYYYYY|YYYYY|YYYY|YY|U|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,4}|x|X|zz?|ZZ?|.)/g;
 
 var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
 

--- a/src/lib/parse/regex.js
+++ b/src/lib/parse/regex.js
@@ -6,6 +6,7 @@ export var match6         = /[+-]?\d{6}/;    // -999999 - 999999
 export var match1to2      = /\d\d?/;         //       0 - 99
 export var match1to3      = /\d{1,3}/;       //       0 - 999
 export var match1to4      = /\d{1,4}/;       //       0 - 9999
+export var match2or4      = /\d\d(\d\d)?/;   //      00 - 9999
 export var match1to6      = /[+-]?\d{1,6}/;  // -999999 - 999999
 
 export var matchUnsigned  = /\d+/;           //       0 - inf

--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -1,7 +1,7 @@
 import { makeGetSet } from '../moment/get-set';
 import { addFormatToken } from '../format/format';
 import { addUnitAlias } from './aliases';
-import { addRegexToken, match1to2, match1to4, match1to6, match2, match4, match6, matchSigned } from '../parse/regex';
+import { addRegexToken, match1to2, match1to4, match2or4, match1to6, match2, match4, match6, matchSigned } from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { hooks } from '../utils/hooks';
 import { YEAR } from './constants';
@@ -16,6 +16,7 @@ addFormatToken(0, ['YY', 2], 0, function () {
 addFormatToken(0, ['YYYY',   4],       0, 'year');
 addFormatToken(0, ['YYYYY',  5],       0, 'year');
 addFormatToken(0, ['YYYYYY', 6, true], 0, 'year');
+addFormatToken(0, ['U', 4],            0, 'year');
 
 // ALIASES
 
@@ -28,10 +29,15 @@ addRegexToken('YY',     match1to2, match2);
 addRegexToken('YYYY',   match1to4, match4);
 addRegexToken('YYYYY',  match1to6, match6);
 addRegexToken('YYYYYY', match1to6, match6);
+addRegexToken('U',      match2or4);
 
 addParseToken(['YYYY', 'YYYYY', 'YYYYYY'], YEAR);
 addParseToken('YY', function (input, array) {
     array[YEAR] = hooks.parseTwoDigitYear(input);
+});
+
+addParseToken('U', function (input, array) {
+  array[YEAR] = input.length === 4 ? toInt(input) : hooks.parseTwoDigitYear(input);
 });
 
 // HELPERS

--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -37,7 +37,7 @@ addParseToken('YY', function (input, array) {
 });
 
 addParseToken('U', function (input, array) {
-  array[YEAR] = input.length === 4 ? toInt(input) : hooks.parseTwoDigitYear(input);
+    array[YEAR] = input.length === 4 ? toInt(input) : hooks.parseTwoDigitYear(input);
 });
 
 // HELPERS

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -241,10 +241,10 @@ test('string with format', function (assert) {
 });
 
 test('string with 2 or 4 digit year format (U)', function (assert) {
-  assert.equal(moment('9/2/99', 'D/M/U').format('DD/MM/YYYY'), '09/02/1999', 'D/M/U ---> 9/2/99');
-  assert.equal(moment('9/2/1999', 'D/M/U').format('DD/MM/YYYY'), '09/02/1999', 'D/M/U ---> 9/2/1999');
-  assert.equal(moment('9/2/68', 'D/M/U').format('DD/MM/YYYY'), '09/02/2068', 'D/M/U ---> 9/2/68');
-  assert.equal(moment('9/2/69', 'D/M/U').format('DD/MM/YYYY'), '09/02/1969', 'D/M/U ---> 9/2/69');
+    assert.equal(moment('9/2/99', 'D/M/U').format('DD/MM/YYYY'), '09/02/1999', 'D/M/U ---> 9/2/99');
+    assert.equal(moment('9/2/1999', 'D/M/U').format('DD/MM/YYYY'), '09/02/1999', 'D/M/U ---> 9/2/1999');
+    assert.equal(moment('9/2/68', 'D/M/U').format('DD/MM/YYYY'), '09/02/2068', 'D/M/U ---> 9/2/68');
+    assert.equal(moment('9/2/69', 'D/M/U').format('DD/MM/YYYY'), '09/02/1969', 'D/M/U ---> 9/2/69');
 });
 
 test('unix timestamp format', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -240,6 +240,13 @@ test('string with format', function (assert) {
     }
 });
 
+test('string with 2 or 4 digit year format (U)', function (assert) {
+  assert.equal(moment('9/2/99', 'D/M/U').format('DD/MM/YYYY'), '09/02/1999', 'D/M/U ---> 9/2/99');
+  assert.equal(moment('9/2/1999', 'D/M/U').format('DD/MM/YYYY'), '09/02/1999', 'D/M/U ---> 9/2/1999');
+  assert.equal(moment('9/2/68', 'D/M/U').format('DD/MM/YYYY'), '09/02/2068', 'D/M/U ---> 9/2/68');
+  assert.equal(moment('9/2/69', 'D/M/U').format('DD/MM/YYYY'), '09/02/1969', 'D/M/U ---> 9/2/69');
+});
+
 test('unix timestamp format', function (assert) {
     var formats = ['X', 'X.S', 'X.SS', 'X.SSS'], i, format;
 


### PR DESCRIPTION
This attempts to fix #2343 by adding a new format specifier, `U`, to allow the parsing of dates with either 2 or 4 digit years.  E.g.:

    moment('D/M/U', '18/9/14').format('DD/MM/YYYY') == '18/09/2014'
    moment('D/M/U', '18/9/2014').format('DD/MM/YYYY') == '18/09/2014'

I said in the issue that I was going to use `Y` as the specifier, but it appears already to be in use for [something else](https://github.com/stewartml/moment/blob/develop/src/lib/units/year.js#L26).  So I picked `U`, for no real reason.

I'm not very familiar with the layout of the code, so hopefully I've done the right things here...