### PR TITLE
Reset the locale back to 'en' after defining all locales in min/locales.js

### DIFF
--- a/tasks/transpile.js
+++ b/tasks/transpile.js
@@ -105,7 +105,11 @@ module.exports = function (grunt) {
             code = files.map(function (file) {
                 var identifier = path.basename(file, '.js').replace('-', '_');
                 return 'import ' + identifier + ' from "./' + file + '";';
-            }).join('\n');
+            }).concat([
+                // Reset the language back to 'en', because every defineLocale
+                // also sets it.
+                'moment.locale(\'en\');'
+            ]).join('\n');
         return transpileCode({
             base: 'src',
             code: code,


### PR DESCRIPTION
Right now, if you include/import/load locales.js the locale is changed to 'zh-tw', because it is the last one defined. This patch resets the locale to `en` after all locales are defined.

Fixes #1798