### PR TITLE
Days and months in spanish should be lowercase

### DIFF
--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -4,11 +4,11 @@
 
 import moment from '../moment';
 
-var monthsShortDot = 'Ene._Feb._Mar._Abr._May._Jun._Jul._Ago._Sep._Oct._Nov._Dic.'.split('_'),
-    monthsShort = 'Ene_Feb_Mar_Abr_May_Jun_Jul_Ago_Sep_Oct_Nov_Dic'.split('_');
+var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
+    monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');
 
 export default moment.defineLocale('es', {
-    months : 'Enero_Febrero_Marzo_Abril_Mayo_Junio_Julio_Agosto_Septiembre_Octubre_Noviembre_Diciembre'.split('_'),
+    months : 'enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre'.split('_'),
     monthsShort : function (m, format) {
         if (/-MMM-/.test(format)) {
             return monthsShort[m.month()];
@@ -16,8 +16,8 @@ export default moment.defineLocale('es', {
             return monthsShortDot[m.month()];
         }
     },
-    weekdays : 'Domingo_Lunes_Martes_Miércoles_Jueves_Viernes_Sábado'.split('_'),
-    weekdaysShort : 'Dom._Lun._Mar._Mié._Jue._Vie._Sáb.'.split('_'),
+    weekdays : 'domingo_lunes_martes_miércoles_jueves_viernes_sábado'.split('_'),
+    weekdaysShort : 'dom._lun._mar._mié._jue._vie._sáb.'.split('_'),
     weekdaysMin : 'Do_Lu_Ma_Mi_Ju_Vi_Sá'.split('_'),
     longDateFormat : {
         LT : 'H:mm',

--- a/src/test/locale/es.js
+++ b/src/test/locale/es.js
@@ -22,15 +22,15 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Domingo, Febrero 14º 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'Dom., 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2º 02 Febrero Feb.'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'domingo, febrero 14º 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'dom., 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2º 02 febrero feb.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14º 14'],
-            ['d do dddd ddd dd',                   '0 0º Domingo Dom. Do'],
+            ['d do dddd ddd dd',                   '0 0º domingo dom. Do'],
             ['DDD DDDo DDDD',                      '45 45º 045'],
             ['w wo ww',                            '6 6º 06'],
-            ['YYYY-MMM-DD',                        '2010-Feb-14'],
+            ['YYYY-MMM-DD',                        '2010-feb-14'],
             ['h hh',                               '3 03'],
             ['H HH',                               '15 15'],
             ['m mm',                               '25 25'],
@@ -39,13 +39,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45º day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 de Febrero de 2010'],
-            ['LLL',                                '14 de Febrero de 2010 15:25'],
-            ['LLLL',                               'Domingo, 14 de Febrero de 2010 15:25'],
+            ['LL',                                 '14 de febrero de 2010'],
+            ['LLL',                                '14 de febrero de 2010 15:25'],
+            ['LLLL',                               'domingo, 14 de febrero de 2010 15:25'],
             ['l',                                  '14/2/2010'],
-            ['ll',                                 '14 de Feb. de 2010'],
-            ['lll',                                '14 de Feb. de 2010 15:25'],
-            ['llll',                               'Dom., 14 de Feb. de 2010 15:25']
+            ['ll',                                 '14 de feb. de 2010'],
+            ['lll',                                '14 de feb. de 2010 15:25'],
+            ['llll',                               'dom., 14 de feb. de 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -92,14 +92,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'Enero Ene._Febrero Feb._Marzo Mar._Abril Abr._Mayo May._Junio Jun._Julio Jul._Agosto Ago._Septiembre Sep._Octubre Oct._Noviembre Nov._Diciembre Dic.'.split('_'), i;
+    var expected = 'enero ene._febrero feb._marzo mar._abril abr._mayo may._junio jun._julio jul._agosto ago._septiembre sep._octubre oct._noviembre nov._diciembre dic.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'Domingo Dom. Do_Lunes Lun. Lu_Martes Mar. Ma_Miércoles Mié. Mi_Jueves Jue. Ju_Viernes Vie. Vi_Sábado Sáb. Sá'.split('_'), i;
+    var expected = 'domingo dom. Do_lunes lun. Lu_martes mar. Ma_miércoles mié. Mi_jueves jue. Ju_viernes vie. Vi_sábado sáb. Sá'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -135,7 +135,7 @@ test('library localeData', function (assert) {
 
     assert.equal(moment.localeData().months(jan), 'January', 'no arguments returns global');
     assert.equal(moment.localeData('zh-cn').months(jan), '一月', 'a string returns the locale based on key');
-    assert.equal(moment.localeData(moment().locale('es')).months(jan), 'Enero', 'if you pass in a moment it uses the moment\'s locale');
+    assert.equal(moment.localeData(moment().locale('es')).months(jan), 'enero', 'if you pass in a moment it uses the moment\'s locale');
 });
 
 test('library deprecations', function (assert) {
@@ -169,7 +169,7 @@ test('instance locale method', function (assert) {
     moment.locale('en');
 
     assert.equal(moment([2012, 5, 6]).format('MMMM'), 'June', 'Normally default to global');
-    assert.equal(moment([2012, 5, 6]).locale('es').format('MMMM'), 'Junio', 'Use the instance specific locale');
+    assert.equal(moment([2012, 5, 6]).locale('es').format('MMMM'), 'junio', 'Use the instance specific locale');
     assert.equal(moment([2012, 5, 6]).format('MMMM'), 'June', 'Using an instance specific locale does not affect other moments');
 });
 
@@ -193,9 +193,9 @@ test('instance getter locale substrings', function (assert) {
 test('instance locale persists with manipulation', function (assert) {
     moment.locale('en');
 
-    assert.equal(moment([2012, 5, 6]).locale('es').add({days: 1}).format('MMMM'), 'Junio', 'With addition');
-    assert.equal(moment([2012, 5, 6]).locale('es').day(0).format('MMMM'), 'Junio', 'With day getter');
-    assert.equal(moment([2012, 5, 6]).locale('es').endOf('day').format('MMMM'), 'Junio', 'With endOf');
+    assert.equal(moment([2012, 5, 6]).locale('es').add({days: 1}).format('MMMM'), 'junio', 'With addition');
+    assert.equal(moment([2012, 5, 6]).locale('es').day(0).format('MMMM'), 'junio', 'With day getter');
+    assert.equal(moment([2012, 5, 6]).locale('es').endOf('day').format('MMMM'), 'junio', 'With endOf');
 });
 
 test('instance locale persists with cloning', function (assert) {
@@ -205,8 +205,8 @@ test('instance locale persists with cloning', function (assert) {
         b = a.clone(),
         c = moment(a);
 
-    assert.equal(b.format('MMMM'), 'Junio', 'using moment.fn.clone()');
-    assert.equal(b.format('MMMM'), 'Junio', 'using moment()');
+    assert.equal(b.format('MMMM'), 'junio', 'using moment.fn.clone()');
+    assert.equal(b.format('MMMM'), 'junio', 'using moment()');
 });
 
 test('duration locale method', function (assert) {


### PR DESCRIPTION
In Spanish, day and month names should be lowercase... as they were prior to commit 7d147d6

fixes #2497 