### PR TITLE
Fix months parsing for stranger locales

### DIFF
--- a/src/lib/locale/prototype.js
+++ b/src/lib/locale/prototype.js
@@ -30,14 +30,22 @@ proto.set             = set;
 import {
     localeMonthsParse,
     defaultLocaleMonths,      localeMonths,
-    defaultLocaleMonthsShort, localeMonthsShort
+    defaultLocaleMonthsShort, localeMonthsShort,
+    defaultMonthsRegex,       monthsRegex,
+    defaultMonthsShortRegex,  monthsShortRegex,
+    computeMonthsParse
 } from '../units/month';
 
-proto.months       =        localeMonths;
-proto._months      = defaultLocaleMonths;
-proto.monthsShort  =        localeMonthsShort;
-proto._monthsShort = defaultLocaleMonthsShort;
-proto.monthsParse  =        localeMonthsParse;
+proto.months            =        localeMonths;
+proto._months           = defaultLocaleMonths;
+proto.monthsShort       =        localeMonthsShort;
+proto._monthsShort      = defaultLocaleMonthsShort;
+proto.monthsParse       =        localeMonthsParse;
+proto._monthsRegex      = defaultMonthsRegex;
+proto.monthsRegex       = monthsRegex;
+proto._monthsShortRegex = defaultMonthsShortRegex;
+proto.monthsShortRegex  = monthsShortRegex;
+proto._computeMonthsParse = computeMonthsParse;
 
 // Week
 import { localeWeek, defaultLocaleWeek, localeFirstDayOfYear, localeFirstDayOfWeek } from '../units/week';

--- a/src/lib/locale/prototype.js
+++ b/src/lib/locale/prototype.js
@@ -32,8 +32,7 @@ import {
     defaultLocaleMonths,      localeMonths,
     defaultLocaleMonthsShort, localeMonthsShort,
     defaultMonthsRegex,       monthsRegex,
-    defaultMonthsShortRegex,  monthsShortRegex,
-    computeMonthsParse
+    defaultMonthsShortRegex,  monthsShortRegex
 } from '../units/month';
 
 proto.months            =        localeMonths;
@@ -45,7 +44,6 @@ proto._monthsRegex      = defaultMonthsRegex;
 proto.monthsRegex       = monthsRegex;
 proto._monthsShortRegex = defaultMonthsShortRegex;
 proto.monthsShortRegex  = monthsShortRegex;
-proto._computeMonthsParse = computeMonthsParse;
 
 // Week
 import { localeWeek, defaultLocaleWeek, localeFirstDayOfYear, localeFirstDayOfWeek } from '../units/week';

--- a/src/lib/parse/regex.js
+++ b/src/lib/parse/regex.js
@@ -20,7 +20,7 @@ export var matchTimestamp = /[+-]?\d+(\.\d{1,3})?/; // 123456789 123456789.123
 
 // any word (or two) characters or numbers including two/three word month in arabic.
 // includes scottish gaelic two word and hyphenated months
