### PR TITLE
Ignore src directory in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "Gruntfile.js",
     "Moment.js.nuspec",
     "package.js",
-    "package.json"
+    "package.json",
+    "src"
   ]
 }


### PR DESCRIPTION
I'm not sure why the `src` directory needs to be distributed via bower. The
'main' file is set to `/moment.js`, outside of `src`, and users also have access
to the `min` directory.