### PR TITLE
Replace esperanto with Babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "es6-promise": "latest",
         "grunt": "latest",
         "benchmark": "latest",
-        "esperanto": "latest",
+        "Babel": "latest",
         "grunt-contrib-clean": "latest",
         "grunt-contrib-concat": "latest",
         "grunt-contrib-copy": "latest",


### PR DESCRIPTION
Warnings are showing in travis ci that esperanto and isn't being developed anymore and is deprecated and that to replace it with Babel instead.