### PR TITLE
Attempt to add support for ordinal format for quarters. Fixes issue #2559

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -1,6 +1,6 @@
 import zeroFill from '../utils/zero-fill';
 
-export var formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Q|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
+export var formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo|Q|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
 
 var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
 

--- a/src/lib/units/quarter.js
+++ b/src/lib/units/quarter.js
@@ -7,7 +7,7 @@ import toInt from '../utils/to-int';
 
 // FORMATTING
 
-addFormatToken('Q', 0, 0, 'quarter');
+addFormatToken('Q', 0, 'Qo', 'quarter');
 
 // ALIASES
 

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -331,6 +331,16 @@ test('quarter formats', function (assert) {
     assert.equal(moment([2000, 0,  2]).format('[Q]Q-YYYY'), 'Q1-2000', 'Jan  2 2000 is Q1');
 });
 
+test('quarter ordinal formats', function (assert) {
+    assert.equal(moment([1985, 1,  4]).format('Qo'), '1st', 'Feb  4 1985 is 1st quarter');
+    assert.equal(moment([2029, 8, 18]).format('Qo'), '3rd', 'Sep 18 2029 is 3rd quarter');
+    assert.equal(moment([2013, 3, 24]).format('Qo'), '2nd', 'Apr 24 2013 is 2nd quarter');
+    assert.equal(moment([2015, 2,  5]).format('Qo'), '1st', 'Mar  5 2015 is 1st quarter');
+    assert.equal(moment([1970, 0,  2]).format('Qo'), '1st', 'Jan  2 1970 is 1st quarter');
+    assert.equal(moment([2001, 11, 12]).format('Qo'), '4th', 'Dec 12 2001 is 4th quarter');
+    assert.equal(moment([2000, 0,  2]).format('Qo [quarter] YYYY'), '1st quarter 2000', 'Jan  2 2000 is 1st quarter');
+});
+
 test('full expanded format is returned from abbreviated formats', function (assert) {
     var locales = '';
 

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -332,7 +332,7 @@ test('quarter formats', function (assert) {
 });
 
 test('quarter ordinal formats', function (assert) {
-    assert.equal(moment([1985, 1,  4]).format('Qo'), '1st', 'Feb  4 1985 is 1st quarter');
+    assert.equal(moment([1985, 1, 4]).format('Qo'), '1st', 'Feb 4 1985 is 1st quarter');
     assert.equal(moment([2029, 8, 18]).format('Qo'), '3rd', 'Sep 18 2029 is 3rd quarter');
     assert.equal(moment([2013, 3, 24]).format('Qo'), '2nd', 'Apr 24 2013 is 2nd quarter');
     assert.equal(moment([2015, 2,  5]).format('Qo'), '1st', 'Mar  5 2015 is 1st quarter');


### PR DESCRIPTION
Have some problems removing historical commits from the PR. Please ignore the two initial commits listed. No source code is included with them.

I have added ordinal support for quarters and tests for that according to my understanding of issue #2559. If you also want me to add parsing support, please let me know. Of course also open to any comments you may have to my code.