### PR TITLE
Allow calendar to use functions

### DIFF
--- a/src/lib/moment/calendar.js
+++ b/src/lib/moment/calendar.js
@@ -13,5 +13,8 @@ export function calendar (time, formats) {
             diff < 1 ? 'sameDay' :
             diff < 2 ? 'nextDay' :
             diff < 7 ? 'nextWeek' : 'sameElse';
-    return this.format(formats && formats[format] || this.localeData().calendar(format, this, createLocal(now)));
+
+    var output = formats && (typeof formats[format] === 'function' ? formats[format]() : formats[format]);
+
+    return this.format(output || this.localeData().calendar(format, this, createLocal(now)));
 }

--- a/src/test/moment/calendar.js
+++ b/src/test/moment/calendar.js
@@ -1,0 +1,17 @@
+// These tests are for locale independent features
+// locale dependent tests would be in locale test folder
+import { module, test } from '../qunit';
+import moment from '../../moment';
+
+module('calendar');
+
+test('passing a function', function (assert) {
+    var a  = moment().hours(2).minutes(0).seconds(0);
+    assert.equal(moment(a).calendar(null, {
+        'sameDay': function () {
+            return 'h:mmA';
+        }
+    }), '2:00AM', 'should equate');
+});
+
+


### PR DESCRIPTION
This is in response to the issue #2678 
I have tried to fix the bug by checking if it is a function or not, similar to what is done in this file
```Javascript
// src/lib/locale/calendar.js
export function calendar (key, mom, now) {
    var output = this._calendar[key];
    return typeof output === 'function' ? output.call(mom, now) : output;
}
```
Also a test file was created, as suggested by @mj1856 .
I was wondering if there are any arguments to be passed in the function via call method.
Any suggestions/reviews?