### PR TITLE
Fix imports in locale files

### DIFF
--- a/src/test/locale/af.js
+++ b/src/test/locale/af.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('af');
 
 test('parse', function (assert) {

--- a/src/test/locale/ar-ma.js
+++ b/src/test/locale/ar-ma.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ar-ma');
 
 test('parse', function (assert) {

--- a/src/test/locale/ar-sa.js
+++ b/src/test/locale/ar-sa.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ar-sa');
 
 test('parse', function (assert) {

--- a/src/test/locale/ar-tn.js
+++ b/src/test/locale/ar-tn.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ar-tn');
 
 test('parse', function (assert) {

--- a/src/test/locale/ar.js
+++ b/src/test/locale/ar.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ar');
 
 var months = [

--- a/src/test/locale/az.js
+++ b/src/test/locale/az.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('az');
 
 test('parse', function (assert) {

--- a/src/test/locale/be.js
+++ b/src/test/locale/be.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('be');
 
 test('parse', function (assert) {

--- a/src/test/locale/bg.js
+++ b/src/test/locale/bg.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('bg');
 
 test('parse', function (assert) {

--- a/src/test/locale/bn.js
+++ b/src/test/locale/bn.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('bn');
 
 test('parse', function (assert) {

--- a/src/test/locale/bo.js
+++ b/src/test/locale/bo.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('bo');
 
 test('parse', function (assert) {

--- a/src/test/locale/br.js
+++ b/src/test/locale/br.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('br');
 
 test('parse', function (assert) {

--- a/src/test/locale/bs.js
+++ b/src/test/locale/bs.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('bs');
 
 test('parse', function (assert) {

--- a/src/test/locale/ca.js
+++ b/src/test/locale/ca.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ca');
 
 test('parse', function (assert) {

--- a/src/test/locale/cs.js
+++ b/src/test/locale/cs.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('cs');
 
 test('parse', function (assert) {

--- a/src/test/locale/cv.js
+++ b/src/test/locale/cv.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('cv');
 
 test('parse', function (assert) {

--- a/src/test/locale/cy.js
+++ b/src/test/locale/cy.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('cy');
 
 test('parse', function (assert) {

--- a/src/test/locale/da.js
+++ b/src/test/locale/da.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('da');
 
 test('parse', function (assert) {

--- a/src/test/locale/de-at.js
+++ b/src/test/locale/de-at.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('de-at');
 
 test('parse', function (assert) {

--- a/src/test/locale/de.js
+++ b/src/test/locale/de.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('de');
 
 test('parse', function (assert) {

--- a/src/test/locale/el.js
+++ b/src/test/locale/el.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('el');
 
 test('parse', function (assert) {

--- a/src/test/locale/en-au.js
+++ b/src/test/locale/en-au.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('en-au');
 
 test('parse', function (assert) {

--- a/src/test/locale/en-ca.js
+++ b/src/test/locale/en-ca.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('en-ca');
 
 test('parse', function (assert) {

--- a/src/test/locale/en-gb.js
+++ b/src/test/locale/en-gb.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('en-gb');
 
 test('parse', function (assert) {

--- a/src/test/locale/en.js
+++ b/src/test/locale/en.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('en');
 
 test('parse', function (assert) {

--- a/src/test/locale/eo.js
+++ b/src/test/locale/eo.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('eo');
 
 test('parse', function (assert) {

--- a/src/test/locale/es.js
+++ b/src/test/locale/es.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('es');
 
 test('parse', function (assert) {

--- a/src/test/locale/et.js
+++ b/src/test/locale/et.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('et');
 
 test('parse', function (assert) {

--- a/src/test/locale/eu.js
+++ b/src/test/locale/eu.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('eu');
 
 test('parse', function (assert) {

--- a/src/test/locale/fa.js
+++ b/src/test/locale/fa.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('fa');
 
 test('parse', function (assert) {

--- a/src/test/locale/fi.js
+++ b/src/test/locale/fi.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('fi');
 
 test('parse', function (assert) {

--- a/src/test/locale/fo.js
+++ b/src/test/locale/fo.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('fo');
 
 test('parse', function (assert) {

--- a/src/test/locale/fr-ca.js
+++ b/src/test/locale/fr-ca.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('fr-ca');
 
 test('parse', function (assert) {

--- a/src/test/locale/fr.js
+++ b/src/test/locale/fr.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('fr');
 
 test('parse', function (assert) {

--- a/src/test/locale/fy.js
+++ b/src/test/locale/fy.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('fy');
 
 test('parse', function (assert) {

--- a/src/test/locale/gl.js
+++ b/src/test/locale/gl.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('gl');
 
 test('parse', function (assert) {

--- a/src/test/locale/he.js
+++ b/src/test/locale/he.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('he');
 
 test('parse', function (assert) {

--- a/src/test/locale/hi.js
+++ b/src/test/locale/hi.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('hi');
 
 test('parse', function (assert) {

--- a/src/test/locale/hr.js
+++ b/src/test/locale/hr.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('hr');
 
 test('parse', function (assert) {

--- a/src/test/locale/hu.js
+++ b/src/test/locale/hu.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('hu');
 
 test('parse', function (assert) {

--- a/src/test/locale/hy-am.js
+++ b/src/test/locale/hy-am.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('hy-am');
 
 test('parse', function (assert) {

--- a/src/test/locale/id.js
+++ b/src/test/locale/id.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('id');
 
 test('parse', function (assert) {

--- a/src/test/locale/is.js
+++ b/src/test/locale/is.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('is');
 
 test('parse', function (assert) {

--- a/src/test/locale/it.js
+++ b/src/test/locale/it.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('it');
 
 test('parse', function (assert) {

--- a/src/test/locale/ja.js
+++ b/src/test/locale/ja.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ja');
 
 test('parse', function (assert) {

--- a/src/test/locale/jv.js
+++ b/src/test/locale/jv.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('jv');
 
 

--- a/src/test/locale/ka.js
+++ b/src/test/locale/ka.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ka');
 
 test('parse', function (assert) {

--- a/src/test/locale/km.js
+++ b/src/test/locale/km.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('km');
 
 test('parse', function (assert) {

--- a/src/test/locale/ko.js
+++ b/src/test/locale/ko.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ko');
 
 test('parse', function (assert) {

--- a/src/test/locale/lb.js
+++ b/src/test/locale/lb.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('lb');
 
 test('parse', function (assert) {

--- a/src/test/locale/lt.js
+++ b/src/test/locale/lt.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('lt');
 
 test('parse', function (assert) {

--- a/src/test/locale/lv.js
+++ b/src/test/locale/lv.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('lv');
 
 test('parse', function (assert) {

--- a/src/test/locale/me.js
+++ b/src/test/locale/me.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('me');
 
 test('parse', function (assert) {

--- a/src/test/locale/mk.js
+++ b/src/test/locale/mk.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('mk');
 
 test('parse', function (assert) {

--- a/src/test/locale/ml.js
+++ b/src/test/locale/ml.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ml');
 
 test('parse', function (assert) {

--- a/src/test/locale/mr.js
+++ b/src/test/locale/mr.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('mr');
 
 test('parse', function (assert) {

--- a/src/test/locale/ms-my.js
+++ b/src/test/locale/ms-my.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ms-my');
 
 test('parse', function (assert) {

--- a/src/test/locale/my.js
+++ b/src/test/locale/my.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('my');
 
 test('parse', function (assert) {

--- a/src/test/locale/nb.js
+++ b/src/test/locale/nb.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('nb');
 
 test('parse', function (assert) {

--- a/src/test/locale/ne.js
+++ b/src/test/locale/ne.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ne');
 
 test('parse', function (assert) {

--- a/src/test/locale/nl.js
+++ b/src/test/locale/nl.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('nl');
 
 test('parse', function (assert) {

--- a/src/test/locale/nn.js
+++ b/src/test/locale/nn.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('nn');
 
 test('parse', function (assert) {

--- a/src/test/locale/pl.js
+++ b/src/test/locale/pl.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('pl');
 
 test('parse', function (assert) {

--- a/src/test/locale/pt-br.js
+++ b/src/test/locale/pt-br.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('pt-br');
 
 test('parse', function (assert) {

--- a/src/test/locale/pt.js
+++ b/src/test/locale/pt.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('pt');
 
 test('parse', function (assert) {

--- a/src/test/locale/ro.js
+++ b/src/test/locale/ro.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ro');
 
 test('parse', function (assert) {

--- a/src/test/locale/ru.js
+++ b/src/test/locale/ru.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ru');
 
 test('parse', function (assert) {

--- a/src/test/locale/si.js
+++ b/src/test/locale/si.js
@@ -1,5 +1,5 @@
-﻿import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import {localeModule, test} from '../qunit';
+import moment from '../../moment';
 localeModule('si');
 
 /*jshint -W100*/

--- a/src/test/locale/sk.js
+++ b/src/test/locale/sk.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('sk');
 
 test('parse', function (assert) {

--- a/src/test/locale/sl.js
+++ b/src/test/locale/sl.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('sl');
 
 test('parse', function (assert) {

--- a/src/test/locale/sq.js
+++ b/src/test/locale/sq.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('sq');
 
 test('parse', function (assert) {

--- a/src/test/locale/sr-cyrl.js
+++ b/src/test/locale/sr-cyrl.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('sr-cyrl');
 
 test('parse', function (assert) {

--- a/src/test/locale/sr.js
+++ b/src/test/locale/sr.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('sr');
 
 test('parse', function (assert) {

--- a/src/test/locale/sv.js
+++ b/src/test/locale/sv.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('sv');
 
 test('parse', function (assert) {

--- a/src/test/locale/ta.js
+++ b/src/test/locale/ta.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('ta');
 
 test('parse', function (assert) {

--- a/src/test/locale/th.js
+++ b/src/test/locale/th.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('th');
 
 test('parse', function (assert) {

--- a/src/test/locale/tl-ph.js
+++ b/src/test/locale/tl-ph.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('tl-ph');
 
 test('parse', function (assert) {

--- a/src/test/locale/tr.js
+++ b/src/test/locale/tr.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('tr');
 
 test('parse', function (assert) {

--- a/src/test/locale/tzm-latn.js
+++ b/src/test/locale/tzm-latn.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('tzm-latn');
 
 test('parse', function (assert) {

--- a/src/test/locale/tzm.js
+++ b/src/test/locale/tzm.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('tzm');
 
 test('parse', function (assert) {

--- a/src/test/locale/uk.js
+++ b/src/test/locale/uk.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('uk');
 
 test('parse', function (assert) {

--- a/src/test/locale/uz.js
+++ b/src/test/locale/uz.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('uz');
 
 test('parse', function (assert) {

--- a/src/test/locale/vi.js
+++ b/src/test/locale/vi.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('vi');
 
 test('parse', function (assert) {

--- a/src/test/locale/zh-cn.js
+++ b/src/test/locale/zh-cn.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('zh-cn');
 
 test('parse', function (assert) {

--- a/src/test/locale/zh-tw.js
+++ b/src/test/locale/zh-tw.js
@@ -1,5 +1,5 @@
 import {localeModule, test} from '../qunit';
-import {moment} from '../../moment';
+import moment from '../../moment';
 localeModule('zh-tw');
 
 test('parse', function (assert) {


### PR DESCRIPTION
Moment is exported as a default export from moment.js but locale files import it as a named export.
This results in `Module does not export 'moment'` errors (issue #2394).

This pull request fixes named imports in locale files to use default import.