### PR TITLE
Mark moment as invalid if bad string weekday repr is parsed, fixes #2423

### DIFF
--- a/src/lib/create/valid.js
+++ b/src/lib/create/valid.js
@@ -9,6 +9,7 @@ export function isValid(m) {
             flags.overflow < 0 &&
             !flags.empty &&
             !flags.invalidMonth &&
+            !flags.invalidWeekday &&
             !flags.nullInput &&
             !flags.invalidFormat &&
             !flags.userInvalidated;

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -872,3 +872,18 @@ test('array with strings', function (assert) {
 test('utc with array of formats', function (assert) {
     assert.equal(moment.utc('2014-01-01', ['YYYY-MM-DD', 'YYYY-MM']).format(), '2014-01-01T00:00:00+00:00', 'moment.utc works with array of formats');
 });
+
+test('parsing invalid string weekdays', function (assert) {
+    assert.equal(false, moment('a', 'dd').isValid(),
+            'dd with invalid weekday, non-strict');
+    assert.equal(false, moment('a', 'dd', true).isValid(),
+            'dd with invalid weekday, strict');
+    assert.equal(false, moment('a', 'ddd').isValid(),
+            'ddd with invalid weekday, non-strict');
+    assert.equal(false, moment('a', 'ddd', true).isValid(),
+            'ddd with invalid weekday, strict');
+    assert.equal(false, moment('a', 'dddd').isValid(),
+            'dddd with invalid weekday, non-strict');
+    assert.equal(false, moment('a', 'dddd', true).isValid(),
+            'dddd with invalid weekday, strict');
+});


### PR DESCRIPTION
Well, we were just not checking if the weekday was invalid.

I also found other issues related to the week-year, week, week-day parsing -- we don't do any overflow checks there, I'll submit it as another issue.