### PR TITLE
Improved duration bubbling, fixes #2166

### DIFF
--- a/src/lib/duration/as.js
+++ b/src/lib/duration/as.js
@@ -1,4 +1,4 @@
-import { daysToYears, yearsToDays } from './bubble';
+import { daysToMonths, monthsToDays } from './bubble';
 import { normalizeUnits } from '../units/aliases';
 import toInt from '../utils/to-int';
 
@@ -11,11 +11,11 @@ export function as (units) {
 
     if (units === 'month' || units === 'year') {
         days   = this._days   + milliseconds / 864e5;
-        months = this._months + daysToYears(days) * 12;
+        months = this._months + daysToMonths(days);
         return units === 'month' ? months : months / 12;
     } else {
         // handle milliseconds separately because of floating point math errors (issue #1867)
-        days = this._days + Math.round(yearsToDays(this._months / 12));
+        days = this._days + Math.round(monthsToDays(this._months));
         switch (units) {
             case 'week'   : return days / 7     + milliseconds / 6048e5;
             case 'day'    : return days         + milliseconds / 864e5;

--- a/src/lib/duration/bubble.js
+++ b/src/lib/duration/bubble.js
@@ -1,4 +1,5 @@
 import absFloor from '../utils/abs-floor';
+import absCeil from '../utils/abs-ceil';
 import { createUTCDate } from '../create/date-from-array';
 
 export function bubble () {
@@ -6,13 +7,13 @@ export function bubble () {
     var days         = this._days;
     var months       = this._months;
     var data         = this._data;
-    var seconds, minutes, hours, years = 0, monthDaySplit, sign;
+    var seconds, minutes, hours, years, monthsFromDays;
 
     // if we have a mix of positive and negative values, bubble down first
     // check: https://github.com/moment/moment/issues/2166
     if (!((milliseconds >= 0 && days >= 0 && months >= 0) ||
             (milliseconds <= 0 && days <= 0 && months <= 0))) {
-        milliseconds += absFloor(yearsToDays(months / 12) + days) * 864e5;
+        milliseconds += absCeil(monthsToDays(months) + days) * 864e5;
         days = 0;
         months = 0;
     }
@@ -32,20 +33,13 @@ export function bubble () {
 
     days += absFloor(hours / 24);
 
-    // Accurately convert days to years, assume start from year 0.
-    years = absFloor(daysToYears(days));
-    days -= absFloor(yearsToDays(years));
-
-    // Use Jan 1st 1970 as anchor.
-    if (days !== 0) {
-        monthDaySplit = createUTCDate(1970, 0, Math.abs(days) + 1);
-        sign = days < 0 ? -1 : 1;
-        months += sign * monthDaySplit.getUTCMonth();
-        days = sign * (monthDaySplit.getUTCDate() - 1);
-    }
+    // convert days to months
+    monthsFromDays = absFloor(daysToMonths(days));
+    months += monthsFromDays;
+    days -= absCeil(monthsToDays(monthsFromDays));
 
     // 12 months -> 1 year
-    years  += absFloor(months / 12);
+    years = absFloor(months / 12);
     months %= 12;
 
     data.days   = days;
@@ -55,13 +49,13 @@ export function bubble () {
     return this;
 }
 
-export function daysToYears (days) {
+export function daysToMonths (days) {
     // 400 years have 146097 days (taking into account leap year rules)
-    return days * 400 / 146097;
+    // 400 years have 12 months === 4800
+    return days * 4800 / 146097;
 }
 
-export function yearsToDays (years) {
-    // years * 365 + absFloor(years / 4) -
-    //     absFloor(years / 100) + absFloor(years / 400);
-    return years * 146097 / 400;
+export function monthsToDays (months) {
+    // the reverse of daysToMonths
+    return months * 146097 / 4800;
 }

--- a/src/lib/utils/abs-ceil.js
+++ b/src/lib/utils/abs-ceil.js
@@ -1,0 +1,7 @@
+export default function absCeil (number) {
+    if (number < 0) {
+        return Math.floor(number);
+    } else {
+        return Math.ceil(number);
+    }
+}

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -220,7 +220,7 @@ test('instatiation from serialized C# TimeSpan maxValue', function (assert) {
 
     assert.equal(d.years(), 29227, '29227 years');
     assert.equal(d.months(), 8, '8 months');
-    assert.equal(d.days(), 14, '14 day');  // this should be 13, maybe
+    assert.equal(d.days(), 12, '12 day');  // if you have to change this value -- just do it
 
     assert.equal(d.hours(), 2, '2 hours');
     assert.equal(d.minutes(), 48, '48 minutes');
@@ -233,7 +233,7 @@ test('instatiation from serialized C# TimeSpan minValue', function (assert) {
 
     assert.equal(d.years(), -29227, '29653 years');
     assert.equal(d.months(), -8, '8 day');
-    assert.equal(d.days(), -14, '17 day'); // this should be 13, maybe
+    assert.equal(d.days(), -12, '12 day');  // if you have to change this value -- just do it
 
     assert.equal(d.hours(), -2, '2 hours');
     assert.equal(d.minutes(), -48, '48 minutes');
@@ -370,11 +370,11 @@ test('clipping', function (assert) {
     assert.equal(moment.duration({months: 13}).months(), 1,  '13 months is 1 month left over');
     assert.equal(moment.duration({months: 13}).years(),  1,  '13 months makes 1 year');
 
-    assert.equal(moment.duration({days: 29}).days(),   29, '29 days is 29 days');
-    assert.equal(moment.duration({days: 29}).months(), 0,  '29 days makes no month');
-    assert.equal(moment.duration({days: 31}).days(),   0,  '31 days is 0 day left over');
+    assert.equal(moment.duration({days: 30}).days(),   30, '30 days is 30 days');
+    assert.equal(moment.duration({days: 30}).months(), 0,  '30 days makes no month');
+    assert.equal(moment.duration({days: 31}).days(),   0,  '31 days is 0 days left over');
     assert.equal(moment.duration({days: 31}).months(), 1,  '31 days is a month');
-    assert.equal(moment.duration({days: 32}).days(),   1,  '32 days is 1 days left over');
+    assert.equal(moment.duration({days: 32}).days(),   1,  '32 days is 1 day left over');
     assert.equal(moment.duration({days: 32}).months(), 1,  '32 days is a month');
 
     assert.equal(moment.duration({hours: 23}).hours(), 23, '23 hours is 23 hours');
@@ -383,6 +383,23 @@ test('clipping', function (assert) {
     assert.equal(moment.duration({hours: 24}).days(),  1,  '24 hours makes 1 day');
     assert.equal(moment.duration({hours: 25}).hours(), 1,  '25 hours is 1 hour left over');
     assert.equal(moment.duration({hours: 25}).days(),  1,  '25 hours makes 1 day');
+});
+
+test('bubbling consistency', function (assert) {
+    var days = 0, months = 0, newDays, newMonths, totalDays, d;
+    for (totalDays = 1; totalDays <= 500; ++totalDays) {
+        d = moment.duration(totalDays, 'days');
+        newDays = d.days();
+        newMonths = d.months() + d.years() * 12;
+        assert.ok(
+                (months === newMonths && days + 1 === newDays) ||
+                (months + 1 === newMonths && newDays === 0),
+                'consistent total days ' + totalDays +
+                ' was ' + months + ' ' + days +
+                ' now ' + newMonths + ' ' + newDays);
+        days = newDays;
+        months = newMonths;
+    }
 });
 
 test('effective equivalency', function (assert) {

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -220,7 +220,7 @@ test('instatiation from serialized C# TimeSpan maxValue', function (assert) {
 
     assert.equal(d.years(), 29227, '29227 years');
     assert.equal(d.months(), 8, '8 months');
-    assert.equal(d.days(), 17, '17 day');  // this should be 13
+    assert.equal(d.days(), 14, '14 day');  // this should be 13, maybe
 
     assert.equal(d.hours(), 2, '2 hours');
     assert.equal(d.minutes(), 48, '48 minutes');
@@ -233,7 +233,7 @@ test('instatiation from serialized C# TimeSpan minValue', function (assert) {
 
     assert.equal(d.years(), -29227, '29653 years');
     assert.equal(d.months(), -8, '8 day');
-    assert.equal(d.days(), -17, '17 day'); // this should be 13
+    assert.equal(d.days(), -14, '17 day'); // this should be 13, maybe
 
     assert.equal(d.hours(), -2, '2 hours');
     assert.equal(d.minutes(), -48, '48 minutes');
@@ -372,10 +372,10 @@ test('clipping', function (assert) {
 
     assert.equal(moment.duration({days: 29}).days(),   29, '29 days is 29 days');
     assert.equal(moment.duration({days: 29}).months(), 0,  '29 days makes no month');
-    assert.equal(moment.duration({days: 30}).days(),   0,  '30 days is 0 days left over');
-    assert.equal(moment.duration({days: 30}).months(), 1,  '30 days is a month');
-    assert.equal(moment.duration({days: 31}).days(),   1,  '31 days is 1 day left over');
+    assert.equal(moment.duration({days: 31}).days(),   0,  '31 days is 0 day left over');
     assert.equal(moment.duration({days: 31}).months(), 1,  '31 days is a month');
+    assert.equal(moment.duration({days: 32}).days(),   1,  '32 days is 1 days left over');
+    assert.equal(moment.duration({days: 32}).months(), 1,  '32 days is a month');
 
     assert.equal(moment.duration({hours: 23}).hours(), 23, '23 hours is 23 hours');
     assert.equal(moment.duration({hours: 23}).days(),  0,  '23 hours makes no day');
@@ -391,7 +391,7 @@ test('effective equivalency', function (assert) {
     assert.deepEqual(moment.duration({minutes: 60})._data, moment.duration({hours: 1})._data,           '1 hour is the same as 60 minutes');
     assert.deepEqual(moment.duration({hours: 24})._data,   moment.duration({days: 1})._data,            '1 day is the same as 24 hours');
     assert.deepEqual(moment.duration({days: 7})._data,     moment.duration({weeks: 1})._data,           '1 week is the same as 7 days');
-    assert.deepEqual(moment.duration({days: 30})._data,    moment.duration({months: 1})._data,          '1 month is the same as 30 days');
+    assert.deepEqual(moment.duration({days: 31})._data,    moment.duration({months: 1})._data,          '1 month is the same as 30 days');
     assert.deepEqual(moment.duration({months: 12})._data,  moment.duration({years: 1})._data,           '1 years is the same as 12 months');
 });
 
@@ -530,17 +530,53 @@ test('add', function (assert) {
 });
 
 test('add and bubble', function (assert) {
+    var d;
+
     assert.equal(moment.duration(1, 'second').add(1000, 'milliseconds').seconds(), 2, 'Adding milliseconds should bubble up to seconds');
     assert.equal(moment.duration(1, 'minute').add(60, 'second').minutes(), 2, 'Adding seconds should bubble up to minutes');
     assert.equal(moment.duration(1, 'hour').add(60, 'minutes').hours(), 2, 'Adding minutes should bubble up to hours');
     assert.equal(moment.duration(1, 'day').add(24, 'hours').days(), 2, 'Adding hours should bubble up to days');
+
+    d = moment.duration(-1, 'day').add(1, 'hour');
+    assert.equal(d.hours(), -23, '-1 day + 1 hour == -23 hour (component)');
+    assert.equal(d.asHours(), -23, '-1 day + 1 hour == -23 hours');
+
+    d = moment.duration(-1, 'year').add(1, 'day');
+    assert.equal(d.days(), -30, '- 1 year + 1 day == -30 days (component)');
+    assert.equal(d.months(), -11, '- 1 year + 1 day == -11 months (component)');
+    assert.equal(d.years(), 0, '- 1 year + 1 day == 0 years (component)');
+    assert.equal(d.asDays(), -364, '- 1 year + 1 day == -364 days');
+
+    d = moment.duration(-1, 'year').add(1, 'hour');
+    assert.equal(d.hours(), -23, '- 1 year + 1 hour == -23 hours (component)');
+    assert.equal(d.days(), -30, '- 1 year + 1 hour == -30 days (component)');
+    assert.equal(d.months(), -11, '- 1 year + 1 hour == -11 months (component)');
+    assert.equal(d.years(), 0, '- 1 year + 1 hour == 0 years (component)');
 });
 
 test('subtract and bubble', function (assert) {
+    var d;
+
     assert.equal(moment.duration(2, 'second').subtract(1000, 'milliseconds').seconds(), 1, 'Subtracting milliseconds should bubble up to seconds');
     assert.equal(moment.duration(2, 'minute').subtract(60, 'second').minutes(), 1, 'Subtracting seconds should bubble up to minutes');
     assert.equal(moment.duration(2, 'hour').subtract(60, 'minutes').hours(), 1, 'Subtracting minutes should bubble up to hours');
     assert.equal(moment.duration(2, 'day').subtract(24, 'hours').days(), 1, 'Subtracting hours should bubble up to days');
+
+    d = moment.duration(1, 'day').subtract(1, 'hour');
+    assert.equal(d.hours(), 23, '1 day - 1 hour == 23 hour (component)');
+    assert.equal(d.asHours(), 23, '1 day - 1 hour == 23 hours');
+
+    d = moment.duration(1, 'year').subtract(1, 'day');
+    assert.equal(d.days(), 30, '1 year - 1 day == 30 days (component)');
+    assert.equal(d.months(), 11, '1 year - 1 day == 11 months (component)');
+    assert.equal(d.years(), 0, '1 year - 1 day == 0 years (component)');
+    assert.equal(d.asDays(), 364, '1 year - 1 day == 364 days');
+
+    d = moment.duration(1, 'year').subtract(1, 'hour');
+    assert.equal(d.hours(), 23, '1 year - 1 hour == 23 hours (component)');
+    assert.equal(d.days(), 30, '1 year - 1 hour == 30 days (component)');
+    assert.equal(d.months(), 11, '1 year - 1 hour == 11 months (component)');
+    assert.equal(d.years(), 0, '1 year - 1 hour == 0 years (component)');
 });
 
 test('subtract', function (assert) {


### PR DESCRIPTION
It also fixes broken way days were bubbling to months before, including (but not limited to) 364 days being 1 year and 4 days (because we round 30 days to a month, and extract 12 months from 364 with 4 extra ... LOL).

I had to change the "fundamental" 30 days == 1 month (now its 31 days, because of the anchoring).

@icambron @mj1856 what do you think?