### PR TITLE
Parse ISO-8061 duration containing both day and week values

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -10,7 +10,8 @@ var aspNetRegex = /(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
-var isoRegex = /^(-)?P(?:(?:([0-9,.]*)Y)?(?:([0-9,.]*)M)?(?:([0-9,.]*)D)?(?:T(?:([0-9,.]*)H)?(?:([0-9,.]*)M)?(?:([0-9,.]*)S)?)?|([0-9,.]*)W)$/;
+// and further modified to allow for strings containing both week and day
+var isoRegex = /^(-)?P(?:([0-9,.]*)Y)?(?:([0-9,.]*)M)?(?:([0-9,.]*)W)?(?:([0-9,.]*)D)?(?:T(?:([0-9,.]*)H)?(?:([0-9,.]*)M)?(?:([0-9,.]*)S)?)?$/;
 
 export function createDuration (input, key) {
     var duration = input,
@@ -48,11 +49,11 @@ export function createDuration (input, key) {
         duration = {
             y : parseIso(match[2], sign),
             M : parseIso(match[3], sign),
-            d : parseIso(match[4], sign),
-            h : parseIso(match[5], sign),
-            m : parseIso(match[6], sign),
-            s : parseIso(match[7], sign),
-            w : parseIso(match[8], sign)
+            w : parseIso(match[4], sign),
+            d : parseIso(match[5], sign),
+            h : parseIso(match[6], sign),
+            m : parseIso(match[7], sign),
+            s : parseIso(match[8], sign)
         };
     } else if (duration == null) {// checks for null or undefined
         duration = {};

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -250,6 +250,7 @@ test('instatiation from serialized C# TimeSpan minValue', function (assert) {
 
 test('instantiation from ISO 8601 duration', function (assert) {
     assert.equal(moment.duration('P1Y2M3DT4H5M6S').asSeconds(), moment.duration({y: 1, M: 2, d: 3, h: 4, m: 5, s: 6}).asSeconds(), 'all fields');
+    assert.equal(moment.duration('P3W3D').asSeconds(), moment.duration({w: 3, d: 3}).asSeconds(), 'week and day fields');
     assert.equal(moment.duration('P1M').asSeconds(), moment.duration({M: 1}).asSeconds(), 'single month field');
     assert.equal(moment.duration('PT1M').asSeconds(), moment.duration({m: 1}).asSeconds(), 'single minute field');
     assert.equal(moment.duration('P1MT2H').asSeconds(), moment.duration({M: 1, h: 2}).asSeconds(), 'random fields missing');


### PR DESCRIPTION
This should resolve issue #2797 

More generally it looks like it was previously not possible to combine week values with anything else; when weeks were specified they had to be the ONLY value given.