### PR TITLE
valueOf should return NaN for any invalid moment

### DIFF
--- a/src/lib/moment/to-type.js
+++ b/src/lib/moment/to-type.js
@@ -1,4 +1,7 @@
 export function valueOf () {
+    if (!this.isValid()) {
+        return NaN;
+    }
     return +this._d - ((this._offset || 0) * 60000);
 }
 

--- a/src/test/moment/invalid.js
+++ b/src/test/moment/invalid.js
@@ -25,3 +25,11 @@ test('invalid with custom flag', function (assert) {
     assert.equal(m.parsingFlags().tooBusyWith, 'reiculating splines');
     assert.ok(isNaN(m.valueOf()));
 });
+
+test('invalid with valid date', function (assert) {
+    var m = moment.invalid();
+    m._d = new Date();
+    assert.equal(m.isValid(), false);
+    assert.equal(m.parsingFlags().userInvalidated, true);
+    assert.ok(isNaN(m.valueOf()));
+});

--- a/src/test/moment/is_same.js
+++ b/src/test/moment/is_same.js
@@ -145,3 +145,15 @@ test('is same with utc offset moments', function (assert) {
     assert.ok(moment.parseZone('2013-02-01T-05:00').isSame(moment.parseZone('2013-02-01T-06:30'), 'year'),
             'zoned vs (differently) zoned moment');
 });
+
+test('is same with invalid moments', function (assert) {
+    assert.equal(moment.invalid().isSame(moment.invalid()), false, 'invalid moments are not considered equal');
+    assert.equal(moment.invalid().year(2010).isSame(moment.invalid().year(2010)), false, 'with year set');
+    assert.equal(moment.invalid().month(10).isSame(moment.invalid().month(10)), false, 'with month set');
+    assert.equal(moment.invalid().week(2).isSame(moment.invalid().week(2)), false, 'with week set');
+    assert.equal(moment.invalid().day(2).isSame(moment.invalid().day(2)), false, 'with day set');
+    assert.equal(moment.invalid().hour(2).isSame(moment.invalid().hour(2)), false, 'with hour set');
+    assert.equal(moment.invalid().minute(2).isSame(moment.invalid().minute(2)), false, 'with minute set');
+    assert.equal(moment.invalid().second(2).isSame(moment.invalid().second(2)), false, 'with second set');
+    assert.equal(moment.invalid().millisecond(2).isSame(moment.invalid().millisecond(2)), false, 'with millisecond set');
+});


### PR DESCRIPTION
this fixes an issue where isSame would return true for two invalid moments, which is inconsistent with NaN === NaN and also inconsistent with other cases where isSame would return false for two invalid moments. (some invalid moments are backed by a valid date)

Fixes #2354