### PR TITLE
List loaded locales

### DIFF
--- a/src/lib/locale/locale.js
+++ b/src/lib/locale/locale.js
@@ -4,7 +4,8 @@ import './prototype';
 import {
     getSetGlobalLocale,
     defineLocale,
-    getLocale
+    getLocale,
+    listLocales
 } from './locales';
 
 import {
@@ -19,6 +20,7 @@ export {
     getSetGlobalLocale,
     defineLocale,
     getLocale,
+    listLocales,
     listMonths,
     listMonthsShort,
     listWeekdays,

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -116,3 +116,7 @@ export function getLocale (key) {
 
     return chooseLocale(key);
 }
+
+export function listLocales() {
+    return Object.keys(locales);
+}

--- a/src/moment.js
+++ b/src/moment.js
@@ -25,6 +25,7 @@ import {
     defineLocale,
     getSetGlobalLocale as locale,
     getLocale          as localeData,
+    listLocales        as locales,
     listMonths         as months,
     listMonthsShort    as monthsShort,
     listWeekdays       as weekdays,
@@ -63,6 +64,7 @@ moment.isDuration            = isDuration;
 moment.monthsShort           = monthsShort;
 moment.weekdaysMin           = weekdaysMin;
 moment.defineLocale          = defineLocale;
+moment.locales               = locales;
 moment.weekdaysShort         = weekdaysShort;
 moment.normalizeUnits        = normalizeUnits;
 moment.relativeTimeThreshold = relativeTimeThreshold;

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -152,6 +152,10 @@ test('defineLocale', function (assert) {
     assert.equal(moment().locale('dude').locale(), 'dude', 'defineLocale defines a locale');
 });
 
+test('locales', function (assert) {
+    assert.equal(moment.locales().length > 0, true, 'locales returns an array of defined locales');
+});
+
 test('library convenience', function (assert) {
     moment.locale('something', {week: {dow: 3}});
     moment.locale('something');

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -153,7 +153,9 @@ test('defineLocale', function (assert) {
 });
 
 test('locales', function (assert) {
-    assert.equal(moment.locales().length > 0, true, 'locales returns an array of defined locales');
+    moment.defineLocale('dude', {months: ['Movember']});
+    assert.equal(true, !!~moment.locales().indexOf('dude'), 'locales returns an array of defined locales');
+    assert.equal(true, !!~moment.locales().indexOf('en'), 'locales should always include english');
 });
 
 test('library convenience', function (assert) {


### PR DESCRIPTION
Fixes #843

This adds the method `moment.locales()` to get an array of the locales that have been loaded (ie, bundled with moment.js or manually required in node.)

It does not list or `require` available (but unloaded) locales in node. I think that should be a separate feature if needed at all.