### PR TITLE
Ensure Locale#calendar keys that are callback functions are scoped to…

### DIFF
--- a/src/lib/moment/calendar.js
+++ b/src/lib/moment/calendar.js
@@ -15,7 +15,7 @@ export function calendar (time, formats) {
             diff < 2 ? 'nextDay' :
             diff < 7 ? 'nextWeek' : 'sameElse';
 
-    var output = formats && (isFunction(formats[format]) ? formats[format]() : formats[format]);
+    var output = formats && (isFunction(formats[format]) ? formats[format].apply(this) : formats[format]);
 
     return this.format(output || this.localeData().calendar(format, this, createLocal(now)));
 }


### PR DESCRIPTION
In my testing when calling moment#calendar 'this' in a callback function referred not to the current moment but rather to the formatting strings object. Using apply and passing in the current moment fixed the issue.