### PR TITLE
verified 'require' is a function (on templates)

### DIFF
--- a/templates/locale-header.js
+++ b/templates/locale-header.js
@@ -1,5 +1,6 @@
 (function (global, factory) {
-   typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../moment')) :
+   typeof exports === 'object' && typeof module !== 'undefined' 
+       && typeof require === 'function' ? factory(require('../moment')) :
    typeof define === 'function' && define.amd ? define(['moment'], factory) :
    factory(global.moment)
 }(this, function (moment) { 'use strict';

--- a/templates/test-header.js
+++ b/templates/test-header.js
@@ -1,5 +1,6 @@
 (function (global, factory) {
-   typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../../moment')) :
+   typeof exports === 'object' && typeof module !== 'undefined' 
+       && typeof require === 'function' ? factory(require('../../moment')) :
    typeof define === 'function' && define.amd ? define(['../../moment'], factory) :
    factory(global.moment)
 }(this, function (moment) { 'use strict';


### PR DESCRIPTION
Added a check to verify 'require' is a function, before assuming it exists. In some cases 'exports' and 'module' are defined even when the system is not using require. (such as when using the lumbarjs module management).