### PR TITLE
Make package compatible with Meteor v1.2

### DIFF
--- a/meteor/package.js
+++ b/meteor/package.js
@@ -13,7 +13,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0', 'METEOR@1.2']);
   api.export('moment');
   api.addFiles([
     'moment.js',


### PR DESCRIPTION
It's currently breaking on apps running Meteor v1.2. Very simple fix. 

Line 6 was breaking for me when developing this locally. I had it set up by symlinking this directory over to my packages/ directory within an app. Had to supply the absolute path to `package.json` to get it to work locally, but I think that's only because of my setup.