### PR TITLE
dep: add grunt-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "uglify-js": "latest",
         "es6-promise": "latest",
         "grunt": "latest",
+        "grunt-cli": "latest",
         "benchmark": "latest",
         "esperanto": "latest",
         "grunt-contrib-clean": "latest",


### PR DESCRIPTION
currently the project relies on grunt-cli to run unit tests.
There are no instructions in the readme to inform developers of this dependency.

This PR adds grunt-cli to the dev-dependencies for a more seamless development
process. This PR will also make moment compatible with [CITGM](https://github.com/nodejs/citgm)
the node.js smoketesting utility. This will allow moment's unit test suite to
be ran against every release of Node.js, giving us an opportunity to give you a heads
up if anything breaks before a release.