### PR TITLE
Add Node.js v0.12 and v4 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
+
 node_js:
   - "0.10"
+  - "0.12"
+  - "4"
+
 sudo: false
 
 env:


### PR DESCRIPTION
Node.js v0.10 is a bit old at this point.