### PR TITLE
RequireJS fix?

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -6,7 +6,7 @@
 
 (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-    typeof define === 'function' && define.amd ? define(factory) :
+    typeof define === 'function' && define.amd ? define("moment", factory) :
     global.moment = factory()
 }(this, function () { 'use strict';
 


### PR DESCRIPTION
Old version that I use (2.6.0) in production has define like so:
define("moment", function (require, exports, module) {
That works.
The new version 2.10.6 (change in maybe one in the middle) does not.
Please review my fix, thank you.