### PR TITLE
Only call setFullYear when necessary

### DIFF
--- a/src/lib/create/date-from-array.js
+++ b/src/lib/create/date-from-array.js
@@ -3,8 +3,8 @@ export function createDate (y, m, d, h, M, s, ms) {
     //http://stackoverflow.com/questions/181348/instantiating-a-javascript-object-by-calling-prototype-constructor-apply
     var date = new Date(y, m, d, h, M, s, ms);
 
-    //the date constructor doesn't accept years < 1970
-    if (y < 1970 && isFinite(date.getYear())) {
+    //the date constructor remaps years 0-99 to 1900-1999
+    if (y < 100 && y >= 0 && isFinite(date.getYear())) {
         date.setFullYear(y);
     }
     return date;
@@ -12,7 +12,9 @@ export function createDate (y, m, d, h, M, s, ms) {
 
 export function createUTCDate (y) {
     var date = new Date(Date.UTC.apply(null, arguments));
-    if (y < 1970 && isFinite(date.getUTCFullYear())) {
+
+    //the Date.UTC function remaps years 0-99 to 1900-1999
+    if (y < 100 && y >= 0 && isFinite(date.getUTCFullYear())) {
         date.setUTCFullYear(y);
     }
     return date;


### PR DESCRIPTION
This reapplies #2465, which was approved for 2.10.6, but somehow got deleted before it was merged.

Basically, the comments are wrong about the `Date` object not accepting years before 1970.  It's just that it re-maps years 0 to 99 to 1900-1999 in a strange attempt at a Y2K fix.