### PR TITLE
Update to icelandic locale 

### DIFF
--- a/src/locale/is.js
+++ b/src/locale/is.js
@@ -80,7 +80,7 @@ export default moment.defineLocale('is', {
     longDateFormat : {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
-        L : 'DD/MM/YYYY',
+        L : 'DD.MM.YYYY',
         LL : 'D. MMMM YYYY',
         LLL : 'D. MMMM YYYY [kl.] H:mm',
         LLLL : 'dddd, D. MMMM YYYY [kl.] H:mm'

--- a/src/test/locale/is.js
+++ b/src/test/locale/is.js
@@ -37,11 +37,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14/02/2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. febrúar 2010'],
             ['LLL',                                '14. febrúar 2010 kl. 15:25'],
             ['LLLL',                               'sunnudagur, 14. febrúar 2010 kl. 15:25'],
-            ['l',                                  '14/2/2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. feb 2010'],
             ['lll',                                '14. feb 2010 kl. 15:25'],
             ['llll',                               'sun, 14. feb 2010 kl. 15:25']


### PR DESCRIPTION
Format specifier 'L' should use dot instead of forward slash:
'14.02.2010' instead of '14/02/2010'.

@hinrik , could you confirm?