### PR TITLE
Update zh-cn.js

### DIFF
--- a/locale/zh-cn.js
+++ b/locale/zh-cn.js
@@ -13,9 +13,9 @@
     var zh_cn = moment.defineLocale('zh-cn', {
         months : '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
         monthsShort : '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),
-        weekdays : '星期日_星期一_星期二_星期三_星期四_星期五_星期六'.split('_'),
-        weekdaysShort : '周日_周一_周二_周三_周四_周五_周六'.split('_'),
-        weekdaysMin : '日_一_二_三_四_五_六'.split('_'),
+        weekdays : '星期一_星期二_星期三_星期四_星期五_星期六_星期日'.split('_'),
+        weekdaysShort : '周一_周二_周三_周四_周五_周六_周日'.split('_'),
+        weekdaysMin : '一_二_三_四_五_六_日'.split('_'),
         longDateFormat : {
             LT : 'Ah点mm分',
             LTS : 'Ah点m分s秒',


### PR DESCRIPTION
the week.dow does not matching weekdays, weekdaysShort and weekdaysMin.
"一" means Monday， "日" means Sunday