### PR TITLE
Add "files"-property for smaller npm-module size

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     },
     "ender": "./ender.js",
     "dojoBuild": "package.js",
+    "files": [
+        "moment.js",
+        "locale"
+    ],
     "jspm": {
         "files": [
             "moment.js",


### PR DESCRIPTION
"npm install moment" causes my project to be 5 MB larger than before. Looking at the code and the API-documentation it seems to me, that only the "moment.js"-file and the "locale"-files are needed in node. The "min"-directory can be omitted. I have added a "files"-property to the "package.json" that  includes only "moment.js" and the "locale"-directory.