### PR TITLE
fix transpile-custom

### DIFF
--- a/tasks/transpile.js
+++ b/tasks/transpile.js
@@ -142,6 +142,7 @@ module.exports = function (grunt) {
             }
             code = code.replace(getDefaultRegExp, '');
             code = code.replace('var moment_with_locales = ' + crap[1], 'var moment_with_locales = ' + crap[2]);
+            code = code.replace('var moment_with_locales_custom = ' + crap[1], 'var moment_with_locales_custom = ' + crap[2]);
             if (code.match('get default')) {
                 grunt.file.write('/tmp/crap.js', code);
                 throw new Error('Stupid shit es6 get default plaguing the code, check /tmp/crap.js');


### PR DESCRIPTION
`grunt transpile:fr,ru` is broken-- if you attempt to use a resulting custom build, the browser will throw the error "moment is undefined." The offending line in the build:
`var moment_with_locales_custom = moment;`
should be
`var moment_with_locales_custom = moment__default;`
This substitution is made with regex that I added.