### PR TITLE
Fix test for fractional-hour offsets, fixes #2389

### DIFF
--- a/src/test/moment/utc.js
+++ b/src/test/moment/utc.js
@@ -20,7 +20,7 @@ test('utc and local', function (assert) {
         assert.equal(m.date(), 2, 'the date should be correct for local');
         assert.equal(m.day(), 3, 'the day should be correct for local');
     }
-    offset = Math.ceil(m.utcOffset() / 60);
+    offset = Math.floor(m.utcOffset() / 60);
     expected = (24 + 3 + offset) % 24;
     assert.equal(m.hours(), expected, 'the hours (' + m.hours() + ') should be correct for local');
     assert.equal(moment().utc().utcOffset(), 0, 'timezone in utc should always be zero');


### PR DESCRIPTION
When this test was switched from `.zone()` to `.utcOffset()`, the sign of the value changed, which broke the test for time zones that use fractional-hour offsets, such as UTC+05:30.  We now need to round down instead of up.

Fixes #2389. 