### PR TITLE
Fix moment creation with object of strings

### DIFF
--- a/src/lib/create/from-object.js
+++ b/src/lib/create/from-object.js
@@ -1,5 +1,6 @@
 import { normalizeObjectUnits } from '../units/aliases';
 import { configFromArray } from './from-array';
+import map from '../utils/map';
 
 export function configFromObject(config) {
     if (config._d) {
@@ -7,7 +8,9 @@ export function configFromObject(config) {
     }
 
     var i = normalizeObjectUnits(config._i);
-    config._a = [i.year, i.month, i.day || i.date, i.hour, i.minute, i.second, i.millisecond];
+    config._a = map([i.year, i.month, i.day || i.date, i.hour, i.minute, i.second, i.millisecond], function (obj) {
+        return obj && parseInt(obj, 10);
+    });
 
     configFromArray(config);
 }

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -880,6 +880,10 @@ test('array with strings', function (assert) {
     assert.equal(moment(['2014', '7', '31']).isValid(), true, 'string array + isValid');
 });
 
+test('object with strings', function (assert) {
+    assert.equal(moment({year: '2014', month: '7', day: '31'}).isValid(), true, 'string object + isValid');
+});
+
 test('utc with array of formats', function (assert) {
     assert.equal(moment.utc('2014-01-01', ['YYYY-MM-DD', 'YYYY-MM']).format(), '2014-01-01T00:00:00+00:00', 'moment.utc works with array of formats');
 });


### PR DESCRIPTION
Fixes problem with parsing Aug 31st for objects with string values (see test for an example of the problem). Analogous behavior to problem in #1870 with arrays


