### PR TITLE
Update deprecate.js

### DIFF
--- a/src/lib/utils/deprecate.js
+++ b/src/lib/utils/deprecate.js
@@ -8,12 +8,11 @@ function warn(msg) {
 }
 
 export function deprecate(msg, fn) {
-    var firstTime = true,
-        msgWithStack = msg + '\n' + (new Error()).stack;
+    var firstTime = true;
 
     return extend(function () {
         if (firstTime) {
-            warn(msgWithStack);
+            warn(msg + '\n' + (new Error()).stack);
             firstTime = false;
         }
         return fn.apply(this, arguments);


### PR DESCRIPTION
As explained in the issue #2479, deprecate function causes Firefox 10 to hang for approximatively 3 seconds at each page load.