### PR TITLE
Enable 'd hh:mm:ss.sss' format for durations

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -6,7 +6,7 @@ import { cloneWithOffset } from '../units/offset';
 import { createLocal } from '../create/local';
 
 // ASP.NET json date format regex
-var aspNetRegex = /(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
+var aspNetRegex = /(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -180,6 +180,13 @@ test('instatiation from serialized C# TimeSpan with days', function (assert) {
     assert.equal(moment.duration('1.02:03:04.9999999').minutes(), 3, '3 minutes');
     assert.equal(moment.duration('1.02:03:04.9999999').seconds(), 4, '4 seconds');
     assert.equal(moment.duration('1.02:03:04.9999999').milliseconds(), 999, '999 milliseconds');
+
+    assert.equal(moment.duration('1 02:03:04.9999999').years(), 0, '0 years');
+    assert.equal(moment.duration('1 02:03:04.9999999').days(), 1, '1 day');
+    assert.equal(moment.duration('1 02:03:04.9999999').hours(), 2, '2 hours');
+    assert.equal(moment.duration('1 02:03:04.9999999').minutes(), 3, '3 minutes');
+    assert.equal(moment.duration('1 02:03:04.9999999').seconds(), 4, '4 seconds');
+    assert.equal(moment.duration('1 02:03:04.9999999').milliseconds(), 999, '999 milliseconds');
 });
 
 test('instatiation from serialized C# TimeSpan without days', function (assert) {


### PR DESCRIPTION
Fix #2342