### PR TITLE
Support up to milliseconds tokens up to 9 digits, fixes #2436

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -1,6 +1,6 @@
 import zeroFill from '../utils/zero-fill';
 
-export var formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Q|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,4}|x|X|zz?|ZZ?|.)/g;
+export var formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Q|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
 
 var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
 

--- a/src/lib/units/millisecond.js
+++ b/src/lib/units/millisecond.js
@@ -16,12 +16,26 @@ addFormatToken(0, ['SS', 2], 0, function () {
     return ~~(this.millisecond() / 10);
 });
 
-function milliseconds (token) {
-    addFormatToken(0, [token, 3], 0, 'millisecond');
-}
+addFormatToken(0, ['SSS', 3], 0, 'millisecond');
+addFormatToken(0, ['SSSS', 4], 0, function () {
+    return this.millisecond() * 10;
+});
+addFormatToken(0, ['SSSSS', 5], 0, function () {
+    return this.millisecond() * 100;
+});
+addFormatToken(0, ['SSSSSS', 6], 0, function () {
+    return this.millisecond() * 1000;
+});
+addFormatToken(0, ['SSSSSSS', 7], 0, function () {
+    return this.millisecond() * 10000;
+});
+addFormatToken(0, ['SSSSSSSS', 8], 0, function () {
+    return this.millisecond() * 100000;
+});
+addFormatToken(0, ['SSSSSSSSS', 9], 0, function () {
+    return this.millisecond() * 1000000;
+});
 
-milliseconds('SSS');
-milliseconds('SSSS');
 
 // ALIASES
 
@@ -33,7 +47,14 @@ addRegexToken('S',    match1to3, match1);
 addRegexToken('SS',   match1to3, match2);
 addRegexToken('SSS',  match1to3, match3);
 addRegexToken('SSSS', matchUnsigned);
-addParseToken(['S', 'SS', 'SSS', 'SSSS'], function (input, array) {
+addRegexToken('SSSSS', matchUnsigned);
+addRegexToken('SSSSSS', matchUnsigned);
+addRegexToken('SSSSSSS', matchUnsigned);
+addRegexToken('SSSSSSSS', matchUnsigned);
+addRegexToken('SSSSSSSSS', matchUnsigned);
+addParseToken(
+        'S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS'.split(' '),
+        function (input, array) {
     array[MILLISECOND] = toInt(('0.' + input) * 1000);
 });
 

--- a/src/lib/units/millisecond.js
+++ b/src/lib/units/millisecond.js
@@ -46,18 +46,19 @@ addUnitAlias('millisecond', 'ms');
 addRegexToken('S',    match1to3, match1);
 addRegexToken('SS',   match1to3, match2);
 addRegexToken('SSS',  match1to3, match3);
-addRegexToken('SSSS', matchUnsigned);
-addRegexToken('SSSSS', matchUnsigned);
-addRegexToken('SSSSSS', matchUnsigned);
-addRegexToken('SSSSSSS', matchUnsigned);
-addRegexToken('SSSSSSSS', matchUnsigned);
-addRegexToken('SSSSSSSSS', matchUnsigned);
-addParseToken(
-        'S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS'.split(' '),
-        function (input, array) {
-    array[MILLISECOND] = toInt(('0.' + input) * 1000);
-});
 
+var token;
+for (token = 'SSSS'; token.length <= 9; token += 'S') {
+    addRegexToken(token, matchUnsigned);
+}
+
+function parseMs(input, array) {
+    array[MILLISECOND] = toInt(('0.' + input) * 1000);
+}
+
+for (token = 'S'; token.length <= 9; token += 'S') {
+    addParseToken(token, parseMs);
+}
 // MOMENTS
 
 export var getSetMillisecond = makeGetSet('Milliseconds', false);

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -872,3 +872,15 @@ test('array with strings', function (assert) {
 test('utc with array of formats', function (assert) {
     assert.equal(moment.utc('2014-01-01', ['YYYY-MM-DD', 'YYYY-MM']).format(), '2014-01-01T00:00:00+00:00', 'moment.utc works with array of formats');
 });
+
+test('milliseconds', function (assert) {
+    assert.equal(moment('1', 'S').millisecond(), 100);
+    assert.equal(moment('12', 'SS').millisecond(), 120);
+    assert.equal(moment('123', 'SSS').millisecond(), 123);
+    assert.equal(moment('1234', 'SSSS').millisecond(), 123);
+    assert.equal(moment('12345', 'SSSSS').millisecond(), 123);
+    assert.equal(moment('123456', 'SSSSSS').millisecond(), 123);
+    assert.equal(moment('1234567', 'SSSSSSS').millisecond(), 123);
+    assert.equal(moment('12345678', 'SSSSSSSS').millisecond(), 123);
+    assert.equal(moment('123456789', 'SSSSSSSSS').millisecond(), 123);
+});

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -359,7 +359,7 @@ test('full expanded format is returned from abbreviated formats', function (asse
 });
 
 test('milliseconds', function (assert) {
-    var m = moment('123','SSS');
+    var m = moment('123', 'SSS');
 
     assert.equal(m.format('S'), '1');
     assert.equal(m.format('SS'), '12');

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -357,3 +357,17 @@ test('full expanded format is returned from abbreviated formats', function (asse
         });
     });
 });
+
+test('milliseconds', function (assert) {
+    var m = moment('123','SSS');
+
+    assert.equal(m.format('S'), '1');
+    assert.equal(m.format('SS'), '12');
+    assert.equal(m.format('SSS'), '123');
+    assert.equal(m.format('SSSS'), '1230');
+    assert.equal(m.format('SSSSS'), '12300');
+    assert.equal(m.format('SSSSSS'), '123000');
+    assert.equal(m.format('SSSSSSS'), '1230000');
+    assert.equal(m.format('SSSSSSSS'), '12300000');
+    assert.equal(m.format('SSSSSSSSS'), '123000000');
+});


### PR DESCRIPTION
Add support for parsing and formatting up to 9 digit milliseconds (fractional seconds). Only milliseconds are stored, so extra digits read are discarded, and extra digits printed are zeros.