### PR TITLE
Standard nomenclature (ro, ca, eo, eu, fo, fr, fr-ca)

### DIFF
--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -5,10 +5,10 @@
 import moment from '../moment';
 
 export default moment.defineLocale('ca', {
-    months : 'gener_febrer_març_abril_maig_juny_juliol_agost_setembre_octubre_novembre_desembre'.split('_'),
-    monthsShort : 'gen._febr._mar._abr._mai._jun._jul._ag._set._oct._nov._des.'.split('_'),
-    weekdays : 'diumenge_dilluns_dimarts_dimecres_dijous_divendres_dissabte'.split('_'),
-    weekdaysShort : 'dg._dl._dt._dc._dj._dv._ds.'.split('_'),
+    months : 'Gener_Febrer_Març_Abril_Maig_Juny_Juliol_Agost_Setembre_Octubre_Novembre_Desembre'.split('_'),
+    monthsShort : 'Gen._Febr._Mar._Abr._Mai._Jun._Jul._Ag._Set._Oct._Nov._Des.'.split('_'),
+    weekdays : 'Diumenge_Dilluns_Dimarts_Dimecres_Dijous_Divendres_Dissabte'.split('_'),
+    weekdaysShort : 'Dg._Dl._Dt._Dc._Dj._Dv._Ds.'.split('_'),
     weekdaysMin : 'Dg_Dl_Dt_Dc_Dj_Dv_Ds'.split('_'),
     longDateFormat : {
         LT : 'H:mm',

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -7,8 +7,8 @@
 import moment from '../moment';
 
 export default moment.defineLocale('eo', {
-    months : 'januaro_februaro_marto_aprilo_majo_junio_julio_aŭgusto_septembro_oktobro_novembro_decembro'.split('_'),
-    monthsShort : 'jan_feb_mar_apr_maj_jun_jul_aŭg_sep_okt_nov_dec'.split('_'),
+    months : 'Januaro_Februaro_Marto_Aprilo_Majo_Junio_Julio_Aŭgusto_Septembro_Oktobro_Novembro_Decembro'.split('_'),
+    monthsShort : 'Jan_Feb_Mar_Apr_Maj_Jun_Jul_Aŭg_Sep_Okt_Nov_Dec'.split('_'),
     weekdays : 'Dimanĉo_Lundo_Mardo_Merkredo_Ĵaŭdo_Vendredo_Sabato'.split('_'),
     weekdaysShort : 'Dim_Lun_Mard_Merk_Ĵaŭ_Ven_Sab'.split('_'),
     weekdaysMin : 'Di_Lu_Ma_Me_Ĵa_Ve_Sa'.split('_'),

--- a/src/locale/eu.js
+++ b/src/locale/eu.js
@@ -5,11 +5,11 @@
 import moment from '../moment';
 
 export default moment.defineLocale('eu', {
-    months : 'urtarrila_otsaila_martxoa_apirila_maiatza_ekaina_uztaila_abuztua_iraila_urria_azaroa_abendua'.split('_'),
-    monthsShort : 'urt._ots._mar._api._mai._eka._uzt._abu._ira._urr._aza._abe.'.split('_'),
-    weekdays : 'igandea_astelehena_asteartea_asteazkena_osteguna_ostirala_larunbata'.split('_'),
-    weekdaysShort : 'ig._al._ar._az._og._ol._lr.'.split('_'),
-    weekdaysMin : 'ig_al_ar_az_og_ol_lr'.split('_'),
+    months : 'Urtarrila_Otsaila_Martxoa_Apirila_Maiatza_Ekaina_Uztaila_Abuztua_Iraila_Urria_Azaroa_Abendua'.split('_'),
+    monthsShort : 'Urt._Ots._Mar._Api._Mai._Eka._Uzt._Abu._Ira._Urr._Aza._Abe.'.split('_'),
+    weekdays : 'Igandea_Astelehena_Asteartea_Asteazkena_Osteguna_Ostirala_Larunbata'.split('_'),
+    weekdaysShort : 'Ig._Al._Ar._Az._Og._Ol._Lr.'.split('_'),
+    weekdaysMin : 'Ig_Al_Ar_Az_Og_Ol_Lr'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',

--- a/src/locale/fo.js
+++ b/src/locale/fo.js
@@ -5,11 +5,11 @@
 import moment from '../moment';
 
 export default moment.defineLocale('fo', {
-    months : 'januar_februar_mars_apríl_mai_juni_juli_august_september_oktober_november_desember'.split('_'),
-    monthsShort : 'jan_feb_mar_apr_mai_jun_jul_aug_sep_okt_nov_des'.split('_'),
-    weekdays : 'sunnudagur_mánadagur_týsdagur_mikudagur_hósdagur_fríggjadagur_leygardagur'.split('_'),
-    weekdaysShort : 'sun_mán_týs_mik_hós_frí_ley'.split('_'),
-    weekdaysMin : 'su_má_tý_mi_hó_fr_le'.split('_'),
+    months : 'Januar_Februar_Mars_Apríl_Mai_Juni_Juli_August_September_Oktober_November_Desember'.split('_'),
+    monthsShort : 'Jan_Feb_Mar_Apr_Mai_Jun_Jul_Aug_Sep_Okt_Nov_Des'.split('_'),
+    weekdays : 'Sunnudagur_Mánadagur_Týsdagur_Mikudagur_Hósdagur_Fríggjadagur_Leygardagur'.split('_'),
+    weekdaysShort : 'Sun_Mán_Týs_Mik_Hós_Frí_Ley'.split('_'),
+    weekdaysMin : 'Su_Má_Tý_Mi_Hó_Fr_Le'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -5,10 +5,10 @@
 import moment from '../moment';
 
 export default moment.defineLocale('fr-ca', {
-    months : 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split('_'),
-    monthsShort : 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
-    weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
-    weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
+    months : 'Janvier_Février_Mars_Avril_Mai_Juin_Juillet_Août_Septembre_Octobre_Novembre_Décembre'.split('_'),
+    monthsShort : 'Janv._Févr._Mars_Avr._Mai_Juin_Juil._Août_Sept._Oct._Nov._Déc.'.split('_'),
+    weekdays : 'Dimanche_Lundi_Mardi_Mercredi_Jeudi_Vendredi_Samedi'.split('_'),
+    weekdaysShort : 'Dim._Lun._Mar._Mer._Jeu._Ven._Sam.'.split('_'),
     weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -5,10 +5,10 @@
 import moment from '../moment';
 
 export default moment.defineLocale('fr', {
-    months : 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split('_'),
-    monthsShort : 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
-    weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
-    weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
+    months : 'Janvier_Février_Mars_Avril_Mai_Juin_Juillet_Août_Septembre_Octobre_Novembre_Décembre'.split('_'),
+    monthsShort : 'Janv._Févr._Mars_Avr._Mai_Juin_Juil._Août_Sept._Oct._Nov._Déc.'.split('_'),
+    weekdays : 'Dimanche_Lundi_Mardi_Mercredi_Jeudi_Vendredi_Samedi'.split('_'),
+    weekdaysShort : 'Dim._Lun._Mar._Mer._Jeu._Ven._Sam.'.split('_'),
     weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',

--- a/src/locale/fy.js
+++ b/src/locale/fy.js
@@ -4,7 +4,7 @@
 
 import moment from '../moment';
 
-var monthsShortWithDots = 'Jan._Feb._Mrt._Apr._Mai_Jun._Jul._Aug._Sep._Okt._Nov._Des.'.split('_'),
+var monthsShortWithDots = 'Jan._Feb._Mrt._Apr._Mai._Jun._Jul._Aug._Sep._Okt._Nov._Des.'.split('_'),
     monthsShortWithoutDots = 'Jan_Feb_Mrt_Apr_Mai_Jun_Jul_Aug_Sep_Okt_Nov_Des'.split('_');
 
 export default moment.defineLocale('fy', {
@@ -16,7 +16,7 @@ export default moment.defineLocale('fy', {
             return monthsShortWithDots[m.month()];
         }
     },
-    weekdays : 'Snein_Moandei_Tiisdei_Woansdei_Yongersdei_Freed_Sneon'.split('_'),
+    weekdays : 'Snein_Moandei_Tiisdei_Woansdei_Tongersdei_Freed_Sneon'.split('_'),
     weekdaysShort : 'Si._Mo._Ti._Wo._To._Fr._So.'.split('_'),
     weekdaysMin : 'Si_Mo_Ti_Wo_To_Fr_So'.split('_'),
     longDateFormat : {

--- a/src/locale/fy.js
+++ b/src/locale/fy.js
@@ -4,11 +4,11 @@
 
 import moment from '../moment';
 
-var monthsShortWithDots = 'jan._feb._mrt._apr._mai_jun._jul._aug._sep._okt._nov._des.'.split('_'),
-    monthsShortWithoutDots = 'jan_feb_mrt_apr_mai_jun_jul_aug_sep_okt_nov_des'.split('_');
+var monthsShortWithDots = 'Jan._Feb._Mrt._Apr._Mai_Jun._Jul._Aug._Sep._Okt._Nov._Des.'.split('_'),
+    monthsShortWithoutDots = 'Jan_Feb_Mrt_Apr_Mai_Jun_Jul_Aug_Sep_Okt_Nov_Des'.split('_');
 
 export default moment.defineLocale('fy', {
-    months : 'jannewaris_febrewaris_maart_april_maaie_juny_july_augustus_septimber_oktober_novimber_desimber'.split('_'),
+    months : 'Jannewaris_Febrewaris_Maart_April_Maaie_Juny_July_Augustus_Septimber_Oktober_Novimber_Desimber'.split('_'),
     monthsShort : function (m, format) {
         if (/-MMM-/.test(format)) {
             return monthsShortWithoutDots[m.month()];
@@ -16,8 +16,8 @@ export default moment.defineLocale('fy', {
             return monthsShortWithDots[m.month()];
         }
     },
-    weekdays : 'snein_moandei_tiisdei_woansdei_tongersdei_freed_sneon'.split('_'),
-    weekdaysShort : 'si._mo._ti._wo._to._fr._so.'.split('_'),
+    weekdays : 'Snein_Moandei_Tiisdei_Woansdei_Yongersdei_Freed_Sneon'.split('_'),
+    weekdaysShort : 'Si._Mo._Ti._Wo._To._Fr._So.'.split('_'),
     weekdaysMin : 'Si_Mo_Ti_Wo_To_Fr_So'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',

--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -21,9 +21,9 @@ function relativeTimeWithPlural(number, withoutSuffix, key) {
 }
 
 export default moment.defineLocale('ro', {
-    months : 'ianuarie_februarie_martie_aprilie_mai_iunie_iulie_august_septembrie_octombrie_noiembrie_decembrie'.split('_'),
-    monthsShort : 'ian._febr._mart._apr._mai_iun._iul._aug._sept._oct._nov._dec.'.split('_'),
-    weekdays : 'duminică_luni_marți_miercuri_joi_vineri_sâmbătă'.split('_'),
+    months : 'Ianuarie_Februarie_Martie_Aprilie_Mai_Iunie_Iulie_August_Septembrie_Octombrie_Noiembrie_Decembrie'.split('_'),
+    monthsShort : 'Ian._Febr._Mart._Apr._Mai_Iun._Iul._Aug._Sept._Oct._Nov._Dec.'.split('_'),
+    weekdays : 'Duminică_Luni_Marți_Miercuri_Joi_Vineri_Sâmbătă'.split('_'),
     weekdaysShort : 'Dum_Lun_Mar_Mie_Joi_Vin_Sâm'.split('_'),
     weekdaysMin : 'Du_Lu_Ma_Mi_Jo_Vi_Sâ'.split('_'),
     longDateFormat : {

--- a/src/test/locale/ca.js
+++ b/src/test/locale/ca.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('ca');
 
 test('parse', function (assert) {
-    var tests = 'gener gen._febrer febr._març mar._abril abr._maig mai._juny jun._juliol jul._agost ag._setembre set._octubre oct._novembre nov._desembre des.'.split('_'), i;
+    var tests = 'Gener Gen._Febrer Febr._Març Mar._Abril Abr._Maig Mai._Juny Jun._Juliol Jul._Agost Ag._Setembre Set._Octubre Oct._Novembre Nov._Desembre Des.'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -22,12 +22,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, Do MMMM YYYY, h:mm:ss a',      'diumenge, 14è febrer 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'dg., 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2n 02 febrer febr.'],
+            ['dddd, Do MMMM YYYY, h:mm:ss a',      'Diumenge, 14è Febrer 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Dg., 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2n 02 Febrer Febr.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14è 14'],
-            ['d do dddd ddd dd',                   '0 0è diumenge dg. Dg'],
+            ['d do dddd ddd dd',                   '0 0è Diumenge Dg. Dg'],
             ['DDD DDDo DDDD',                      '45 45è 045'],
             ['w wo ww',                            '6 6a 06'],
             ['h hh',                               '3 03'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45è day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 febrer 2010'],
-            ['LLL',                                '14 febrer 2010 15:25'],
-            ['LLLL',                               'diumenge 14 febrer 2010 15:25'],
+            ['LL',                                 '14 Febrer 2010'],
+            ['LLL',                                '14 Febrer 2010 15:25'],
+            ['LLLL',                               'Diumenge 14 Febrer 2010 15:25'],
             ['l',                                  '14/2/2010'],
-            ['ll',                                 '14 febr. 2010'],
-            ['lll',                                '14 febr. 2010 15:25'],
-            ['llll',                               'dg. 14 febr. 2010 15:25']
+            ['ll',                                 '14 Febr. 2010'],
+            ['lll',                                '14 Febr. 2010 15:25'],
+            ['llll',                               'Dg. 14 Febr. 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,14 +91,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'gener gen._febrer febr._març mar._abril abr._maig mai._juny jun._juliol jul._agost ag._setembre set._octubre oct._novembre nov._desembre des.'.split('_'), i;
+    var expected = 'Gener Gen._Febrer Febr._Març Mar._Abril Abr._Maig Mai._Juny Jun._Juliol Jul._Agost Ag._Setembre Set._Octubre Oct._Novembre Nov._Desembre Des.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'diumenge dg. Dg_dilluns dl. Dl_dimarts dt. Dt_dimecres dc. Dc_dijous dj. Dj_divendres dv. Dv_dissabte ds. Ds'.split('_'), i;
+    var expected = 'Diumenge Dg. Dg_Dilluns Dl. Dl_Dimarts Dt. Dt_Dimecres Dc. Dc_Dijous Dj. Dj_Divendres Dv. Dv_Dissabte Ds. Ds'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/locale/eo.js
+++ b/src/test/locale/eo.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('eo');
 
 test('parse', function (assert) {
-    var tests = 'januaro jan_februaro feb_marto mar_aprilo apr_majo maj_junio jun_julio jul_aŭgusto aŭg_septembro sep_oktobro okt_novembro nov_decembro dec'.split('_'), i;
+    var tests = 'Januaro Jan_Februaro Feb_Marto Mar_Aprilo Apr_Majo Maj_Junio Jun_Julio Jul_Aŭgusto Aŭg_Septembro Sep_Oktobro Okt_Novembro Nov_Decembro Dec'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -22,9 +22,9 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Dimanĉo, februaro 14a 2010, 3:25:50 p.t.m.'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Dimanĉo, Februaro 14a 2010, 3:25:50 p.t.m.'],
             ['ddd, hA',                            'Dim, 3P.T.M.'],
-            ['M Mo MM MMMM MMM',                   '2 2a 02 februaro feb'],
+            ['M Mo MM MMMM MMM',                   '2 2a 02 Februaro Feb'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14a 14'],
             ['d do dddd ddd dd',                   '0 0a Dimanĉo Dim Di'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[la] DDDo [tago] [de] [la] [jaro]',  'la 45a tago de la jaro'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '2010-02-14'],
-            ['LL',                                 '14-an de februaro, 2010'],
-            ['LLL',                                '14-an de februaro, 2010 15:25'],
-            ['LLLL',                               'Dimanĉo, la 14-an de februaro, 2010 15:25'],
+            ['LL',                                 '14-an de Februaro, 2010'],
+            ['LLL',                                '14-an de Februaro, 2010 15:25'],
+            ['LLLL',                               'Dimanĉo, la 14-an de Februaro, 2010 15:25'],
             ['l',                                  '2010-2-14'],
-            ['ll',                                 '14-an de feb, 2010'],
-            ['lll',                                '14-an de feb, 2010 15:25'],
-            ['llll',                               'Dim, la 14-an de feb, 2010 15:25']
+            ['ll',                                 '14-an de Feb, 2010'],
+            ['lll',                                '14-an de Feb, 2010 15:25'],
+            ['llll',                               'Dim, la 14-an de Feb, 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,7 +91,7 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'januaro jan_februaro feb_marto mar_aprilo apr_majo maj_junio jun_julio jul_aŭgusto aŭg_septembro sep_oktobro okt_novembro nov_decembro dec'.split('_'), i;
+    var expected = 'Januaro Jan_Februaro Feb_Marto Mar_Aprilo Apr_Majo Maj_Junio Jun_Julio Jul_Aŭgusto Aŭg_Septembro Sep_Oktobro Okt_Novembro Nov_Decembro Dec'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }

--- a/src/test/locale/eu.js
+++ b/src/test/locale/eu.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('eu');
 
 test('parse', function (assert) {
-    var tests = 'urtarrila urt._otsaila ots._martxoa mar._apirila api._maiatza mai._ekaina eka._uztaila uzt._abuztua abu._iraila ira._urria urr._azaroa aza._abendua abe.'.split('_'), i;
+    var tests = 'Urtarrila Urt._Otsaila Ots._Martxoa Mar._Apirila Api._Maiatza Mai._Ekaina Eka._Uztaila Uzt._Abuztua Abu._Iraila Ira._Urria Urr._Azaroa Aza._Abendua Abe.'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -22,12 +22,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'igandea, otsaila 14. 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'ig., 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2. 02 otsaila ots.'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Igandea, Otsaila 14. 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Ig., 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2. 02 Otsaila Ots.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14. 14'],
-            ['d do dddd ddd dd',                   '0 0. igandea ig. ig'],
+            ['d do dddd ddd dd',                   '0 0. Igandea Ig. Ig'],
             ['DDD DDDo DDDD',                      '45 45. 045'],
             ['w wo ww',                            '7 7. 07'],
             ['h hh',                               '3 03'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '2010-02-14'],
-            ['LL',                                 '2010ko otsailaren 14a'],
-            ['LLL',                                '2010ko otsailaren 14a 15:25'],
-            ['LLLL',                               'igandea, 2010ko otsailaren 14a 15:25'],
+            ['LL',                                 '2010ko Otsailaren 14a'],
+            ['LLL',                                '2010ko Otsailaren 14a 15:25'],
+            ['LLLL',                               'Igandea, 2010ko Otsailaren 14a 15:25'],
             ['l',                                  '2010-2-14'],
-            ['ll',                                 '2010ko ots. 14a'],
-            ['lll',                                '2010ko ots. 14a 15:25'],
-            ['llll',                               'ig., 2010ko ots. 14a 15:25']
+            ['ll',                                 '2010ko Ots. 14a'],
+            ['lll',                                '2010ko Ots. 14a 15:25'],
+            ['llll',                               'Ig., 2010ko Ots. 14a 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,14 +91,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'urtarrila urt._otsaila ots._martxoa mar._apirila api._maiatza mai._ekaina eka._uztaila uzt._abuztua abu._iraila ira._urria urr._azaroa aza._abendua abe.'.split('_'), i;
+    var expected = 'Urtarrila Urt._Otsaila Ots._Martxoa Mar._Apirila Api._Maiatza Mai._Ekaina Eka._Uztaila Uzt._Abuztua Abu._Iraila Ira._Urria Urr._Azaroa Aza._Abendua Abe.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'igandea ig. ig_astelehena al. al_asteartea ar. ar_asteazkena az. az_osteguna og. og_ostirala ol. ol_larunbata lr. lr'.split('_'), i;
+    var expected = 'Igandea Ig. Ig_Astelehena Al. Al_Asteartea Ar. Ar_Asteazkena Az. Az_Osteguna Og. Og_Ostirala Ol. Ol_Larunbata Lr. Lr'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/locale/fo.js
+++ b/src/test/locale/fo.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('fo');
 
 test('parse', function (assert) {
-    var tests = 'januar jan_februar feb_mars mar_apríl apr_mai mai_juni jun_juli jul_august aug_september sep_oktober okt_november nov_desember des'.split('_'), i;
+    var tests = 'Januar Jan_Februar Feb_Mars Mar_Apríl Apr_Mai Mai_Juni Jun_Juli Jul_August Aug_September Sep_Oktober Okt_November Nov_Desember Des'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -22,12 +22,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd [tann] Do MMMM YYYY, h:mm:ss a', 'sunnudagur tann 14. februar 2010, 3:25:50 pm'],
-            ['ddd hA',                             'sun 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2. 02 februar feb'],
+            ['dddd [tann] Do MMMM YYYY, h:mm:ss a', 'Sunnudagur tann 14. Februar 2010, 3:25:50 pm'],
+            ['ddd hA',                             'Sun 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2. 02 Februar Feb'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14. 14'],
-            ['d do dddd ddd dd',                   '0 0. sunnudagur sun su'],
+            ['d do dddd ddd dd',                   '0 0. Sunnudagur Sun Su'],
             ['DDD DDDo DDDD',                      '45 45. 045'],
             ['w wo ww',                            '6 6. 06'],
             ['h hh',                               '3 03'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[tann] DDDo [dagin á árinum]',       'tann 45. dagin á árinum'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 februar 2010'],
-            ['LLL',                                '14 februar 2010 15:25'],
-            ['LLLL',                               'sunnudagur 14. februar, 2010 15:25'],
+            ['LL',                                 '14 Februar 2010'],
+            ['LLL',                                '14 Februar 2010 15:25'],
+            ['LLLL',                               'Sunnudagur 14. Februar, 2010 15:25'],
             ['l',                                  '14/2/2010'],
-            ['ll',                                 '14 feb 2010'],
-            ['lll',                                '14 feb 2010 15:25'],
-            ['llll',                               'sun 14. feb, 2010 15:25']
+            ['ll',                                 '14 Feb 2010'],
+            ['lll',                                '14 Feb 2010 15:25'],
+            ['llll',                               'Sun 14. Feb, 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,14 +91,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'januar jan_februar feb_mars mar_apríl apr_mai mai_juni jun_juli jul_august aug_september sep_oktober okt_november nov_desember des'.split('_'), i;
+    var expected = 'Januar Jan_Februar Feb_Mars Mar_Apríl Apr_Mai Mai_Juni Jun_Juli Jul_August Aug_September Sep_Oktober Okt_November Nov_Desember Des'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'sunnudagur sun su_mánadagur mán má_týsdagur týs tý_mikudagur mik mi_hósdagur hós hó_fríggjadagur frí fr_leygardagur ley le'.split('_'), i;
+    var expected = 'Sunnudagur Sun Su_Mánadagur Mán Má_Týsdagur Týs Tý_Mikudagur Mik Mi_Hósdagur Hós Hó_Fríggjadagur Frí Fr_Leygardagur Ley Le'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/locale/fr-ca.js
+++ b/src/test/locale/fr-ca.js
@@ -4,7 +4,7 @@ localeModule('fr-ca');
 
 test('parse', function (assert) {
     var i,
-        tests = 'janvier janv._février févr._mars mars_avril avr._mai mai_juin juin_juillet juil._août août_septembre sept._octobre oct._novembre nov._décembre déc.'.split('_');
+        tests = 'Janvier Janv._Février Févr._Mars Mars_Avril Avr._Mai Mai_Juin Juin_Juillet Juil._Août Août_Septembre Sept._Octobre Oct._Novembre Nov._Décembre Déc.'.split('_');
 
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
@@ -25,12 +25,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'dimanche, février 14e 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'dim., 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2e 02 février févr.'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Dimanche, Février 14e 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Dim., 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2e 02 Février Févr.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14e 14'],
-            ['d do dddd ddd dd',                   '0 0e dimanche dim. Di'],
+            ['d do dddd ddd dd',                   '0 0e Dimanche Dim. Di'],
             ['DDD DDDo DDDD',                      '45 45e 045'],
             ['w wo ww',                            '8 8e 08'],
             ['h hh',                               '3 03'],
@@ -41,13 +41,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45e day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '2010-02-14'],
-            ['LL',                                 '14 février 2010'],
-            ['LLL',                                '14 février 2010 15:25'],
-            ['LLLL',                               'dimanche 14 février 2010 15:25'],
+            ['LL',                                 '14 Février 2010'],
+            ['LLL',                                '14 Février 2010 15:25'],
+            ['LLLL',                               'Dimanche 14 Février 2010 15:25'],
             ['l',                                  '2010-2-14'],
-            ['ll',                                 '14 févr. 2010'],
-            ['lll',                                '14 févr. 2010 15:25'],
-            ['llll',                               'dim. 14 févr. 2010 15:25']
+            ['ll',                                 '14 Févr. 2010'],
+            ['lll',                                '14 Févr. 2010 15:25'],
+            ['llll',                               'Dim. 14 Févr. 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -96,7 +96,7 @@ test('format ordinal', function (assert) {
 
 test('format month', function (assert) {
     var i,
-        expected = 'janvier janv._février févr._mars mars_avril avr._mai mai_juin juin_juillet juil._août août_septembre sept._octobre oct._novembre nov._décembre déc.'.split('_');
+        expected = 'Janvier Janv._Février Févr._Mars Mars_Avril Avr._Mai Mai_Juin Juin_Juillet Juil._Août Août_Septembre Sept._Octobre Oct._Novembre Nov._Décembre Déc.'.split('_');
 
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
@@ -105,7 +105,7 @@ test('format month', function (assert) {
 
 test('format week', function (assert) {
     var i,
-        expected = 'dimanche dim. Di_lundi lun. Lu_mardi mar. Ma_mercredi mer. Me_jeudi jeu. Je_vendredi ven. Ve_samedi sam. Sa'.split('_');
+        expected = 'Dimanche Dim. Di_Lundi Lun. Lu_Mardi Mar. Ma_Mercredi Mer. Me_Jeudi Jeu. Je_Vendredi Ven. Ve_Samedi Sam. Sa'.split('_');
 
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);

--- a/src/test/locale/fr.js
+++ b/src/test/locale/fr.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('fr');
 
 test('parse', function (assert) {
-    var tests = 'janvier janv._février févr._mars mars_avril avr._mai mai_juin juin_juillet juil._août août_septembre sept._octobre oct._novembre nov._décembre déc.'.split('_'),
+    var tests = 'Janvier Janv._Février Févr._Mars Mars_Avril Avr._Mai Mai_Juin Juin_Juillet Juil._Août Août_Septembre Sept._Octobre Oct._Novembre Nov._Décembre Déc.'.split('_'),
         i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
@@ -23,12 +23,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'dimanche, février 14 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'dim., 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2 02 février févr.'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Dimanche, Février 14 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Dim., 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2 02 Février Févr.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14 14'],
-            ['d do dddd ddd dd',                   '0 0 dimanche dim. Di'],
+            ['d do dddd ddd dd',                   '0 0 Dimanche Dim. Di'],
             ['DDD DDDo DDDD',                      '45 45 045'],
             ['w wo ww',                            '6 6 06'],
             ['h hh',                               '3 03'],
@@ -39,13 +39,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45 day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 février 2010'],
-            ['LLL',                                '14 février 2010 15:25'],
-            ['LLLL',                               'dimanche 14 février 2010 15:25'],
+            ['LL',                                 '14 Février 2010'],
+            ['LLL',                                '14 Février 2010 15:25'],
+            ['LLLL',                               'Dimanche 14 Février 2010 15:25'],
             ['l',                                  '14/2/2010'],
-            ['ll',                                 '14 févr. 2010'],
-            ['lll',                                '14 févr. 2010 15:25'],
-            ['llll',                               'dim. 14 févr. 2010 15:25']
+            ['ll',                                 '14 Févr. 2010'],
+            ['lll',                                '14 Févr. 2010 15:25'],
+            ['llll',                               'Dim. 14 Févr. 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -92,14 +92,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'janvier janv._février févr._mars mars_avril avr._mai mai_juin juin_juillet juil._août août_septembre sept._octobre oct._novembre nov._décembre déc.'.split('_'), i;
+    var expected = 'Janvier Janv._Février Févr._Mars Mars_Avril Avr._Mai Mai_Juin Juin_Juillet Juil._Août Août_Septembre Sept._Octobre Oct._Novembre Nov._Décembre Déc.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'dimanche dim. Di_lundi lun. Lu_mardi mar. Ma_mercredi mer. Me_jeudi jeu. Je_vendredi ven. Ve_samedi sam. Sa'.split('_'), i;
+    var expected = 'Dimanche Dim. Di_Lundi Lun. Lu_Mardi Mar. Ma_Mercredi Mer. Me_Jeudi Jeu. Je_Vendredi Ven. Ve_Samedi Sam. Sa'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/locale/fy.js
+++ b/src/test/locale/fy.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('fy');
 
 test('parse', function (assert) {
-    var tests = 'jannewaris jan._febrewaris feb._maart mrt._april apr._maaie mai._juny jun._july jul._augustus aug._septimber sep._oktober okt._novimber nov._desimber des.'.split('_'), i;
+    var tests = 'Jannewaris Jan._Febrewaris Feb._Maart Mrt._April Apr._Maaie Mai._Juny Jun._July Jul._Augustus Aug._Septimber Sep._Oktober Okt._Novimber Nov._Desimber Des.'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -22,12 +22,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, HH:mm:ss',       'snein, febrewaris 14de 2010, 15:25:50'],
-            ['ddd, HH',                            'si., 15'],
-            ['M Mo MM MMMM MMM',                   '2 2de 02 febrewaris feb.'],
+            ['dddd, MMMM Do YYYY, HH:mm:ss',       'Snein, Febrewaris 14de 2010, 15:25:50'],
+            ['ddd, HH',                            'Si., 15'],
+            ['M Mo MM MMMM MMM',                   '2 2de 02 Febrewaris Feb.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14de 14'],
-            ['d do dddd ddd dd',                   '0 0de snein si. Si'],
+            ['d do dddd ddd dd',                   '0 0de Snein Si. Si'],
             ['DDD DDDo DDDD',                      '45 45ste 045'],
             ['w wo ww',                            '6 6de 06'],
             ['h hh',                               '3 03'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45ste day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14-02-2010'],
-            ['LL',                                 '14 febrewaris 2010'],
-            ['LLL',                                '14 febrewaris 2010 15:25'],
-            ['LLLL',                               'snein 14 febrewaris 2010 15:25'],
+            ['LL',                                 '14 Febrewaris 2010'],
+            ['LLL',                                '14 Febrewaris 2010 15:25'],
+            ['LLLL',                               'Snein 14 Febrewaris 2010 15:25'],
             ['l',                                  '14-2-2010'],
-            ['ll',                                 '14 feb. 2010'],
-            ['lll',                                '14 feb. 2010 15:25'],
-            ['llll',                               'si. 14 feb. 2010 15:25']
+            ['ll',                                 '14 Feb. 2010'],
+            ['lll',                                '14 Feb. 2010 15:25'],
+            ['llll',                               'Si. 14 Feb. 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,14 +91,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'jannewaris jan._febrewaris feb._maart mrt._april apr._maaie mai_juny jun._july jul._augustus aug._septimber sep._oktober okt._novimber nov._desimber des.'.split('_'), i;
+    var expected = 'Jannewaris Jan._Febrewaris Feb._Maart Mrt._April Apr._Maaie Mai._Juny Jun._July Jul._Augustus Aug._Septimber Sep._Oktober Okt._Novimber Nov._Desimber Des.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'snein si. Si_moandei mo. Mo_tiisdei ti. Ti_woansdei wo. Wo_tongersdei to. To_freed fr. Fr_sneon so. So'.split('_'), i;
+    var expected = 'Snein Si. Si_Moandei Mo. Mo_Tiisdei Ti. Ti_Woansdei Wo. Wo_Tongersdei To. To_Freed Fr. Fr_Sneon So. So'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }
@@ -200,8 +200,8 @@ test('calendar all else', function (assert) {
 });
 
 test('month abbreviation', function (assert) {
-    assert.equal(moment([2012, 5, 23]).format('D-MMM-YYYY'), '23-jun-2012', 'format month abbreviation surrounded by dashes should not include a dot');
-    assert.equal(moment([2012, 5, 23]).format('D MMM YYYY'), '23 jun. 2012', 'format month abbreviation not surrounded by dashes should include a dot');
+    assert.equal(moment([2012, 5, 23]).format('D-MMM-YYYY'), '23-Jun-2012', 'format month abbreviation surrounded by dashes should not include a dot');
+    assert.equal(moment([2012, 5, 23]).format('D MMM YYYY'), '23 Jun. 2012', 'format month abbreviation not surrounded by dashes should include a dot');
 });
 
 test('weeks year starting sunday', function (assert) {

--- a/src/test/locale/ro.js
+++ b/src/test/locale/ro.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('ro');
 
 test('parse', function (assert) {
-    var tests = 'ianuarie ian._februarie febr._martie mart._aprilie apr._mai mai_iunie iun._iulie iul._august aug._septembrie sept._octombrie oct._noiembrie nov._decembrie dec.'.split('_'), i;
+    var tests = 'Ianuarie Ian._Februarie Febr._Martie Mart._Aprilie Apr._Mai Mai_Iunie Iun._Iulie Iul._August Aug._Septembrie Sept._Octombrie Oct._Noiembrie Nov._Decembrie Dec.'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -22,12 +22,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss A',  'duminică, februarie 14 2010, 3:25:50 PM'],
+            ['dddd, MMMM Do YYYY, h:mm:ss A',  'Duminică, Februarie 14 2010, 3:25:50 PM'],
             ['ddd, hA',                        'Dum, 3PM'],
-            ['M Mo MM MMMM MMM',               '2 2 02 februarie febr.'],
+            ['M Mo MM MMMM MMM',               '2 2 02 Februarie Febr.'],
             ['YYYY YY',                        '2010 10'],
             ['D Do DD',                        '14 14 14'],
-            ['d do dddd ddd dd',               '0 0 duminică Dum Du'],
+            ['d do dddd ddd dd',               '0 0 Duminică Dum Du'],
             ['DDD DDDo DDDD',                  '45 45 045'],
             ['w wo ww',                        '7 7 07'],
             ['h hh',                           '3 03'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[a] DDDo[a zi a anului]',        'a 45a zi a anului'],
             ['LTS',                            '15:25:50'],
             ['L',                              '14.02.2010'],
-            ['LL',                             '14 februarie 2010'],
-            ['LLL',                            '14 februarie 2010 15:25'],
-            ['LLLL',                           'duminică, 14 februarie 2010 15:25'],
+            ['LL',                             '14 Februarie 2010'],
+            ['LLL',                            '14 Februarie 2010 15:25'],
+            ['LLLL',                           'Duminică, 14 Februarie 2010 15:25'],
             ['l',                              '14.2.2010'],
-            ['ll',                             '14 febr. 2010'],
-            ['lll',                            '14 febr. 2010 15:25'],
-            ['llll',                           'Dum, 14 febr. 2010 15:25']
+            ['ll',                             '14 Febr. 2010'],
+            ['lll',                            '14 Febr. 2010 15:25'],
+            ['llll',                           'Dum, 14 Febr. 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,14 +91,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'ianuarie ian._februarie febr._martie mart._aprilie apr._mai mai_iunie iun._iulie iul._august aug._septembrie sept._octombrie oct._noiembrie nov._decembrie dec.'.split('_'), i;
+    var expected = 'Ianuarie Ian._Februarie Febr._Martie Mart._Aprilie Apr._Mai Mai_Iunie Iun._Iulie Iul._August Aug._Septembrie Sept._Octombrie Oct._Noiembrie Nov._Decembrie Dec.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'duminică Dum Du_luni Lun Lu_marți Mar Ma_miercuri Mie Mi_joi Joi Jo_vineri Vin Vi_sâmbătă Sâm Sâ'.split('_'), i;
+    var expected = 'Duminică Dum Du_Luni Lun Lu_Marți Mar Ma_Miercuri Mie Mi_Joi Joi Jo_Vineri Vin Vi_Sâmbătă Sâm Sâ'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }


### PR DESCRIPTION
In english and some other languages, the first of the characters is in uppercase. So why is different in this languages?

I already implemented this change in other languages: [Standart nomenclature (pt, pt-br, es)](https://github.com/moment/moment/pull/2328)