### PR TITLE
add coverage reporting using nyc and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ sauce_connect.log
 npm-debug.log
 .build*
 build
+coverage
+nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script: grunt build:travis
 
 git:
   depth: 10
+
+after_success: npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Join the chat at https://gitter.im/moment/moment](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/moment/moment?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![NPM version][npm-version-image]][npm-url] [![NPM downloads][npm-downloads-image]][npm-url] [![MIT License][license-image]][license-url] [![Build Status][travis-image]][travis-url]
+[![Coverage Status](https://coveralls.io/repos/moment/moment/badge.svg?branch=master)](https://coveralls.io/r/moment/moment?branch=master)
 
 A lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
         "karma-sauce-launcher": "latest",
         "qunit": "^0.7.5",
         "qunit-cli": "^0.1.4",
-        "spacejam": "latest"
+        "spacejam": "latest",
+        "coveralls": "^2.11.2",
+        "nyc": "^2.1.4"
     },
     "ender": "./ender.js",
     "dojoBuild": "package.js",
@@ -82,7 +84,9 @@
         }
     },
     "scripts": {
-        "test": "grunt test"
+        "test": "grunt test",
+        "coverage": "nyc npm test && nyc report",
+        "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
     },
     "spm": {
         "main": "moment.js",


### PR DESCRIPTION
This pull adds coverage reporting facilitated by [nyc](https://www.npmjs.com/package/nyc) and the hosted coverage service coveralls.io.

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
* run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  * you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  * on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN `

Here's what coverage currently looks like for moment:

```shell
---------------------------|-----------|-----------|-----------|-----------|
File                       |   % Stmts |% Branches |   % Funcs |   % Lines |
---------------------------|-----------|-----------|-----------|-----------|
   ./                      |       100 |        50 |       100 |       100 |
      Gruntfile.js         |       100 |        50 |       100 |       100 |
   ./build/umd/            |     98.11 |     92.61 |     97.59 |      98.1 |
      moment.js            |     98.11 |     92.61 |     97.59 |      98.1 |
   ./build/umd/locale/     |      93.9 |     71.01 |     95.99 |      93.9 |
      af.js                |     77.78 |     57.89 |        80 |     77.78 |
      ar-ma.js             |       100 |      37.5 |       100 |       100 |
      ar-sa.js             |     84.62 |        40 |      87.5 |     84.62 |
      ar-tn.js             |       100 |      37.5 |       100 |       100 |
      ar.js                |     89.47 |     65.38 |     90.91 |     89.47 |
      az.js                |     76.47 |      61.9 |        80 |     76.47 |
      be.js                |     94.44 |     81.67 |     90.91 |     94.44 |
      bg.js                |     95.24 |     74.19 |       100 |     95.24 |
      bn.js                |     94.74 |     68.75 |      87.5 |     94.74 |
      bo.js                |     94.74 |     68.75 |      87.5 |     94.74 |
      br.js                |     96.15 |     72.73 |       100 |     96.15 |
      bs.js                |     89.13 |      74.6 |       100 |     89.13 |
      ca.js                |       100 |     73.33 |       100 |       100 |
      cs.js                |     86.79 |        90 |       100 |     86.79 |
      cv.js                |       100 |     58.33 |       100 |       100 |
      cy.js                |     91.67 |     68.42 |       100 |     91.67 |
      da.js                |       100 |      37.5 |       100 |       100 |
      de-at.js             |       100 |        50 |       100 |       100 |
      de.js                |       100 |        50 |       100 |       100 |
      el.js                |       100 |        75 |       100 |       100 |
      en-au.js             |       100 |     68.75 |       100 |       100 |
      en-ca.js             |       100 |     68.75 |       100 |       100 |
      en-gb.js             |       100 |     68.75 |       100 |       100 |
      eo.js                |        75 |     42.86 |        75 |        75 |
      es.js                |       100 |        60 |       100 |       100 |
      et.js                |       100 |     64.29 |       100 |       100 |
      eu.js                |       100 |      37.5 |       100 |       100 |
      fa.js                |     84.62 |        40 |      87.5 |     84.62 |
      fi.js                |       100 |     68.89 |       100 |       100 |
      fo.js                |       100 |      37.5 |       100 |       100 |
      fr-ca.js             |       100 |        50 |       100 |       100 |
      fr.js                |       100 |        50 |       100 |       100 |
      fy.js                |       100 |     66.67 |       100 |       100 |
      gl.js                |       100 |        65 |       100 |       100 |
      he.js                |       100 |        75 |       100 |       100 |
      hi.js                |       100 |        80 |       100 |       100 |
      hr.js                |     89.13 |      74.6 |       100 |     89.13 |
      hu.js                |     92.86 |     78.87 |      87.5 |     92.86 |
      hy-am.js             |     96.43 |     78.26 |        90 |     96.43 |
      id.js                |       100 |     76.92 |       100 |       100 |
      is.js                |     82.98 |     59.52 |       100 |     82.98 |
      it.js                |      87.5 |        50 |       100 |      87.5 |
      ja.js                |      87.5 |        50 |        75 |      87.5 |
      jv.js                |       100 |     76.92 |       100 |       100 |
      ka.js                |     90.91 |     67.86 |       100 |     90.91 |
      km.js                |       100 |      37.5 |       100 |       100 |
      ko.js                |       100 |        50 |       100 |       100 |
      lb.js                |      87.8 |     72.73 |       100 |      87.8 |
      lt.js                |     92.86 |     61.29 |       100 |     92.86 |
      lv.js                |       100 |        75 |       100 |       100 |
      me.js                |       100 |        64 |       100 |       100 |
      mk.js                |     95.24 |     74.19 |       100 |     95.24 |
      ml.js                |     92.86 |     68.75 |        75 |     92.86 |
      mr.js                |       100 |        80 |       100 |       100 |
      ms-my.js             |       100 |     76.92 |       100 |       100 |
      my.js                |       100 |      37.5 |       100 |       100 |
      nb.js                |       100 |      37.5 |       100 |       100 |
      ne.js                |       100 |     82.35 |       100 |       100 |
      nl.js                |       100 |     66.67 |       100 |       100 |
      nn.js                |       100 |      37.5 |       100 |       100 |
      pl.js                |     96.15 |     78.38 |       100 |     96.15 |
      pt-br.js             |       100 |     58.33 |       100 |       100 |
      pt.js                |       100 |     58.33 |       100 |       100 |
      ro.js                |       100 |     61.54 |       100 |       100 |
      ru.js                |     93.02 |     82.14 |     91.67 |     93.02 |
      si.js                |       100 |     57.14 |       100 |       100 |
      sk.js                |     86.79 |     89.89 |       100 |     86.79 |
      sl.js                |     90.16 |     80.39 |       100 |     90.16 |
      sq.js                |     83.33 |        50 |        75 |     83.33 |
      sr-cyrl.js           |       100 |        64 |       100 |       100 |
      sr.js                |       100 |        64 |       100 |       100 |
      sv.js                |       100 |     68.75 |       100 |       100 |
      ta.js                |       100 |     85.29 |       100 |       100 |
      th.js                |        75 |        40 |        75 |        75 |
      tl-ph.js             |       100 |      37.5 |       100 |       100 |
      tr.js                |       100 |     66.67 |       100 |       100 |
      tzm-latn.js          |       100 |      37.5 |       100 |       100 |
      tzm.js               |       100 |      37.5 |       100 |       100 |
      uk.js                |     92.11 |     77.78 |     91.67 |     92.11 |
      uz.js                |       100 |      37.5 |       100 |       100 |
      vi.js                |       100 |      37.5 |       100 |       100 |
      zh-cn.js             |     97.44 |     76.92 |       100 |     97.44 |
      zh-tw.js             |      96.3 |     81.08 |       100 |      96.3 |
   ./tasks/                |     44.98 |      37.1 |     43.01 |     44.98 |
      bump_version.js      |        20 |         0 |        50 |        20 |
      check_sauce_creds.js |     33.33 |         0 |        50 |     33.33 |
      component.js         |     33.33 |       100 |        50 |     33.33 |
      embed_locales.js     |     29.17 |         0 |     16.67 |     29.17 |
      history.js           |        20 |         0 |      6.25 |        20 |
      nuget.js             |       100 |       100 |       100 |       100 |
      size.js              |        20 |         0 |      8.33 |        20 |
      transpile.js         |     79.05 |     76.67 |     81.58 |     79.05 |
      update_index.js      |       100 |       100 |       100 |       100 |
      zones.js             |        20 |         0 |      7.69 |        20 |
---------------------------|-----------|-----------|-----------|-----------|
All files                  |     91.68 |     76.29 |     90.09 |     91.67 |
```