### PR TITLE
fix of spelling error

### DIFF
--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -58,7 +58,7 @@ function translate(number, withoutSuffix, key) {
 }
 
 export default moment.defineLocale('hr', {
-    months : 'siječanj_veljača_ožujak_travanj_svibanj_lipanj_srpanj_kolovoz_rujan_listopad_studeni_prosinac'.split('_'),
+    months : 'siječnja_veljače_ožujka_travnja_svibnja_lipnja_srpnja_kolovoza_rujna_listopada_studenog_prosinca'.split('_'),
     monthsShort : 'sij._velj._ožu._tra._svi._lip._srp._kol._ruj._lis._stu._pro.'.split('_'),
     weekdays : 'nedjelja_ponedjeljak_utorak_srijeda_četvrtak_petak_subota'.split('_'),
     weekdaysShort : 'ned._pon._uto._sri._čet._pet._sub.'.split('_'),


### PR DESCRIPTION
Even though names of months are 'siječanj' 'veljača' etc. that is NOT the right way to write them as a date!

`Po istom ovom principu pišu se i ostali mjeseci (same goes for other months) :
14. veljače 3. ožujka 17. travnja 21. svibnja 26. lipnja 19. srpnja 1. kolovoza 9. rujna 10. listopada 22. studenog(a) 15. prosinca`