### PR TITLE
Add locale format option LY for MM/DD/YY in en and en-gb

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -2,7 +2,7 @@ import zeroFill from '../utils/zero-fill';
 
 export var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
 
-var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
+var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LY|ly|LL?L?L?|l{1,4})/g;
 
 var formatFunctions = {};
 

--- a/src/lib/locale/formats.js
+++ b/src/lib/locale/formats.js
@@ -2,6 +2,7 @@ export var defaultLongDateFormat = {
     LTS  : 'h:mm:ss A',
     LT   : 'h:mm A',
     L    : 'MM/DD/YYYY',
+    LY   : 'MM/DD/YY',
     LL   : 'MMMM D, YYYY',
     LLL  : 'MMMM D, YYYY h:mm A',
     LLLL : 'dddd, MMMM D, YYYY h:mm A'

--- a/src/locale/en-gb.js
+++ b/src/locale/en-gb.js
@@ -14,6 +14,7 @@ export default moment.defineLocale('en-gb', {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',
         L : 'DD/MM/YYYY',
+        LY : 'DD/MM/YY',
         LL : 'D MMMM YYYY',
         LLL : 'D MMMM YYYY HH:mm',
         LLLL : 'dddd, D MMMM YYYY HH:mm'

--- a/src/test/locale/en-gb.js
+++ b/src/test/locale/en-gb.js
@@ -38,10 +38,12 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45th day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
+            ['LY',                                 '14/02/10'],
             ['LL',                                 '14 February 2010'],
             ['LLL',                                '14 February 2010 15:25'],
             ['LLLL',                               'Sunday, 14 February 2010 15:25'],
             ['l',                                  '14/2/2010'],
+            ['ly',                                 '14/2/10'],
             ['ll',                                 '14 Feb 2010'],
             ['lll',                                '14 Feb 2010 15:25'],
             ['llll',                               'Sun, 14 Feb 2010 15:25']

--- a/src/test/locale/en.js
+++ b/src/test/locale/en.js
@@ -41,10 +41,12 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45th day of the year'],
             ['LTS',                                '3:25:50 PM'],
             ['L',                                  '02/14/2010'],
+            ['LY',                                 '02/14/10'],
             ['LL',                                 'February 14, 2010'],
             ['LLL',                                'February 14, 2010 3:25 PM'],
             ['LLLL',                               'Sunday, February 14, 2010 3:25 PM'],
             ['l',                                  '2/14/2010'],
+            ['ly',                                 '2/14/10'],
             ['ll',                                 'Feb 14, 2010'],
             ['lll',                                'Feb 14, 2010 3:25 PM'],
             ['llll',                               'Sun, Feb 14, 2010 3:25 PM']


### PR DESCRIPTION
PR for Issue https://github.com/moment/moment/issues/2158 (Localized MM/DD/YY)

**Changes Summary**
  * Adds locale format option `LY` to format date as: 
    * `MM/DD/YY` in `en`
    * `DD/MM/YY` in `en-gb` (cc: locale author, @chrisgedrim)
  * Includes corresponding tests.  `grunt test` output screenshot below.

<img width="417" alt="screen shot 2015-11-16 at 4 09 47 pm" src="https://cloud.githubusercontent.com/assets/6678014/11187506/937517ac-8c7e-11e5-822c-7e4104d557f0.png">