### PR TITLE
Use explicit .valueOf() calls instead of coercion

### DIFF
--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -63,7 +63,7 @@ function configFromInput(config) {
     if (input === undefined) {
         config._d = new Date(hooks.now());
     } else if (isDate(input)) {
-        config._d = new Date(+input);
+        config._d = new Date(input.valueOf());
     } else if (typeof input === 'string') {
         configFromString(config);
     } else if (isArray(input)) {

--- a/src/lib/moment/add-subtract.js
+++ b/src/lib/moment/add-subtract.js
@@ -34,7 +34,7 @@ export function addSubtract (mom, duration, isAdding, updateOffset) {
     updateOffset = updateOffset == null ? true : updateOffset;
 
     if (milliseconds) {
-        mom._d.setTime(+mom._d + milliseconds * isAdding);
+        mom._d.setTime(mom._d.valueOf() + milliseconds * isAdding);
     }
     if (days) {
         set(mom, 'Date', get(mom, 'Date') + days * isAdding);

--- a/src/lib/moment/compare.js
+++ b/src/lib/moment/compare.js
@@ -10,9 +10,9 @@ export function isAfter (input, units) {
     }
     units = normalizeUnits(!isUndefined(units) ? units : 'millisecond');
     if (units === 'millisecond') {
-        return +this > +localInput;
+        return this.valueOf() > localInput.valueOf();
     } else {
-        return +localInput < +this.clone().startOf(units);
+        return localInput.valueOf() < this.clone().startOf(units).valueOf();
     }
 }
 
@@ -23,9 +23,9 @@ export function isBefore (input, units) {
     }
     units = normalizeUnits(!isUndefined(units) ? units : 'millisecond');
     if (units === 'millisecond') {
-        return +this < +localInput;
+        return this.valueOf() < localInput.valueOf();
     } else {
-        return +this.clone().endOf(units) < +localInput;
+        return this.clone().endOf(units).valueOf() < localInput.valueOf();
     }
 }
 
@@ -41,10 +41,10 @@ export function isSame (input, units) {
     }
     units = normalizeUnits(units || 'millisecond');
     if (units === 'millisecond') {
-        return +this === +localInput;
+        return this.valueOf() === localInput.valueOf();
     } else {
-        inputMs = +localInput;
-        return +(this.clone().startOf(units)) <= inputMs && inputMs <= +(this.clone().endOf(units));
+        inputMs = localInput.valueOf();
+        return this.clone().startOf(units).valueOf() <= inputMs && inputMs <= this.clone().endOf(units).valueOf();
     }
 }
 

--- a/src/lib/moment/to-type.js
+++ b/src/lib/moment/to-type.js
@@ -1,13 +1,13 @@
 export function valueOf () {
-    return +this._d - ((this._offset || 0) * 60000);
+    return this._d.valueOf() - ((this._offset || 0) * 60000);
 }
 
 export function unix () {
-    return Math.floor(+this / 1000);
+    return Math.floor(this.valueOf() / 1000);
 }
 
 export function toDate () {
-    return this._offset ? new Date(+this) : this._d;
+    return this._offset ? new Date(this.valueOf()) : this._d;
 }
 
 export function toArray () {

--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -61,9 +61,9 @@ export function cloneWithOffset(input, model) {
     var res, diff;
     if (model._isUTC) {
         res = model.clone();
-        diff = (isMoment(input) || isDate(input) ? +input : +createLocal(input)) - (+res);
+        diff = (isMoment(input) || isDate(input) ? input.valueOf() : createLocal(input).valueOf()) - res.valueOf();
         // Use low-level api, because this fn is low-level api.
-        res._d.setTime(+res._d + diff);
+        res._d.setTime(res._d.valueOf() + diff);
         hooks.updateOffset(res, false);
         return res;
     } else {


### PR DESCRIPTION
This seems to result in speedups by around 10% for comparing moments.

http://jsperf.com/explicit-valueof-for-momentjs