### PR TITLE
Add format and parse token Y, so it actually works

### DIFF
--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -11,14 +11,7 @@ import toInt from '../utils/to-int';
 
 addFormatToken('Y', 0, 0, function () {
     var y = this.year();
-    if (y < 0) {
-        return y;
-    } else if (y <= 9999) {
-        return y;
-    } else {
-        // force plus for longer years.
-        return '+' + y;
-    }
+    return y <= 9999 ? '' + y : '+' + y;
 });
 
 addFormatToken(0, ['YY', 2], 0, function () {

--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -9,6 +9,18 @@ import toInt from '../utils/to-int';
 
 // FORMATTING
 
+addFormatToken('Y', 0, 0, function () {
+    var y = this.year();
+    if (y < 0) {
+        return y;
+    } else if (y <= 9999) {
+        return y;
+    } else {
+        // force plus for longer years.
+        return '+' + y;
+    }
+});
+
 addFormatToken(0, ['YY', 2], 0, function () {
     return this.year() % 100;
 });
@@ -35,6 +47,9 @@ addParseToken('YYYY', function (input, array) {
 });
 addParseToken('YY', function (input, array) {
     array[YEAR] = hooks.parseTwoDigitYear(input);
+});
+addParseToken('Y', function (input, array) {
+    array[YEAR] = parseInt(input, 10);
 });
 
 // HELPERS

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -1037,3 +1037,7 @@ test('hmm', function (assert) {
     assert.equal(moment('112345', 'Hmmss', true).format('HH:mm:ss'), '11:23:45', '112345 with Hmmss');
     assert.equal(moment('172345', 'Hmmss', true).format('HH:mm:ss'), '17:23:45', '112345 with Hmmss');
 });
+
+test('Y token', function (assert) {
+    assert.equal(moment('1-1-2010', 'M-D-Y', true).year(), 2010, 'parsing Y');
+});

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -429,4 +429,8 @@ test('Y token', function (assert) {
     assert.equal(moment('2010-01-01', 'YYYY-MM-DD', true).format('Y'), '2010', 'format 2010 with Y');
     assert.equal(moment('-123-01-01', 'Y-MM-DD', true).format('Y'), '-123', 'format -123 with Y');
     assert.equal(moment('12345-01-01', 'Y-MM-DD', true).format('Y'), '+12345', 'format 12345 with Y');
+    assert.equal(moment('0-01-01', 'Y-MM-DD', true).format('Y'), '0', 'format 0 with Y');
+    assert.equal(moment('1-01-01', 'Y-MM-DD', true).format('Y'), '1', 'format 1 with Y');
+    assert.equal(moment('9999-01-01', 'Y-MM-DD', true).format('Y'), '9999', 'format 9999 with Y');
+    assert.equal(moment('10000-01-01', 'Y-MM-DD', true).format('Y'), '+10000', 'format 10000 with Y');
 });

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -424,3 +424,9 @@ test('Hmm and Hmmss', function (assert) {
     assert.equal(moment('08:34:56', 'HH:mm:ss').format('Hmmss'), '83456');
     assert.equal(moment('18:34:56', 'HH:mm:ss').format('Hmmss'), '183456');
 });
+
+test('Y token', function (assert) {
+    assert.equal(moment('2010-01-01', 'YYYY-MM-DD', true).format('Y'), '2010', 'format 2010 with Y');
+    assert.equal(moment('-123-01-01', 'Y-MM-DD', true).format('Y'), '-123', 'format -123 with Y');
+    assert.equal(moment('12345-01-01', 'Y-MM-DD', true).format('Y'), '+12345', 'format 12345 with Y');
+});


### PR DESCRIPTION
Fix #2859 