### PR TITLE
Add swahili (sw) locale

### DIFF
--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -1,0 +1,49 @@
+//! moment.js locale configuration
+//! locale : swahili (sw)
+//! author : Fahad Kassim : https://github.com/fadsel
+
+import moment from '../moment';
+
+export default moment.defineLocale('sw', {
+    months : 'Januari_Februari_Machi_Aprili_Mei_Juni_Julai_Agosti_Septemba_Oktoba_Novemba_Desemba'.split('_'),
+    monthsShort : 'Jan_Feb_Mac_Apr_Mei_Jun_Jul_Ago_Sep_Okt_Nov_Des'.split('_'),
+    weekdays : 'Jumapili_Jumatatu_Jumanne_Jumatano_Alhamisi_Ijumaa_Jumamosi'.split('_'),
+    weekdaysShort : 'Jpl_Jtat_Jnne_Jtan_Alh_Ijm_Jmos'.split('_'),
+    weekdaysMin : 'J2_J3_J4_J5_Al_Ij_J1'.split('_'),
+    longDateFormat : {
+        LT : 'HH:mm',
+        LTS : 'HH:mm:ss',
+        L : 'DD.MM.YYYY',
+        LL : 'D MMMM YYYY',
+        LLL : 'D MMMM YYYY HH:mm',
+        LLLL : 'dddd, D MMMM YYYY HH:mm'
+    },
+    calendar : {
+        sameDay : '[leo saa] LT',
+        nextDay : '[kesho saa] LT',
+        nextWeek : '[wiki ijayo] dddd [saat] LT',
+        lastDay : '[jana] LT',
+        lastWeek : '[wiki iliyopita] dddd [saat] LT',
+        sameElse : 'L'
+    },
+    relativeTime : {
+        future : '%s baadaye',
+        past : 'tokea %s',
+        s : 'hivi punde',
+        m : 'dakika moja',
+        mm : 'dakika %d',
+        h : 'saa limoja',
+        hh : 'masaa %d',
+        d : 'siku moja',
+        dd : 'masiku %d',
+        M : 'mwezi mmoja',
+        MM : 'miezi %d',
+        y : 'mwaka mmoja',
+        yy : 'miaka %d'
+    },
+    week : {
+        dow : 1, // Monday is the first day of the week.
+        doy : 7  // The week that contains Jan 1st is the first week of the year.
+    }
+});
+

