### PR TITLE
German words for today/yesterday/tomorrow should not be capitalized

### DIFF
--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -3,6 +3,7 @@
 //! author : lluchs : https://github.com/lluchs
 //! author: Menelion Elensúle: https://github.com/Oire
 //! author : Martin Groller : https://github.com/MadMG
+//! author : Mikolaj Dadela : https://github.com/mik01aj
 
 import moment from '../moment';
 
@@ -35,11 +36,11 @@ export default moment.defineLocale('de-at', {
         LLLL : 'dddd, D. MMMM YYYY LT'
     },
     calendar : {
-        sameDay: '[Heute um] LT [Uhr]',
+        sameDay: '[heute um] LT [Uhr]',
         sameElse: 'L',
-        nextDay: '[Morgen um] LT [Uhr]',
+        nextDay: '[morgen um] LT [Uhr]',
         nextWeek: 'dddd [um] LT [Uhr]',
-        lastDay: '[Gestern um] LT [Uhr]',
+        lastDay: '[gestern um] LT [Uhr]',
         lastWeek: '[letzten] dddd [um] LT [Uhr]'
     },
     relativeTime : {
@@ -64,4 +65,3 @@ export default moment.defineLocale('de-at', {
         doy : 4  // The week that contains Jan 4th is the first week of the year.
     }
 });
-

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -2,6 +2,7 @@
 //! locale : german (de)
 //! author : lluchs : https://github.com/lluchs
 //! author: Menelion Elensúle: https://github.com/Oire
+//! author : Mikolaj Dadela : https://github.com/mik01aj
 
 import moment from '../moment';
 
@@ -34,11 +35,11 @@ export default moment.defineLocale('de', {
         LLLL : 'dddd, D. MMMM YYYY LT'
     },
     calendar : {
-        sameDay: '[Heute um] LT [Uhr]',
+        sameDay: '[heute um] LT [Uhr]',
         sameElse: 'L',
-        nextDay: '[Morgen um] LT [Uhr]',
+        nextDay: '[morgen um] LT [Uhr]',
         nextWeek: 'dddd [um] LT [Uhr]',
-        lastDay: '[Gestern um] LT [Uhr]',
+        lastDay: '[gestern um] LT [Uhr]',
         lastWeek: '[letzten] dddd [um] LT [Uhr]'
     },
     relativeTime : {
@@ -63,4 +64,3 @@ export default moment.defineLocale('de', {
         doy : 4  // The week that contains Jan 4th is the first week of the year.
     }
 });
-

--- a/src/test/locale/de-at.js
+++ b/src/test/locale/de-at.js
@@ -150,12 +150,12 @@ test('fromNow', function (assert) {
 test('calendar day', function (assert) {
     var a = moment().hours(2).minutes(0).seconds(0);
 
-    assert.equal(moment(a).calendar(), 'Heute um 02:00 Uhr', 'today at the same time');
-    assert.equal(moment(a).add({m: 25}).calendar(), 'Heute um 02:25 Uhr', 'Now plus 25 min');
-    assert.equal(moment(a).add({h: 1}).calendar(), 'Heute um 03:00 Uhr', 'Now plus 1 hour');
-    assert.equal(moment(a).add({d: 1}).calendar(), 'Morgen um 02:00 Uhr', 'tomorrow at the same time');
-    assert.equal(moment(a).subtract({h: 1}).calendar(), 'Heute um 01:00 Uhr', 'Now minus 1 hour');
-    assert.equal(moment(a).subtract({d: 1}).calendar(), 'Gestern um 02:00 Uhr', 'yesterday at the same time');
+    assert.equal(moment(a).calendar(), 'heute um 02:00 Uhr', 'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(), 'heute um 02:25 Uhr', 'Now plus 25 min');
+    assert.equal(moment(a).add({h: 1}).calendar(), 'heute um 03:00 Uhr', 'Now plus 1 hour');
+    assert.equal(moment(a).add({d: 1}).calendar(), 'morgen um 02:00 Uhr', 'tomorrow at the same time');
+    assert.equal(moment(a).subtract({h: 1}).calendar(), 'heute um 01:00 Uhr', 'Now minus 1 hour');
+    assert.equal(moment(a).subtract({d: 1}).calendar(), 'gestern um 02:00 Uhr', 'yesterday at the same time');
 });
 
 test('calendar next week', function (assert) {

--- a/src/test/locale/de.js
+++ b/src/test/locale/de.js
@@ -149,12 +149,12 @@ test('fromNow', function (assert) {
 test('calendar day', function (assert) {
     var a = moment().hours(2).minutes(0).seconds(0);
 
-    assert.equal(moment(a).calendar(),                     'Heute um 02:00 Uhr',   'today at the same time');
-    assert.equal(moment(a).add({m: 25}).calendar(),      'Heute um 02:25 Uhr',   'Now plus 25 min');
-    assert.equal(moment(a).add({h: 1}).calendar(),       'Heute um 03:00 Uhr',   'Now plus 1 hour');
-    assert.equal(moment(a).add({d: 1}).calendar(),       'Morgen um 02:00 Uhr',  'tomorrow at the same time');
-    assert.equal(moment(a).subtract({h: 1}).calendar(),  'Heute um 01:00 Uhr',   'Now minus 1 hour');
-    assert.equal(moment(a).subtract({d: 1}).calendar(),  'Gestern um 02:00 Uhr', 'yesterday at the same time');
+    assert.equal(moment(a).calendar(),                     'heute um 02:00 Uhr',   'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(),      'heute um 02:25 Uhr',   'Now plus 25 min');
+    assert.equal(moment(a).add({h: 1}).calendar(),       'heute um 03:00 Uhr',   'Now plus 1 hour');
+    assert.equal(moment(a).add({d: 1}).calendar(),       'morgen um 02:00 Uhr',  'tomorrow at the same time');
+    assert.equal(moment(a).subtract({h: 1}).calendar(),  'heute um 01:00 Uhr',   'Now minus 1 hour');
+    assert.equal(moment(a).subtract({d: 1}).calendar(),  'gestern um 02:00 Uhr', 'yesterday at the same time');
 });
 
 test('calendar next week', function (assert) {


### PR DESCRIPTION
Grammar ref: http://www.duden.de/sprachwissen/rechtschreibregeln/Gro%C3%9F-%20und%20Kleinschreibung

The original authors of these (`de` and `de-at`) translation are: @lluchs @Oire @MadMG 