### PR TITLE
Allow user to get/set the rounding method used when calculating relative time

### DIFF
--- a/src/lib/duration/duration.js
+++ b/src/lib/duration/duration.js
@@ -3,10 +3,14 @@ import './prototype';
 
 import { createDuration } from './create';
 import { isDuration } from './constructor';
-import { getSetRelativeTimeThreshold } from './humanize';
+import {
+    getSetRelativeTimeRounding,
+    getSetRelativeTimeThreshold
+} from './humanize';
 
 export {
     createDuration,
     isDuration,
+    getSetRelativeTimeRounding,
     getSetRelativeTimeThreshold
 };

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -40,6 +40,18 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
     return substituteTimeAgo.apply(null, a);
 }
 
+// This function allows you to set the rounding function for relative time strings
+export function getSetRelativeTimeRounding (roundingFunction) {
+    if (roundingFunction === undefined) {
+        return round;
+    }
+    if (typeof(roundingFunction) === 'function') {
+        round = roundingFunction;
+        return true;
+    }
+    return false;
+}
+
 // This function allows you to set a threshold for relative time strings
 export function getSetRelativeTimeThreshold (threshold, limit) {
     if (thresholds[threshold] === undefined) {

--- a/src/moment.js
+++ b/src/moment.js
@@ -35,6 +35,7 @@ import {
 import {
     isDuration,
     createDuration as duration,
+    getSetRelativeTimeRounding as relativeTimeRounding,
     getSetRelativeTimeThreshold as relativeTimeThreshold
 } from './lib/duration/duration';
 
@@ -65,6 +66,7 @@ moment.weekdaysMin           = weekdaysMin;
 moment.defineLocale          = defineLocale;
 moment.weekdaysShort         = weekdaysShort;
 moment.normalizeUnits        = normalizeUnits;
+moment.relativeTimeRounding = relativeTimeRounding;
 moment.relativeTimeThreshold = relativeTimeThreshold;
 moment.prototype             = fn;
 

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -139,6 +139,64 @@ test('custom thresholds', function (assert) {
     moment.relativeTimeThreshold('M', 11);
 });
 
+test('custom rounding', function (assert) {
+    var roundingDefault = moment.relativeTimeRounding();
+
+    // Round relative time evaluation down
+    moment.relativeTimeRounding(Math.floor);
+
+    moment.relativeTimeThreshold('s', 60);
+    moment.relativeTimeThreshold('m', 60);
+    moment.relativeTimeThreshold('h', 24);
+    moment.relativeTimeThreshold('d', 31);
+    moment.relativeTimeThreshold('M', 12);
+
+    var a = moment();
+    a.subtract({minutes: 59, seconds: 59});
+    assert.equal(a.toNow(), 'in 59 minutes', 'Round down towards the nearest minute');
+
+    a = moment();
+    a.subtract({hours: 23, minutes: 59, seconds: 59});
+    assert.equal(a.toNow(), 'in 23 hours', 'Round down towards the nearest hour');
+
+    a = moment();
+    a.subtract({days: 30, hours: 23, minutes: 59});
+    assert.equal(a.toNow(), 'in 30 days', 'Round down towards the nearest day');
+
+    a = moment();
+    a.subtract({days: 364});
+    assert.equal(a.toNow(), 'in 11 months', 'Round down towards the nearest month');
+
+    a = moment();
+    a.subtract({years: 1, days: 364});
+    assert.equal(a.toNow(), 'in a year', 'Round down towards the nearest year');
+
+    // Do not round relative time evaluation
+    var retainValue = function (value) {
+        return value;
+    };
+    moment.relativeTimeRounding(retainValue);
+
+    a = moment();
+    a.subtract({hours: 39});
+    assert.equal(a.toNow(), 'in 1.625 days', 'Round down towards the nearest year');
+
+    // Restore defaults
+    moment.relativeTimeThreshold('s', 45);
+    moment.relativeTimeThreshold('m', 45);
+    moment.relativeTimeThreshold('h', 22);
+    moment.relativeTimeThreshold('d', 26);
+    moment.relativeTimeThreshold('M', 11);
+    moment.relativeTimeRounding(roundingDefault);
+});
+
+test('retrive rounding settings', function (assert) {
+    moment.relativeTimeRounding(Math.round);
+    var roundingFunction = moment.relativeTimeRounding();
+
+    assert.equal(roundingFunction, Math.round, 'Can retrieve rounding setting');
+});
+
 test('retrive threshold settings', function (assert) {
     moment.relativeTimeThreshold('m', 45);
     var minuteThreshold = moment.relativeTimeThreshold('m');


### PR DESCRIPTION
There are many use cases where relative time humanization should use different rounding methods.

This PR is on the same wavelength as https://github.com/moment/moment/pull/1794