--- a/src/test/locale/sw.js
+++ b/src/test/locale/sw.js
@@ -1,0 +1,305 @@
+import {localeModule, test} from '../qunit';
+import moment from '../../moment';
+localeModule('sw');
+
+test('parse', function (assert) {
+    var tests = 'Januari Jan_Februari Feb_Machi Mac_Aprili Apr_Mei Mei_Juni Jun_Julai Jul_Agosti Ago_Septemba Sep_Oktoba Okt_Novemba Nov_Desemba Des'.split('_'), i;
+    function equalTest(input, mmm, i) {
+        assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
+    }
+    for (i = 0; i < 12; i++) {
+        tests[i] = tests[i].split(' ');
+        equalTest(tests[i][0], 'MMM', i);
+        equalTest(tests[i][1], 'MMM', i);
+        equalTest(tests[i][0], 'MMMM', i);
+        equalTest(tests[i][1], 'MMMM', i);
+        equalTest(tests[i][0].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i][1].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i][0].toLocaleUpperCase(), 'MMMM', i);
+        equalTest(tests[i][1].toLocaleUpperCase(), 'MMMM', i);
+    }
+});
+
+test('format', function (assert) {
+    var a = [
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Jumapili, Februari 14 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Jpl, 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2 02 Februari Feb'],
+            ['YYYY YY',                            '2010 10'],
+            ['D Do DD',                            '14 14 14'],
+            ['d do dddd ddd dd',                   '0 0 Jumapili Jpl J2'],
+            ['DDD DDDo DDDD',                      '45 45 045'],
+            ['w wo ww',                            '7 7 07'],
+            ['h hh',                               '3 03'],
+            ['H HH',                               '15 15'],
+            ['m mm',                               '25 25'],
+            ['s ss',                               '50 50'],
+            ['a A',                                'pm PM'],
+            ['[siku] DDDo [ya mwaka]',             'siku 45 ya mwaka'],
+            ['LTS',                                '15:25:50'],
+            ['L',                                  '14.02.2010'],
+            ['LL',                                 '14 Februari 2010'],
+            ['LLL',                                '14 Februari 2010 15:25'],
+            ['LLLL',                               'Jumapili, 14 Februari 2010 15:25'],
+            ['l',                                  '14.2.2010'],
+            ['ll',                                 '14 Feb 2010'],
+            ['lll',                                '14 Feb 2010 15:25'],
+            ['llll',                               'Jpl, 14 Feb 2010 15:25']
+        ],
+        b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
+        i;
+    for (i = 0; i < a.length; i++) {
+        assert.equal(b.format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
+    }
+});
+
+test('format ordinal', function (assert) {
+    assert.equal(moment([2011, 0, 1]).format('DDDo'), '1', '1');
+    assert.equal(moment([2011, 0, 2]).format('DDDo'), '2', '2');
+    assert.equal(moment([2011, 0, 3]).format('DDDo'), '3', '3');
+    assert.equal(moment([2011, 0, 4]).format('DDDo'), '4', '4');
+    assert.equal(moment([2011, 0, 5]).format('DDDo'), '5', '5');
+    assert.equal(moment([2011, 0, 6]).format('DDDo'), '6', '6');
+    assert.equal(moment([2011, 0, 7]).format('DDDo'), '7', '7');
+    assert.equal(moment([2011, 0, 8]).format('DDDo'), '8', '8');
+    assert.equal(moment([2011, 0, 9]).format('DDDo'), '9', '9');
+    assert.equal(moment([2011, 0, 10]).format('DDDo'), '10', '10');
+
+    assert.equal(moment([2011, 0, 11]).format('DDDo'), '11', '11');
+    assert.equal(moment([2011, 0, 12]).format('DDDo'), '12', '12');
+    assert.equal(moment([2011, 0, 13]).format('DDDo'), '13', '13');
+    assert.equal(moment([2011, 0, 14]).format('DDDo'), '14', '14');
+    assert.equal(moment([2011, 0, 15]).format('DDDo'), '15', '15');
+    assert.equal(moment([2011, 0, 16]).format('DDDo'), '16', '16');
+    assert.equal(moment([2011, 0, 17]).format('DDDo'), '17', '17');
+    assert.equal(moment([2011, 0, 18]).format('DDDo'), '18', '18');
+    assert.equal(moment([2011, 0, 19]).format('DDDo'), '19', '19');
+    assert.equal(moment([2011, 0, 20]).format('DDDo'), '20', '20');
+
+    assert.equal(moment([2011, 0, 21]).format('DDDo'), '21', '21');
+    assert.equal(moment([2011, 0, 22]).format('DDDo'), '22', '22');
+    assert.equal(moment([2011, 0, 23]).format('DDDo'), '23', '23');
+    assert.equal(moment([2011, 0, 24]).format('DDDo'), '24', '24');
+    assert.equal(moment([2011, 0, 25]).format('DDDo'), '25', '25');
+    assert.equal(moment([2011, 0, 26]).format('DDDo'), '26', '26');
+    assert.equal(moment([2011, 0, 27]).format('DDDo'), '27', '27');
+    assert.equal(moment([2011, 0, 28]).format('DDDo'), '28', '28');
+    assert.equal(moment([2011, 0, 29]).format('DDDo'), '29', '29');
+    assert.equal(moment([2011, 0, 30]).format('DDDo'), '30', '30');
+
+    assert.equal(moment([2011, 0, 31]).format('DDDo'), '31', '31');
+});
+
+test('format month', function (assert) {
+    var expected = 'Januari Jan_Februari Feb_Machi Mac_Aprili Apr_Mei Mei_Juni Jun_Julai Jul_Agosti Ago_Septemba Sep_Oktoba Okt_Novemba Nov_Desemba Des'.split('_'), i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
+    }
+});
+
+test('format week', function (assert) {
+    var expected = 'Jumapili Jpl J2_Jumatatu Jtat J3_Jumanne Jnne J4_Jumatano Jtan J5_Alhamisi Alh Al_Ijumaa Ijm Ij_Jumamosi Jmos J1'.split('_'), i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
+    }
+});
+
+test('from', function (assert) {
+    var start = moment([2007, 1, 28]);
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true),  'hivi punde',   '44 seconds = a few seconds');
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  'dakika moja',  '45 seconds = a minute');
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  'dakika moja',  '89 seconds = a minute');
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 90}), true),  'dakika 2',     '90 seconds = 2 minutes');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 44}), true),  'dakika 44',    '44 minutes = 44 minutes');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 45}), true),  'saa limoja',   '45 minutes = an hour');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 89}), true),  'saa limoja',   '89 minutes = an hour');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 90}), true),  'masaa 2',      '90 minutes = 2 hours');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 5}), true),   'masaa 5',      '5 hours = 5 hours');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 21}), true),  'masaa 21',     '21 hours = 21 hours');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 22}), true),  'siku moja',    '22 hours = a day');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 35}), true),  'siku moja',    '35 hours = a day');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 36}), true),  'masiku 2',     '36 hours = 2 days');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 1}), true),   'siku moja',    '1 day = a day');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 5}), true),   'masiku 5',     '5 days = 5 days');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 25}), true),  'masiku 25',    '25 days = 25 days');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 26}), true),  'mwezi mmoja',  '26 days = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 30}), true),  'mwezi mmoja',  '30 days = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 43}), true),  'mwezi mmoja',  '43 days = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 46}), true),  'miezi 2',      '46 days = 2 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 74}), true),  'miezi 2',      '75 days = 2 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 76}), true),  'miezi 3',      '76 days = 3 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({M: 1}), true),   'mwezi mmoja',  '1 month = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({M: 5}), true),   'miezi 5',      '5 months = 5 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 345}), true), 'mwaka mmoja',  '345 days = a year');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 548}), true), 'miaka 2',      '548 days = 2 years');
+    assert.equal(start.from(moment([2007, 1, 28]).add({y: 1}), true),   'mwaka mmoja',  '1 year = a year');
+    assert.equal(start.from(moment([2007, 1, 28]).add({y: 5}), true),   'miaka 5',      '5 years = 5 years');
+});
+
+test('suffix', function (assert) {
+    assert.equal(moment(30000).from(0), 'hivi punde baadaye',  'prefix');
+    assert.equal(moment(0).from(30000), 'tokea hivi punde', 'suffix');
+});
+
+test('now from now', function (assert) {
+    assert.equal(moment().fromNow(), 'tokea hivi punde',  'now from now should display as in the past');
+});
+
+test('fromNow', function (assert) {
+    assert.equal(moment().add({s: 30}).fromNow(), 'hivi punde baadaye', 'in a few seconds');
+    assert.equal(moment().add({d: 5}).fromNow(), 'masiku 5 baadaye', 'in 5 days');
+});
+
+test('calendar day', function (assert) {
+    var a = moment().hours(2).minutes(0).seconds(0);
+    assert.equal(moment(a).calendar(),                   'leo saa 02:00',      'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(),      'leo saa 02:25',      'Now plus 25 min');
+    assert.equal(moment(a).add({h: 1}).calendar(),       'leo saa 03:00',      'Now plus 1 hour');
+    assert.equal(moment(a).add({d: 1}).calendar(),       'kesho saa 02:00',    'tomorrow at the same time');
+    assert.equal(moment(a).subtract({h: 1}).calendar(),  'leo saa 01:00',      'Now minus 1 hour');
+    assert.equal(moment(a).subtract({d: 1}).calendar(),  'jana 02:00',         'yesterday at the same time');
+});
+
+test('calendar next week', function (assert) {
+    var i, m;
+    for (i = 2; i < 7; i++) {
+        m = moment().add({d: i});
+        assert.equal(m.calendar(),       m.format('[wiki ijayo] dddd [saat] LT'),  'Today + ' + i + ' days current time');
+        m.hours(0).minutes(0).seconds(0).milliseconds(0);
+        assert.equal(m.calendar(),       m.format('[wiki ijayo] dddd [saat] LT'),  'Today + ' + i + ' days beginning of day');
+        m.hours(23).minutes(59).seconds(59).milliseconds(999);
+        assert.equal(m.calendar(),       m.format('[wiki ijayo] dddd [saat] LT'),  'Today + ' + i + ' days end of day');
+    }
+});
+
+test('calendar last week', function (assert) {
+    var i, m;
+
+    for (i = 2; i < 7; i++) {
+        m = moment().subtract({d: i});
+        assert.equal(m.calendar(),       m.format('[wiki iliyopita] dddd [saat] LT'),  'Today - ' + i + ' days current time');
+        m.hours(0).minutes(0).seconds(0).milliseconds(0);
+        assert.equal(m.calendar(),       m.format('[wiki iliyopita] dddd [saat] LT'),  'Today - ' + i + ' days beginning of day');
+        m.hours(23).minutes(59).seconds(59).milliseconds(999);
+        assert.equal(m.calendar(),       m.format('[wiki iliyopita] dddd [saat] LT'),  'Today - ' + i + ' days end of day');
+    }
+});
+
+test('calendar all else', function (assert) {
+    var weeksAgo = moment().subtract({w: 1}),
+        weeksFromNow = moment().add({w: 1});
+
+    assert.equal(weeksAgo.calendar(),       weeksAgo.format('L'),      '1 week ago');
+    assert.equal(weeksFromNow.calendar(),   weeksFromNow.format('L'),  'in 1 week');
+
+    weeksAgo = moment().subtract({w: 2});
+    weeksFromNow = moment().add({w: 2});
+
+    assert.equal(weeksAgo.calendar(),       weeksAgo.format('L'),  '2 weeks ago');
+    assert.equal(weeksFromNow.calendar(),   weeksFromNow.format('L'),  'in 2 weeks');
+});
+
+test('weeks year starting sunday', function (assert) {
+    assert.equal(moment([2011, 11, 26]).week(), 1, 'Dec 26 2011 should be week 1');
+    assert.equal(moment([2012,  0,  1]).week(), 1, 'Jan  1 2012 should be week 1');
+    assert.equal(moment([2012,  0,  2]).week(), 2, 'Jan  2 2012 should be week 2');
+    assert.equal(moment([2012,  0,  8]).week(), 2, 'Jan  8 2012 should be week 2');
+    assert.equal(moment([2012,  0,  9]).week(), 3, 'Jan  9 2012 should be week 3');
+});
+
+test('weeks year starting monday', function (assert) {
+    assert.equal(moment([2007, 0, 1]).week(),  1, 'Jan  1 2007 should be week 1');
+    assert.equal(moment([2007, 0, 7]).week(),  1, 'Jan  7 2007 should be week 1');
+    assert.equal(moment([2007, 0, 8]).week(),  2, 'Jan  8 2007 should be week 2');
+    assert.equal(moment([2007, 0, 14]).week(), 2, 'Jan 14 2007 should be week 2');
+    assert.equal(moment([2007, 0, 15]).week(), 3, 'Jan 15 2007 should be week 3');
+});
+
+test('weeks year starting tuesday', function (assert) {
+    assert.equal(moment([2007, 11, 31]).week(), 1, 'Dec 31 2007 should be week 1');
+    assert.equal(moment([2008,  0,  1]).week(), 1, 'Jan  1 2008 should be week 1');
+    assert.equal(moment([2008,  0,  6]).week(), 1, 'Jan  6 2008 should be week 1');
+    assert.equal(moment([2008,  0,  7]).week(), 2, 'Jan  7 2008 should be week 2');
+    assert.equal(moment([2008,  0, 13]).week(), 2, 'Jan 13 2008 should be week 2');
+    assert.equal(moment([2008,  0, 14]).week(), 3, 'Jan 14 2008 should be week 3');
+});
+
+test('weeks year starting wednesday', function (assert) {
+    assert.equal(moment([2002, 11, 30]).week(), 1, 'Dec 30 2002 should be week 1');
+    assert.equal(moment([2003,  0,  1]).week(), 1, 'Jan  1 2003 should be week 1');
+    assert.equal(moment([2003,  0,  5]).week(), 1, 'Jan  5 2003 should be week 1');
+    assert.equal(moment([2003,  0,  6]).week(), 2, 'Jan  6 2003 should be week 2');
+    assert.equal(moment([2003,  0, 12]).week(), 2, 'Jan 12 2003 should be week 2');
+    assert.equal(moment([2003,  0, 13]).week(), 3, 'Jan 13 2003 should be week 3');
+});
+
+test('weeks year starting thursday', function (assert) {
+    assert.equal(moment([2008, 11, 29]).week(), 1, 'Dec 29 2008 should be week 1');
+    assert.equal(moment([2009,  0,  1]).week(), 1, 'Jan  1 2009 should be week 1');
+    assert.equal(moment([2009,  0,  4]).week(), 1, 'Jan  4 2009 should be week 1');
+    assert.equal(moment([2009,  0,  5]).week(), 2, 'Jan  5 2009 should be week 2');
+    assert.equal(moment([2009,  0, 11]).week(), 2, 'Jan 11 2009 should be week 2');
+    assert.equal(moment([2009,  0, 12]).week(), 3, 'Jan 12 2009 should be week 3');
+});
+
+test('weeks year starting friday', function (assert) {
+    assert.equal(moment([2009, 11, 28]).week(), 1, 'Dec 28 2009 should be week 1');
+    assert.equal(moment([2010,  0,  1]).week(), 1, 'Jan  1 2010 should be week 1');
+    assert.equal(moment([2010,  0,  3]).week(), 1, 'Jan  3 2010 should be week 1');
+    assert.equal(moment([2010,  0,  4]).week(), 2, 'Jan  4 2010 should be week 2');
+    assert.equal(moment([2010,  0, 10]).week(), 2, 'Jan 10 2010 should be week 2');
+    assert.equal(moment([2010,  0, 11]).week(), 3, 'Jan 11 2010 should be week 3');
+});
+
+test('weeks year starting saturday', function (assert) {
+    assert.equal(moment([2010, 11, 27]).week(), 1, 'Dec 27 2010 should be week 1');
+    assert.equal(moment([2011,  0,  1]).week(), 1, 'Jan  1 2011 should be week 1');
+    assert.equal(moment([2011,  0,  2]).week(), 1, 'Jan  2 2011 should be week 1');
+    assert.equal(moment([2011,  0,  3]).week(), 2, 'Jan  3 2011 should be week 2');
+    assert.equal(moment([2011,  0,  9]).week(), 2, 'Jan  9 2011 should be week 2');
+    assert.equal(moment([2011,  0, 10]).week(), 3, 'Jan 10 2011 should be week 3');
+});
+
+test('weeks year starting sunday format', function (assert) {
+    assert.equal(moment([2011, 11, 26]).format('w ww wo'), '1 01 1', 'Dec 26 2011 should be week 1');
+    assert.equal(moment([2012,  0,  1]).format('w ww wo'), '1 01 1', 'Jan  1 2012 should be week 1');
+    assert.equal(moment([2012,  0,  2]).format('w ww wo'), '2 02 2', 'Jan  2 2012 should be week 2');
+    assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2', 'Jan  8 2012 should be week 2');
+    assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3', 'Jan  9 2012 should be week 3');
+});
+
+test('lenient ordinal parsing', function (assert) {
+    var i, ordinalStr, testMoment;
+    for (i = 1; i <= 31; ++i) {
+        ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
+        testMoment = moment(ordinalStr, 'YYYY MM Do');
+        assert.equal(testMoment.year(), 2014,
+                'lenient ordinal parsing ' + i + ' year check');
+        assert.equal(testMoment.month(), 0,
+                'lenient ordinal parsing ' + i + ' month check');
+        assert.equal(testMoment.date(), i,
+                'lenient ordinal parsing ' + i + ' date check');
+    }
+});
+
+test('lenient ordinal parsing of number', function (assert) {
+    var i, testMoment;
+    for (i = 1; i <= 31; ++i) {
+        testMoment = moment('2014 01 ' + i, 'YYYY MM Do');
+        assert.equal(testMoment.year(), 2014,
+                'lenient ordinal parsing of number ' + i + ' year check');
+        assert.equal(testMoment.month(), 0,
+                'lenient ordinal parsing of number ' + i + ' month check');
+        assert.equal(testMoment.date(), i,
+                'lenient ordinal parsing of number ' + i + ' date check');
+    }
+});
+
+test('strict ordinal parsing', function (assert) {
+    var i, ordinalStr, testMoment;
+    for (i = 1; i <= 31; ++i) {
+        ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
+        testMoment = moment(ordinalStr, 'YYYY MM Do', true);
+        assert.ok(testMoment.isValid(), 'strict ordinal parsing ' + i);
+    }
+});


### PR DESCRIPTION
This is an update of Pull Request #2228 authored by @fadsel. 
It has been rebased to latest develop; the locale moved to src/local; and tests added.
I don't speak swahili so the language is as per the original Pull Request.

To be confirmed by @fadsel:
- [x] Is using AM and PM for time correct? As this is not defined, AM/PM this will be used by default;
- [x] Is it correct that no ordinals are defined? This will mean that 1st, 2nd, 3rd and 4th are just written as 1, 2, 3 and 4.
- [ ] Does "hivi punde baadaye" make sense for "in a few seconds / in a short while" and does "tokea hivi punde" make sense for "a few seconds ago / a short while ago"? This is how Moment will produce those phrases.
- [ ] The translation of "at" seems inconsistent for today & tomorrow ("saa") vs. next week and last week ("saat") and seems to be missing for yesterday i.e. should "[jana] LT" be "[jana saa] LT"?
- [ ] Next week & last week seem to be the equivalent of "next week Tuesday" and "last week Tuesday". Wouldn't you just say "next Tuesday" and "last Tuesday"?

That's all. Feel free to submit your own Pull Request using this work if it helps.