### PR TITLE
Fix toJSON casting of invalid moment

### DIFF
--- a/src/lib/moment/to-type.js
+++ b/src/lib/moment/to-type.js
@@ -29,6 +29,6 @@ export function toObject () {
 }
 
 export function toJSON () {
-    // JSON.stringify(new Date(NaN)) === 'null'
-    return this.isValid() ? this.toISOString() : 'null';
+    // JSON.stringify(new Date(NaN)) === null
+    return this.isValid() ? this.toISOString() : null;
 }

--- a/src/lib/moment/to-type.js
+++ b/src/lib/moment/to-type.js
@@ -29,6 +29,6 @@ export function toObject () {
 }
 
 export function toJSON () {
-    // JSON.stringify(new Date(NaN)) === null
+    // new Date(NaN).toJSON() === null
     return this.isValid() ? this.toISOString() : null;
 }

--- a/src/test/moment/invalid.js
+++ b/src/test/moment/invalid.js
@@ -99,7 +99,7 @@ test('invalid operations', function (assert) {
         });
         assert.ok(moment.isDate(invalid.toDate()));
         assert.ok(isNaN(invalid.toDate().valueOf()));
-        assert.equal(invalid.toJSON(), 'null');
+        assert.equal(invalid.toJSON(), null);
         assert.equal(invalid.toString(), 'Invalid date');
         assert.ok(isNaN(invalid.unix()));
         assert.ok(isNaN(invalid.valueOf()));


### PR DESCRIPTION
This is an attempt at solving issue #2886.

Invalid moments were casting as 'null' (the string)
Now they are properly casting as null (the literal)