-export var matchWord = /[0-9]*(a[mn]\s?)?['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF\-]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
+export var matchWord = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
 
 
 import hasOwnProp from '../utils/has-own-prop';
@@ -29,7 +29,7 @@ import isFunction from '../utils/is-function';
 var regexes = {};
 
 export function addRegexToken (token, regex, strictRegex) {
-    regexes[token] = isFunction(regex) ? regex : function (isStrict) {
+    regexes[token] = isFunction(regex) ? regex : function (isStrict, localeData) {
         return (isStrict && strictRegex) ? strictRegex : regex;
     };
 }
@@ -44,7 +44,11 @@ export function getParseRegexForToken (token, config) {
 
 // Code from http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript
 function unescapeFormat(s) {
-    return s.replace('\\', '').replace(/\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g, function (matched, p1, p2, p3, p4) {
+    return regexEscape(s.replace('\\', '').replace(/\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g, function (matched, p1, p2, p3, p4) {
         return p1 || p2 || p3 || p4;
-    }).replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    }));
+}
+
+export function regexEscape(s) {
+    return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }

--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -196,6 +196,11 @@ function computeMonthsParse () {
     shortPieces.sort(cmpLenRev);
     longPieces.sort(cmpLenRev);
     mixedPieces.sort(cmpLenRev);
+    for (i = 0; i < 12; i++) {
+        shortPieces[i] = regexEscape(shortPieces[i]);
+        longPieces[i] = regexEscape(longPieces[i]);
+        mixedPieces[i] = regexEscape(mixedPieces[i]);
+    }
 
     this._monthsRegex = new RegExp('^(' + mixedPieces.join('|') + ')', 'i');
     this._monthsShortRegex = this._monthsRegex;

--- a/src/locale/gd.js
+++ b/src/locale/gd.js
@@ -5,18 +5,7 @@
 import moment from '../moment';
 
 var months = [
-    'Am Faoilleach',
-    'An Gearran',
-    'Am Màrt',
-    'An Giblean',
-    'An Cèitean',
-    'An t-Ògmhios',
-    'An t-Iuchar',
-    'An Lùnastal',
-    'An t-Sultain',
-    'An Dàmhair',
-    'An t-Samhain',
-    'An Dùbhlachd'
+    'Am Faoilleach', 'An Gearran', 'Am Màrt', 'An Giblean', 'An Cèitean', 'An t-Ògmhios', 'An t-Iuchar', 'An Lùnastal', 'An t-Sultain', 'An Dàmhair', 'An t-Samhain', 'An Dùbhlachd'
 ];
 
 var monthsShort = ['Faoi', 'Gear', 'Màrt', 'Gibl', 'Cèit', 'Ògmh', 'Iuch', 'Lùn', 'Sult', 'Dàmh', 'Samh', 'Dùbh'];
@@ -30,6 +19,7 @@ var weekdaysMin = ['Dò', 'Lu', 'Mà', 'Ci', 'Ar', 'Ha', 'Sa'];
 export default moment.defineLocale('gd', {
     months : months,
     monthsShort : monthsShort,
+    monthsParseExact : true,
     weekdays : weekdays,
     weekdaysShort : weekdaysShort,
     weekdaysMin : weekdaysMin,

--- a/src/test/locale/gd.js
+++ b/src/test/locale/gd.js
@@ -19,7 +19,7 @@ var months = [
 
 test('parse', function (assert) {
     function equalTest(monthName, monthFormat, monthNum) {
-        assert.equal(moment(monthName, monthFormat).month(), monthNum, monthName + ' should be month ' + monthNum + 1);
+        assert.equal(moment(monthName, monthFormat).month(), monthNum, monthName + ' should be month ' + (monthNum + 1));
     }
 
     for (var i = 0; i < 12; i++) {

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -445,3 +445,35 @@ test('moment().lang with missing key doesn\'t change locale', function (assert) 
             'preserve global locale in case of bad locale id');
 });
 
+
+// TODO: Enable this after fixing pl months parse hack hack
+// test('monthsParseExact', function (assert) {
+//     var locale = 'test-months-parse-exact';
+
+//     moment.defineLocale(locale, {
+//         monthsParseExact: true,
+//         months: 'A_AA_AAA_B_B B_BB  B_C_C-C_C,C2C_D_D+D_D`D*D'.split('_'),
+//         monthsShort: 'E_EE_EEE_F_FF_FFF_G_GG_GGG_H_HH_HHH'.split('_')
+//     });
+
+//     assert.equal(moment('A', 'MMMM', true).month(), 0, 'parse long month 0 with MMMM');
+//     assert.equal(moment('AA', 'MMMM', true).month(), 1, 'parse long month 1 with MMMM');
+//     assert.equal(moment('AAA', 'MMMM', true).month(), 2, 'parse long month 2 with MMMM');
+//     assert.equal(moment('B B', 'MMMM', true).month(), 4, 'parse long month 4 with MMMM');
+//     assert.equal(moment('BB  B', 'MMMM', true).month(), 5, 'parse long month 5 with MMMM');
+//     assert.equal(moment('C-C', 'MMMM', true).month(), 7, 'parse long month 7 with MMMM');
+//     assert.equal(moment('C,C2C', 'MMMM', true).month(), 8, 'parse long month 8 with MMMM');
+//     assert.equal(moment('D+D', 'MMMM', true).month(), 10, 'parse long month 10 with MMMM');
+//     assert.equal(moment('D`D*D', 'MMMM', true).month(), 11, 'parse long month 11 with MMMM');
+
+//     assert.equal(moment('E', 'MMM', true).month(), 0, 'parse long month 0 with MMM');
+//     assert.equal(moment('EE', 'MMM', true).month(), 1, 'parse long month 1 with MMM');
+//     assert.equal(moment('EEE', 'MMM', true).month(), 2, 'parse long month 2 with MMM');
+
+//     assert.equal(moment('A', 'MMM').month(), 0, 'non-strict parse long month 0 with MMM');
+//     assert.equal(moment('AA', 'MMM').month(), 1, 'non-strict parse long month 1 with MMM');
+//     assert.equal(moment('AAA', 'MMM').month(), 2, 'non-strict parse long month 2 with MMM');
+//     assert.equal(moment('E', 'MMMM').month(), 0, 'non-strict parse short month 0 with MMMM');
+//     assert.equal(moment('EE', 'MMMM').month(), 1, 'non-strict parse short month 1 with MMMM');
+//     assert.equal(moment('EEE', 'MMMM').month(), 2, 'non-strict parse short month 2 with MMMM');
+// });


### PR DESCRIPTION
This fixes #2841

TODO:
- [ ] add weekdays in the mix
- [ ] test with months ending in dot and enable it there too
- [x] sort regex parts by reverse length
- [ ] add tests specific to this feature
- [ ] fix polish monthsParse hack