### PR TITLE
Fixed package.json jspm config

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "ender": "./ender.js",
     "dojoBuild": "package.js",
     "jspm": {
-        "files": [
-            "moment.js",
-            "locale"
-        ],
-        "map": {
-            "moment": "./moment"
+        "directories": {
+            "lib": "src"
         },
+        "main": "moment.js",
+        "ignore": [
+            "./src/test/"
+        ],
         "buildConfig": {
             "uglify": true
         }


### PR DESCRIPTION
We shouldn't point to the bundled file in the jspm config. Because in the top the bundled file is trying to export itself when runs inside jspm bundle is broken in Firefox (https://github.com/moment/moment/issues/2576), I can't replicate this in Chrome but even that we shouldn't do that.

@ryanlanciaux keep in mind this issue for Griddle because is the same problem in this ticket https://github.com/GriddleGriddle/Griddle/issues/201 The main file is very important file for these tools.