### PR TITLE
Fix isDSTShifted, fixes #2141

### DIFF
--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -14,9 +14,19 @@ import { configFromArray }           from './from-array';
 import { configFromObject }          from './from-object';
 
 function createFromConfig (config) {
+    var res = new Moment(checkOverflow(prepareConfig(config)));
+    if (res._nextDay) {
+        // Adding is smart enough around DST
+        res.add(1, 'd');
+        res._nextDay = undefined;
+    }
+
+    return res;
+}
+
+export function prepareConfig (config) {
     var input = config._i,
-        format = config._f,
-        res;
+        format = config._f;
 
     config._locale = config._locale || getLocale(config._l);
 
@@ -40,14 +50,7 @@ function createFromConfig (config) {
         configFromInput(config);
     }
 
-    res = new Moment(checkOverflow(config));
-    if (res._nextDay) {
-        // Adding is smart enough around DST
-        res.add(1, 'd');
-        res._nextDay = undefined;
-    }
-
-    return res;
+    return config;
 }
 
 function configFromInput(config) {

--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -1,11 +1,12 @@
 import zeroFill from '../utils/zero-fill';
 import { createDuration } from '../duration/create';
 import { addSubtract } from '../moment/add-subtract';
-import { isMoment } from '../moment/constructor';
+import { isMoment, copyConfig } from '../moment/constructor';
 import { addFormatToken } from '../format/format';
 import { addRegexToken, matchOffset } from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { createLocal } from '../create/local';
+import { prepareConfig } from '../create/from-anything';
 import { createUTC } from '../create/utc';
 import isDate from '../utils/is-date';
 import toInt from '../utils/to-int';
@@ -184,12 +185,24 @@ export function isDaylightSavingTime () {
 }
 
 export function isDaylightSavingTimeShifted () {
-    if (this._a) {
-        var other = this._isUTC ? createUTC(this._a) : createLocal(this._a);
-        return this.isValid() && compareArrays(this._a, other.toArray()) > 0;
+    if (typeof this._isDSTShifted !== 'undefined') {
+        return this._isDSTShifted;
     }
 
-    return false;
+    var c = {};
+
+    copyConfig(c, this);
+    c = prepareConfig(c);
+
+    if (c._a) {
+        var other = c._isUTC ? createUTC(c._a) : createLocal(c._a);
+        this._isDSTShifted = this.isValid() &&
+            compareArrays(c._a, other.toArray()) > 0;
+    } else {
+        this._isDSTShifted = false;
+    }
+
+    return this._isDSTShifted;
 }
 
 export function isLocal () {


### PR DESCRIPTION
Maybe its a bit of a hack, but I didn't want to store the input array (`_a`) inside the moment object, just for that function. So I recreate it, as if the moment is created right now, then I do the checks and cache the result.

@icambron what do you think?