### PR TITLE
Support grunt test --only=moment/duration,locale/ru

### DIFF
--- a/tasks/qtest.js
+++ b/tasks/qtest.js
@@ -10,10 +10,26 @@ module.exports = function (grunt) {
         testrunner.options.log.testing = false;
         testrunner.options.maxBlockDuration = 120000;
 
+        var tests;
+
+        if (grunt.option("only") != null) {
+            tests = grunt.file.expand.apply(null, grunt.option('only').split(',').map(function (file) {
+                if (file === 'moment') {
+                    return 'build/umd/test/moment/*.js';
+                } else if (file === 'locale') {
+                    return 'build/umd/test/locale/*.js';
+                } else {
+                    return 'build/umd/test/' + file + '.js';
+                }
+            }));
+        } else {
+            tests = grunt.file.expand('build/umd/test/moment/*.js',
+                'build/umd/test/locale/*.js');
+        }
+
         testrunner.run({
             code: 'build/umd/moment.js',
-            tests: grunt.file.expand('build/umd/test/moment/*.js',
-                    'build/umd/test/locale/*.js')
+            tests: tests
         }, function (err, report) {
             if (err) {
                 console.log('woot', err, report);

--- a/tasks/qtest.js
+++ b/tasks/qtest.js
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
 
         var tests;
 
-        if (grunt.option("only") != null) {
+        if (grunt.option('only') != null) {
             tests = grunt.file.expand.apply(null, grunt.option('only').split(',').map(function (file) {
                 if (file === 'moment') {
                     return 'build/umd/test/moment/*.js';


### PR DESCRIPTION
When too much tests are broken, testing just a single file makes things easier to debug.