### PR TITLE
perf: use faster form of copying dates, across the board improvement

### DIFF
--- a/benchmarks/clone.js
+++ b/benchmarks/clone.js
@@ -4,7 +4,7 @@ var Benchmark = require('benchmark'),
 
 module.exports = {
   name: 'clone',
-  onComplete: function(){console.log('done');},
+  onComplete: function(){},
   fn: function(){base.clone();},
   async: true
 };

--- a/benchmarks/fromDate.js
+++ b/benchmarks/fromDate.js
@@ -4,7 +4,7 @@ var Benchmark = require('benchmark'),
 
 module.exports = {
   name: 'fromDate',
-  onComplete: function(){console.log('done');},
+  onComplete: function(){},
   fn: function(){
       moment(base);
   },

--- a/benchmarks/makeDuration.js
+++ b/benchmarks/makeDuration.js
@@ -1,12 +1,11 @@
 var Benchmark = require('benchmark'),
-    moment = require('./../moment.js'),
-    base = new Date();
+    moment = require('./../moment.js');
 
 module.exports = {
-  name: 'fromDateUtc',
+  name: 'makeDuration',
   onComplete: function(){},
   fn: function(){
-      moment.utc(base);
+      moment.duration(5, 'years');
   },
   async: true
 };

--- a/src/lib/moment/constructor.js
+++ b/src/lib/moment/constructor.js
@@ -58,7 +58,7 @@ var updateInProgress = false;
 // Moment prototype object
 export function Moment(config) {
     copyConfig(this, config);
-    this._d = new Date(+config._d);
+    this._d = new Date(config._d.getTime());
     // Prevent infinite loop in case updateOffset creates new moment
     // objects.
     if (updateInProgress === false) {


### PR DESCRIPTION
Reference: http://jsperf.com/date-copy-constructor/3

Didn't expect this to make so much of a difference, but here we are.  I presume `Moment` always gets a `config` object where `_d` is a Date; certainly seems to be the case and no tests failed.  Results of `grunt test update-index benchmark`:

-----
Before:
```
Running benchmark clone [benchmarks/clone.js]...
>> clone x 3,698,440 ops/sec ±0.77% (85 runs sampled)
Running benchmark fromDate [benchmarks/fromDate.js]...
>> fromDate x 1,709,634 ops/sec ±1.05% (79 runs sampled)
Running benchmark fromDateUtc [benchmarks/fromDateUtc.js]...
>> fromDateUtc x 1,623,291 ops/sec ±0.95% (90 runs sampled)
```

-----
After:
```
Running benchmark clone [benchmarks/clone.js]...
>> clone x 4,919,547 ops/sec ±0.69% (87 runs sampled)
Running benchmark fromDate [benchmarks/fromDate.js]...
>> fromDate x 2,232,456 ops/sec ±0.54% (92 runs sampled)
Running benchmark fromDateUtc [benchmarks/fromDateUtc.js]...
>> fromDateUtc x 2,151,327 ops/sec ±1.01% (78 runs sampled)
```