### PR TITLE
Show arguments in deprecation warnings.

### DIFF
--- a/src/lib/utils/deprecate.js
+++ b/src/lib/utils/deprecate.js
@@ -12,7 +12,7 @@ export function deprecate(msg, fn) {
 
     return extend(function () {
         if (firstTime) {
-            warn(msg + '\n' + (new Error()).stack);
+            warn(msg + '\nArguments: ' + Array.prototype.slice.call(arguments).join(', ') + '\n' + (new Error()).stack);
             firstTime = false;
         }
         return fn.apply(this, arguments);

--- a/src/test/moment/add_subtract.js
+++ b/src/test/moment/add_subtract.js
@@ -1,4 +1,4 @@
-import { module, test } from '../qunit';
+import { module, test, expect } from '../qunit';
 import moment from '../../moment';
 
 module('add and subtract');
@@ -298,7 +298,7 @@ test('add across DST', function (assert) {
     // Detect Safari bug and bail. Hours on 13th March 2011 are shifted
     // with 1 ahead.
     if (new Date(2011, 2, 13, 5, 0, 0).getHours() !== 5) {
-        assert.expect(0);
+        expect(0);
         return;
     }
 

--- a/src/test/moment/deprecate.js
+++ b/src/test/moment/deprecate.js
@@ -1,0 +1,13 @@
+import { module, test, expect } from '../qunit';
+import { deprecate } from '../../lib/utils/deprecate';
+import moment from '../../moment';
+
+module('deprecate');
+
+test('deprecate', function (assert) {
+    var fn = function () {};
+    var deprecatedFn = deprecate('testing deprecation', fn);
+    deprecatedFn();
+
+    expect(0);
+});

--- a/src/test/qunit.js
+++ b/src/test/qunit.js
@@ -4,6 +4,8 @@ import moment from '../moment';
 
 export var test = QUnit.test;
 
+export var expect = QUnit.expect;
+
 export function module (name, lifecycle) {
     QUnit.module(name, {
         setup : function () {


### PR DESCRIPTION
Add an 'arguments' line to show more information about where the deprecated call was used.

Closes #2356 

Here's a jsfiddle with a demonstration: http://jsfiddle.net/sc6x537w/
![image](https://cloud.githubusercontent.com/assets/148787/10866892/efb63c2a-8013-11e5-9ba7-10de97b4443f.png)
