### PR TITLE
parse string arguments for month() correctly, closes #2884

### DIFF
--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -115,7 +115,7 @@ export function setMonth (mom, value) {
     }
 
     // TODO: Move this out of here!
-    if (typeof value === 'string') {
+    if (typeof value === 'string' && !/^\d+$/.test(value)) {
         value = mom.localeData().monthsParse(value);
         // TODO: Another silent failure?
         if (typeof value !== 'number') {

--- a/src/test/moment/getters_setters.js
+++ b/src/test/moment/getters_setters.js
@@ -236,3 +236,22 @@ test('day setter', function (assert) {
     assert.equal(moment(a).day(20).date(), 29, 'set from wednesday to second next saturday');
     assert.equal(moment(a).day(17).date(), 26, 'set from wednesday to second next wednesday');
 });
+
+test('string setters', function (assert) {
+    var a = moment();
+    a.year('2011');
+    a.month('9');
+    a.date('12');
+    a.hours('6');
+    a.minutes('7');
+    a.seconds('8');
+    a.milliseconds('9');
+    assert.equal(a.year(), 2011, 'year');
+    assert.equal(a.month(), 9, 'month');
+    assert.equal(a.date(), 12, 'date');
+    assert.equal(a.day(), 3, 'day');
+    assert.equal(a.hours(), 6, 'hour');
+    assert.equal(a.minutes(), 7, 'minute');
+    assert.equal(a.seconds(), 8, 'second');
+    assert.equal(a.milliseconds(), 9, 'milliseconds');
+});


### PR DESCRIPTION
Lets `moment().month('7')` work the same as `moment().month(7)`