### PR TITLE
New isFunction util

### DIFF
--- a/src/lib/locale/calendar.js
+++ b/src/lib/locale/calendar.js
@@ -7,7 +7,9 @@ export var defaultCalendar = {
     sameElse : 'L'
 };
 
+import isFunction from '../utils/is-function';
+
 export function calendar (key, mom, now) {
     var output = this._calendar[key];
-    return typeof output === 'function' ? output.call(mom, now) : output;
+    return isFunction(output) ? output.call(mom, now) : output;
 }

--- a/src/lib/locale/relative.js
+++ b/src/lib/locale/relative.js
@@ -14,14 +14,16 @@ export var defaultRelativeTime = {
     yy : '%d years'
 };
 
+import isFunction from '../utils/is-function';
+
 export function relativeTime (number, withoutSuffix, string, isFuture) {
     var output = this._relativeTime[string];
-    return (typeof output === 'function') ?
+    return (isFunction(output)) ?
         output(number, withoutSuffix, string, isFuture) :
         output.replace(/%d/i, number);
 }
 
 export function pastFuture (diff, output) {
     var format = this._relativeTime[diff > 0 ? 'future' : 'past'];
-    return typeof format === 'function' ? format(output) : format.replace(/%s/i, output);
+    return isFunction(format) ? format(output) : format.replace(/%s/i, output);
 }

--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -1,8 +1,10 @@
+import isFunction from '../utils/is-function';
+
 export function set (config) {
     var prop, i;
     for (i in config) {
         prop = config[i];
-        if (typeof prop === 'function') {
+        if (isFunction(prop)) {
             this[i] = prop;
         } else {
             this['_' + i] = prop;

--- a/src/lib/moment/format.js
+++ b/src/lib/moment/format.js
@@ -1,5 +1,6 @@
 import { formatMoment } from '../format/format';
 import { hooks } from '../utils/hooks';
+import isFunction from '../utils/is-function';
 
 hooks.defaultFormat = 'YYYY-MM-DDTHH:mm:ssZ';
 
@@ -10,7 +11,7 @@ export function toString () {
 export function toISOString () {
     var m = this.clone().utc();
     if (0 < m.year() && m.year() <= 9999) {
-        if ('function' === typeof Date.prototype.toISOString) {
+        if (isFunction(Date.prototype.toISOString)) {
             // native implementation is ~50x faster, use it when we can
             return this.toDate().toISOString();
         } else {

--- a/src/lib/moment/get-set.js
+++ b/src/lib/moment/get-set.js
@@ -1,5 +1,6 @@
 import { normalizeUnits } from '../units/aliases';
 import { hooks } from '../utils/hooks';
+import isFunction from '../utils/is-function';
 
 export function makeGetSet (unit, keepTime) {
     return function (value) {
@@ -31,7 +32,7 @@ export function getSet (units, value) {
         }
     } else {
         units = normalizeUnits(units);
-        if (typeof this[units] === 'function') {
+        if (isFunction(this[units])) {
             return this[units](value);
         }
     }

--- a/src/lib/parse/regex.js
+++ b/src/lib/parse/regex.js
@@ -19,15 +19,9 @@ export var matchTimestamp = /[+-]?\d+(\.\d{1,3})?/; // 123456789 123456789.123
 export var matchWord = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
 
 import hasOwnProp from '../utils/has-own-prop';
+import isFunction from '../utils/is-function';
 
 var regexes = {};
-
-function isFunction (sth) {
-    // https://github.com/moment/moment/issues/2325
-    return typeof sth === 'function' &&
-        Object.prototype.toString.call(sth) === '[object Function]';
-}
-
 
 export function addRegexToken (token, regex, strictRegex) {
     regexes[token] = isFunction(regex) ? regex : function (isStrict) {

--- a/src/lib/utils/is-function.js
+++ b/src/lib/utils/is-function.js
@@ -1,0 +1,3 @@
+export default function isFunction(input) {
+    return input instanceof Function || Object.prototype.toString.call(input) === '[object Function]';
+}

--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -3,6 +3,7 @@
 //! author : Aggelos Karalias : https://github.com/mehiel
 
 import moment from '../moment';
+import isFunction from '../lib/utils/is-function';
 
 export default moment.defineLocale('el', {
     monthsNominativeEl : 'Ιανουάριος_Φεβρουάριος_Μάρτιος_Απρίλιος_Μάιος_Ιούνιος_Ιούλιος_Αύγουστος_Σεπτέμβριος_Οκτώβριος_Νοέμβριος_Δεκέμβριος'.split('_'),
@@ -55,7 +56,7 @@ export default moment.defineLocale('el', {
     calendar : function (key, mom) {
         var output = this._calendarEl[key],
             hours = mom && mom.hours();
-        if (typeof output === 'function') {
+        if (isFunction(output)) {
             output = output.apply(mom);
         }
         return output.replace('{}', (hours % 12 === 1 ? 'στη' : 'στις'));


### PR DESCRIPTION
`isFunction` was introduced in #2325 but only for one case: `addRegexToken`.

There are also other cases where legacy `Android` versions mistake `RegExps` for `functions`, so we should not rely on `typeof x === 'function'` but rather always check using `isFunction`.