### PR TITLE
Fix building tasks for `moment-with-locales.js` and `moment-with-locales.custom.js`

### DIFF
--- a/tasks/transpile.js
+++ b/tasks/transpile.js
@@ -141,7 +141,15 @@ module.exports = function (grunt) {
                 throw new Error('Failed to detect get default crap, check /tmp/crap.js');
             }
             code = code.replace(getDefaultRegExp, '');
-            code = code.replace('var moment_with_locales = ' + crap[1], 'var moment_with_locales = ' + crap[2]);
+
+            var buildExportVars = ['moment_with_locales', 'moment_with_locales_custom'];
+            buildExportVars.forEach(function (buildExportVar) {
+                var languageReset = buildExportVar  + '.locale(\'en\');';
+                code = code.replace('var ' + buildExportVar + ' = ' + crap[1] + ';',
+                                    'var ' + buildExportVar + ' = ' + crap[2] + ';\n' +
+                                    '    ' + languageReset);
+            });
+
             if (code.match('get default')) {
                 grunt.file.write('/tmp/crap.js', code);
                 throw new Error('Stupid shit es6 get default plaguing the code, check /tmp/crap.js');


### PR DESCRIPTION
#2367 **moment-with-locales.custom.js uses last defined locale by default**

`moment-with-locales.js` and `moment-with-locales.custom.js` were default to "en".

See grunt task `embedLocales`: 
```javascript
var languageReset = 'moment.locale(\'en\');';
```

Adding it back to transpiling task seems the right thing to do. 

---
**custom locale building was broken**

![screen shot 2015-05-28 at 2 38 08 pm](https://cloud.githubusercontent.com/assets/25500/7871808/34824378-0547-11e5-9279-f550314e703f.png)

In current built `moment-with-locales.custom.js`:

this line
```javascript
var moment_with_locales_custom = moment;
```

which `moment` is actually undefined, and should be replaced with the matches from the regex, 
and thus become
```javascript
var moment_with_locales_custom = moment__default;
```
