### PR TITLE
Allow custom formats to be passed to calendar function.

### DIFF
--- a/src/lib/moment/calendar.js
+++ b/src/lib/moment/calendar.js
@@ -1,7 +1,7 @@
 import { createLocal } from '../create/local';
 import { cloneWithOffset } from '../units/offset';
 
-export function calendar (time) {
+export function calendar (time, formats) {
     // We want to compare the start of today, vs this.
     // Getting start-of-today depends on whether we're local/utc/offset or not.
     var now = time || createLocal(),
@@ -13,5 +13,5 @@ export function calendar (time) {
             diff < 1 ? 'sameDay' :
             diff < 2 ? 'nextDay' :
             diff < 7 ? 'nextWeek' : 'sameElse';
-    return this.format(this.localeData().calendar(format, this, createLocal(now)));
+    return this.format(formats && formats[format] || this.localeData().calendar(format, this, createLocal(now)));
 }

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -310,6 +310,12 @@ test('calendar day timezone', function (assert) {
     assert.equal(moment(c).local().calendar(d), 'Tomorrow at 11:59 PM', 'Tomorrow at 11:59 PM, not Yesterday, or the wrong time');
 });
 
+test('calendar with custom formats', function (assert) {
+    assert.equal(moment().calendar(null, {sameDay: '[Today]'}), 'Today', 'Today');
+    assert.equal(moment().add(1, 'days').calendar(null, {nextDay: '[Tomorrow]'}), 'Tomorrow', 'Tomorrow');
+    assert.equal(moment([1985, 1, 4]).calendar(null, {sameElse: 'YYYY-MM-DD'}), '1985-02-04', 'Else');
+});
+
 test('invalid', function (assert) {
     assert.equal(moment.invalid().format(), 'Invalid date');
     assert.equal(moment.invalid().format('YYYY-MM-DD'), 'Invalid date');


### PR DESCRIPTION
This is useful if you want to override the locale-specified defaults on a case-by-case basis (i.e., not by changing the global config), for example if you don't want to include the time:

    moment().calendar(null, {
      sameDay: '[Today]',
      nextDay: '[Tomorrow]',
      nextWeek: 'dddd',
      lastDay: '[Yesterday]',
      lastWeek: '[Last] dddd'
    })

Note that if you don't override a format, the default from the locale is still used - i.e., `sameElse` isn't specified above.