### PR TITLE
Improve unit bubbling for ISO dates

### DIFF
--- a/src/lib/duration/iso-string.js
+++ b/src/lib/duration/iso-string.js
@@ -1,13 +1,37 @@
+import absFloor from '../utils/abs-floor';
 var abs = Math.abs;
 
 export function toISOString() {
+    // for ISO strings we do not use the normal bubbling rules:
+    //  * milliseconds bubble up until they become hours
+    //  * days do not bubble at all
+    //  * months bubble up until they become years
+    // This is because there is no context-free conversion between hours and days
+    // (think of clock changes)
+    // and also not between days and months (28-31 days per month)
+    var seconds = abs(this._milliseconds) / 1000;
+    var days         = abs(this._days);
+    var months       = abs(this._months);
+    var minutes, hours, years;
+
+    // 3600 seconds -> 60 minutes -> 1 hour
+    minutes           = absFloor(seconds / 60);
+    hours             = absFloor(minutes / 60);
+    seconds %= 60;
+    minutes %= 60;
+
+    // 12 months -> 1 year
+    years  = absFloor(months / 12);
+    months %= 12;
+
+
     // inspired by https://github.com/dordille/moment-isoduration/blob/master/moment.isoduration.js
-    var Y = abs(this.years());
-    var M = abs(this.months());
-    var D = abs(this.days());
-    var h = abs(this.hours());
-    var m = abs(this.minutes());
-    var s = abs(this.seconds() + this.milliseconds() / 1000);
+    var Y = years;
+    var M = months;
+    var D = days;
+    var h = hours;
+    var m = minutes;
+    var s = seconds;
     var total = this.asSeconds();
 
     if (!total) {

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -258,6 +258,7 @@ test('serialization to ISO 8601 duration strings', function (assert) {
     assert.equal(moment.duration({s: -0.5}).toISOString(), '-PT0.5S', 'one half second ago');
     assert.equal(moment.duration({y: -0.5, M: 1}).toISOString(), '-P5M', 'a month after half a year ago');
     assert.equal(moment.duration({}).toISOString(), 'P0D', 'zero duration');
+    assert.equal(moment.duration({M: 16, d:40, s: 86465}).toISOString(), 'P1Y4M40DT24H1M5S', 'all fields');
 });
 
 test('toString acts as toISOString', function (assert) {
@@ -267,6 +268,7 @@ test('toString acts as toISOString', function (assert) {
     assert.equal(moment.duration({s: -0.5}).toString(), '-PT0.5S', 'one half second ago');
     assert.equal(moment.duration({y: -0.5, M: 1}).toString(), '-P5M', 'a month after half a year ago');
     assert.equal(moment.duration({}).toString(), 'P0D', 'zero duration');
+    assert.equal(moment.duration({M: 16, d:40, s: 86465}).toString(), 'P1Y4M40DT24H1M5S', 'all fields');
 });
 
 test('toIsoString deprecation', function (assert) {


### PR DESCRIPTION
## What is this?

This PR intends to fix issues with invalid ISO dates getting created from a well formatted `moment.duration`. GitHub Issues I am aware of:

* https://github.com/moment/moment/issues/2162
* https://github.com/moment/moment/issues/1697

What I have done is basically:

* not use `this.data` as source of truth anymore for `toISOString`
    * I thought about changing the way `data` is filled, but I believe this would be the wrong approach, correct me if I am wrong
* use some custom bubbling for `toISOString` that stops bubbling at **hours** and **days**
    * these are basically the borders that are also used internally
    * internal fields are milliseconds (which can bubble up to hours), days and month (becoming years)
* add one-line spec that should cover all new edge cases

## Why is it useful?

The ISO 8601 standard (which I only know from second hand knowledge), makes a difference between hours, days and months. That is:

* `P1D` means tommorrow, at the same time
* `PT24H` means in 24 hours, which can be different from the former case, if the clock changed in the meantime (think of DST changes, leap seconds, etc)
* `P30D` means in thirty days, no matter how many days the current month has
* `P1M` means on the same date in the next month

Thus from an ISO perspective there is a difference between `moment.duration(1, 'days')` and `moment.duration(24, 'hours')` which should now be reflected.

*Note: I've written down similar arguments in the linked issues, but I believe it helps clarity to repeat it if I open a PR ^^*