### PR TITLE
Fix comparisons on invalid moments.

### DIFF
--- a/src/lib/moment/compare.js
+++ b/src/lib/moment/compare.js
@@ -1,28 +1,35 @@
 import { isMoment } from './constructor';
 import { normalizeUnits } from '../units/aliases';
 import { createLocal } from '../create/local';
+import { isValid } from '../create/valid';
 
 export function isAfter (input, units) {
+    var bothValid;
     var inputMs;
+    input = isMoment(input) ? input : createLocal(input);
     units = normalizeUnits(typeof units !== 'undefined' ? units : 'millisecond');
+    bothValid = isValid(this) && isValid(input);
+
     if (units === 'millisecond') {
-        input = isMoment(input) ? input : createLocal(input);
-        return +this > +input;
+        return bothValid && +this > +input;
     } else {
         inputMs = isMoment(input) ? +input : +createLocal(input);
-        return inputMs < +this.clone().startOf(units);
+        return bothValid && inputMs < +this.clone().startOf(units);
     }
 }
 
 export function isBefore (input, units) {
+    var bothValid;
     var inputMs;
+    input = isMoment(input) ? input : createLocal(input);
     units = normalizeUnits(typeof units !== 'undefined' ? units : 'millisecond');
+    bothValid = isValid(this) && isValid(input);
+
     if (units === 'millisecond') {
-        input = isMoment(input) ? input : createLocal(input);
-        return +this < +input;
+        return bothValid && +this < +input;
     } else {
-        inputMs = isMoment(input) ? +input : +createLocal(input);
-        return +this.clone().endOf(units) < inputMs;
+        inputMs = +input;
+        return bothValid && +this.clone().endOf(units) < inputMs;
     }
 }
 
@@ -32,12 +39,15 @@ export function isBetween (from, to, units) {
 
 export function isSame (input, units) {
     var inputMs;
+    var bothValid;
+    input = isMoment(input) ? input : createLocal(input);
     units = normalizeUnits(units || 'millisecond');
+    bothValid = isValid(this) && isValid(input);
+
     if (units === 'millisecond') {
-        input = isMoment(input) ? input : createLocal(input);
-        return +this === +input;
+        return bothValid && +this === +input;
     } else {
-        inputMs = +createLocal(input);
-        return +(this.clone().startOf(units)) <= inputMs && inputMs <= +(this.clone().endOf(units));
+        inputMs = +input;
+        return bothValid && +(this.clone().startOf(units)) <= inputMs && inputMs <= +(this.clone().endOf(units));
     }
 }

--- a/src/test/moment/is_after.js
+++ b/src/test/moment/is_after.js
@@ -162,3 +162,11 @@ test('is after millisecond', function (assert) {
     assert.equal(m.isAfter(m, 'millisecond'), false, 'same moments are not after the same millisecond');
     assert.equal(+m, +mCopy, 'isAfter millisecond should not change moment');
 });
+
+test('is after invalid', function(assert) {
+    assert.equal(moment.invalid().isAfter(moment.invalid()), false, 'not comparable');
+    assert.equal(moment.invalid().isAfter(moment.invalid().year(2015)), false, 'default-invalid matches mutated-invalid');
+    assert.equal(moment.invalid().year(2015).isAfter(moment.invalid()), false, 'mutated-invalid matches default-invalid');
+    assert.equal(moment.invalid().year(2015).isAfter(moment.invalid().year(2016)), false, 'invalid + year before');
+    assert.equal(moment.invalid().year(2016).isAfter(moment.invalid().year(2015)), false, 'invalid + year after');
+});

--- a/src/test/moment/is_after.js
+++ b/src/test/moment/is_after.js
@@ -163,7 +163,7 @@ test('is after millisecond', function (assert) {
     assert.equal(+m, +mCopy, 'isAfter millisecond should not change moment');
 });
 
-test('is after invalid', function(assert) {
+test('is after invalid', function (assert) {
     assert.equal(moment.invalid().isAfter(moment.invalid()), false, 'not comparable');
     assert.equal(moment.invalid().isAfter(moment.invalid().year(2015)), false, 'default-invalid matches mutated-invalid');
     assert.equal(moment.invalid().year(2015).isAfter(moment.invalid()), false, 'mutated-invalid matches default-invalid');

--- a/src/test/moment/is_before.js
+++ b/src/test/moment/is_before.js
@@ -163,7 +163,7 @@ test('is before millisecond', function (assert) {
     assert.equal(+m, +mCopy, 'isBefore millisecond should not change moment');
 });
 
-test('is before invalid', function(assert) {
+test('is before invalid', function (assert) {
     assert.equal(moment.invalid().isBefore(moment.invalid()), false, 'not comparable');
     assert.equal(moment.invalid().isBefore(moment.invalid().year(2015)), false, 'default-invalid matches mutated-invalid');
     assert.equal(moment.invalid().year(2015).isBefore(moment.invalid()), false, 'mutated-invalid matches default-invalid');

--- a/src/test/moment/is_before.js
+++ b/src/test/moment/is_before.js
@@ -162,3 +162,11 @@ test('is before millisecond', function (assert) {
     assert.equal(m.isBefore(m, 'millisecond'), false, 'same moments are not before the same millisecond');
     assert.equal(+m, +mCopy, 'isBefore millisecond should not change moment');
 });
+
+test('is before invalid', function(assert) {
+    assert.equal(moment.invalid().isBefore(moment.invalid()), false, 'not comparable');
+    assert.equal(moment.invalid().isBefore(moment.invalid().year(2015)), false, 'default-invalid matches mutated-invalid');
+    assert.equal(moment.invalid().year(2015).isBefore(moment.invalid()), false, 'mutated-invalid matches default-invalid');
+    assert.equal(moment.invalid().year(2015).isBefore(moment.invalid().year(2016)), false, 'invalid + year before');
+    assert.equal(moment.invalid().year(2016).isBefore(moment.invalid().year(2015)), false, 'invalid + year after');
+});

--- a/src/test/moment/is_same.js
+++ b/src/test/moment/is_same.js
@@ -145,3 +145,15 @@ test('is same with utc offset moments', function (assert) {
     assert.ok(moment.parseZone('2013-02-01T-05:00').isSame(moment.parseZone('2013-02-01T-06:30'), 'year'),
             'zoned vs (differently) zoned moment');
 });
+
+test('is same with invalid moments', function (assert) {
+    assert.equal(moment.invalid().isSame(moment.invalid()), false, 'default-invalid matches default-invalid');
+    assert.equal(moment.invalid().isSame(moment.invalid().year(2015)), false, 'default-invalid matches mutated-invalid');
+    assert.equal(moment.invalid().year(2015).isSame(moment.invalid()), false, 'mutated-invalid matches default-invalid');
+    assert.equal(moment.invalid().year(2015).isSame(moment.invalid().year(2016)), false, 'mutated-invalid matches mutated-invalid');
+
+    var anyValidMoment = moment('2015-05-12');
+    var invalidMoment = moment.invalid().year(2015).month(5).day(12);
+    assert.equal(invalidMoment.isSame(anyValidMoment), false, 'invalid vs valid');
+    assert.equal(anyValidMoment.isSame(invalidMoment), false, 'valid vs invalid');
+});


### PR DESCRIPTION
This fixes https://github.com/moment/moment/issues/2354 and matches the
precedent in javascript following that invalid types are not comparable
(similar to NaN).