### PR TITLE
Coveralls badge should use develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Join the chat at https://gitter.im/moment/moment](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/moment/moment?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![NPM version][npm-version-image]][npm-url] [![NPM downloads][npm-downloads-image]][npm-url] [![MIT License][license-image]][license-url] [![Build Status][travis-image]][travis-url]
-[![Coverage Status](https://coveralls.io/repos/moment/moment/badge.svg?branch=master)](https://coveralls.io/r/moment/moment?branch=master)
+[![Coverage Status](https://coveralls.io/repos/moment/moment/badge.svg?branch=develop)](https://coveralls.io/r/moment/moment?branch=develop)
 
 A lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
 


### PR DESCRIPTION
Since `develop` is this repo's default branch and there's no coverage data for master (yet).