### PR TITLE
Update is.js

### DIFF
--- a/locale/is.js
+++ b/locale/is.js
@@ -86,7 +86,7 @@
         longDateFormat : {
             LT : 'H:mm',
             LTS : 'H:mm:ss',
-            L : 'DD/MM/YYYY',
+            L : 'DD.MM.YYYY',
             LL : 'D. MMMM YYYY',
             LLL : 'D. MMMM YYYY [kl.] H:mm',
             LLLL : 'dddd, D. MMMM YYYY [kl.] H:mm'


### PR DESCRIPTION
Icelandic 'L' locale format should use a dot separator.