### PR TITLE
Fix russian locale for calendar next week

### DIFF
--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -74,8 +74,27 @@ export default moment.defineLocale('ru', {
         sameDay: '[Сегодня в] LT',
         nextDay: '[Завтра в] LT',
         lastDay: '[Вчера в] LT',
-        nextWeek: function () {
-            return this.day() === 2 ? '[Во] dddd [в] LT' : '[В] dddd [в] LT';
+        nextWeek: function (now) {
+            if (now.week() !== this.week()) {
+                switch (this.day()) {
+                case 0:
+                    return '[В следующее] dddd [в] LT';
+                case 1:
+                case 2:
+                case 4:
+                    return '[В следующий] dddd [в] LT';
+                case 3:
+                case 5:
+                case 6:
+                    return '[В следующую] dddd [в] LT';
+                }
+            } else {
+                if (this.day() === 2) {
+                    return '[Во] dddd [в] LT';
+                } else {
+                    return '[В] dddd [в] LT';
+                }
+            }
         },
         lastWeek: function (now) {
             if (now.week() !== this.week()) {

--- a/src/test/locale/ru.js
+++ b/src/test/locale/ru.js
@@ -226,18 +226,50 @@ test('calendar day', function (assert) {
 });
 
 test('calendar next week', function (assert) {
-    var i, m;
-    function makeFormat(d) {
-        return d.day() === 2 ? '[Во] dddd [в] LT' : '[В] dddd [в] LT';
+    var i, m, now;
+
+    function makeFormatNext(d) {
+        switch (d.day()) {
+        case 0:
+            return '[В следующее] dddd [в] LT';
+        case 1:
+        case 2:
+        case 4:
+            return '[В следующий] dddd [в] LT';
+        case 3:
+        case 5:
+        case 6:
+            return '[В следующую] dddd [в] LT';
+        }
     }
 
+    function makeFormatThis(d) {
+        if (d.day() === 2) {
+            return '[Во] dddd [в] LT';
+        }
+        else {
+            return '[В] dddd [в] LT';
+        }
+    }
+
+    now = moment().startOf('week');
     for (i = 2; i < 7; i++) {
-        m = moment().add({d: i});
-        assert.equal(m.calendar(),       m.format(makeFormat(m)),  'Today + ' + i + ' days current time');
+        m = moment(now).add({d: i});
+        assert.equal(m.calendar(now),       m.format(makeFormatThis(m)),  'Today + ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),       m.format(makeFormat(m)),  'Today + ' + i + ' days beginning of day');
+        assert.equal(m.calendar(now),       m.format(makeFormatThis(m)),  'Today + ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),       m.format(makeFormat(m)),  'Today + ' + i + ' days end of day');
+        assert.equal(m.calendar(now),       m.format(makeFormatThis(m)),  'Today + ' + i + ' days end of day');
+    }
+
+    now = moment().endOf('week');
+    for (i = 2; i < 7; i++) {
+        m = moment(now).add({d: i});
+        assert.equal(m.calendar(now),       m.format(makeFormatNext(m)),  'Today + ' + i + ' days current time');
+        m.hours(0).minutes(0).seconds(0).milliseconds(0);
+        assert.equal(m.calendar(now),       m.format(makeFormatNext(m)),  'Today + ' + i + ' days beginning of day');
+        m.hours(23).minutes(59).seconds(59).milliseconds(999);
+        assert.equal(m.calendar(now),       m.format(makeFormatNext(m)),  'Today + ' + i + ' days end of day');
     }
 });
 
@@ -260,15 +292,10 @@ test('calendar last week', function (assert) {
     }
 
     function makeFormatThis(d) {
-        switch (d.day()) {
-        case 2:
+        if (d.day() === 2) {
             return '[Во] dddd [в] LT';
-        case 0:
-        case 1:
-        case 3:
-        case 4:
-        case 5:
-        case 6:
+        }
+        else {
             return '[В] dddd [в] LT';
         }
     }


### PR DESCRIPTION
Reproduce issue:
1. Open http://momentjs.com/
2. Set `Russian` locale.
3. Execute in console (wrong)
```js
moment().subtract(3, 'days').calendar() == moment().add(4, 'days').calendar()
```