### PR TITLE
Fix two digit year parsing with YYYY format

### DIFF
--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -29,7 +29,10 @@ addRegexToken('YYYY',   match1to4, match4);
 addRegexToken('YYYYY',  match1to6, match6);
 addRegexToken('YYYYYY', match1to6, match6);
 
-addParseToken(['YYYY', 'YYYYY', 'YYYYYY'], YEAR);
+addParseToken(['YYYYY', 'YYYYYY'], YEAR);
+addParseToken('YYYY', function (input, array) {
+    array[YEAR] = input.length === 2 ? hooks.parseTwoDigitYear(input) : toInt(input);
+});
 addParseToken('YY', function (input, array) {
     array[YEAR] = hooks.parseTwoDigitYear(input);
 });
@@ -57,4 +60,3 @@ export var getSetYear = makeGetSet('FullYear', false);
 export function getIsLeapYear () {
     return isLeapYear(this.year());
 }
-

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -240,6 +240,13 @@ test('string with format', function (assert) {
     }
 });
 
+test('2 digit year with YYYY format', function (assert) {
+    assert.equal(moment('9/2/99', 'D/M/YYYY').format('DD/MM/YYYY'), '09/02/1999', 'D/M/YYYY ---> 9/2/99');
+    assert.equal(moment('9/2/1999', 'D/M/YYYY').format('DD/MM/YYYY'), '09/02/1999', 'D/M/YYYY ---> 9/2/1999');
+    assert.equal(moment('9/2/68', 'D/M/YYYY').format('DD/MM/YYYY'), '09/02/2068', 'D/M/YYYY ---> 9/2/68');
+    assert.equal(moment('9/2/69', 'D/M/YYYY').format('DD/MM/YYYY'), '09/02/1969', 'D/M/YYYY ---> 9/2/69');
+});
+
 test('unix timestamp format', function (assert) {
     var formats = ['X', 'X.S', 'X.SS', 'X.SSS'], i, format;
 
@@ -637,7 +644,6 @@ test('first century', function (assert) {
     assert.equal(moment([99, 0, 1]).format('YYYY-MM-DD'), '0099-01-01', 'Year AD 99');
     assert.equal(moment([999, 0, 1]).format('YYYY-MM-DD'), '0999-01-01', 'Year AD 999');
     assert.equal(moment('0 1 1', 'YYYY MM DD').format('YYYY-MM-DD'), '0000-01-01', 'Year AD 0');
-    assert.equal(moment('99 1 1', 'YYYY MM DD').format('YYYY-MM-DD'), '0099-01-01', 'Year AD 99');
     assert.equal(moment('999 1 1', 'YYYY MM DD').format('YYYY-MM-DD'), '0999-01-01', 'Year AD 999');
     assert.equal(moment('0 1 1', 'YYYYY MM DD').format('YYYYY-MM-DD'), '00000-01-01', 'Year AD 0');
     assert.equal(moment('99 1 1', 'YYYYY MM DD').format('YYYYY-MM-DD'), '00099-01-01', 'Year AD 99');


### PR DESCRIPTION
Further to the discussion in #2344, this PR provides an alternative way to fix #2343.

I've had to delete one of the existing tests to get this to pass -- it seems that although a couple of people have agreed that the behaviour described in #2343 is unwanted, there was actually a test there to make sure it happened.