### PR TITLE
Run travis tests on last IO.js + node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
+  - "iojs"
+  - "node"
+  - "0.12"
+  - "0.11"
   - "0.10"
 
 env:


### PR DESCRIPTION
I suggest this commit to let travis run on last version of iojs and more versions of node.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/moment/moment/2486)
<!-- Reviewable:end -->
