### PR TITLE
Include changelog in npm release

### DIFF
--- a/scripts/npm_prepublish.sh
+++ b/scripts/npm_prepublish.sh
@@ -32,6 +32,7 @@ mkdir $dest
 cp $src/moment.js $dest
 cp $src/package.json $dest
 cp $src/README.md $dest
+cp $src/CHANGELOG.md $dest
 cp $src/LICENSE $dest
 cp -r $src/locale $dest
 cp -r $src/min $dest


### PR DESCRIPTION
Noticed it missing from the npm tarball when our test broke after upgrading to 2.11