### PR TITLE
Canadian English longDateFormat

### DIFF
--- a/src/locale/en-ca.js
+++ b/src/locale/en-ca.js
@@ -17,9 +17,9 @@ export default moment.defineLocale('en-ca', {
         LT : 'h:mm A',
         LTS : 'h:mm:ss A',
         L : 'YYYY-MM-DD',
-        LL : 'D MMMM, YYYY',
-        LLL : 'D MMMM, YYYY h:mm A',
-        LLLL : 'dddd, D MMMM, YYYY h:mm A'
+        LL : 'MMMM D, YYYY',
+        LLL : 'MMMM D, YYYY h:mm A',
+        LLLL : 'dddd, MMMM D, YYYY h:mm A'
     },
     calendar : {
         sameDay : '[Today at] LT',
@@ -54,4 +54,3 @@ export default moment.defineLocale('en-ca', {
         return number + output;
     }
 });
-

--- a/src/test/locale/en-ca.js
+++ b/src/test/locale/en-ca.js
@@ -41,13 +41,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45th day of the year'],
             ['L',                                  '2010-02-14'],
             ['LTS',                                '3:25:50 PM'],
-            ['LL',                                 '14 February, 2010'],
-            ['LLL',                                '14 February, 2010 3:25 PM'],
-            ['LLLL',                               'Sunday, 14 February, 2010 3:25 PM'],
+            ['LL',                                 'February 14, 2010'],
+            ['LLL',                                'February 14, 2010 3:25 PM'],
+            ['LLLL',                               'Sunday, February 14, 2010 3:25 PM'],
             ['l',                                  '2010-2-14'],
-            ['ll',                                 '14 Feb, 2010'],
-            ['lll',                                '14 Feb, 2010 3:25 PM'],
-            ['llll',                               'Sun, 14 Feb, 2010 3:25 PM']
+            ['ll',                                 'Feb 14, 2010'],
+            ['lll',                                'Feb 14, 2010 3:25 PM'],
+            ['llll',                               'Sun, Feb 14, 2010 3:25 PM']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;


### PR DESCRIPTION
Canadian English mostly puts the day after the month like "January 3, 2016"

Usage examples:

- Parliament: http://www.lop.parl.gc.ca/Visitors/index-e.html
- Government: http://www.cic.gc.ca/english/citizenship/become-how.asp ("Citizenship application forms were updated on **June 11, 2015** ..."
- Toronto Star: http://torontostar.newspaperdirect.com/epaper/viewer.aspx

Original author: @jonbca
