### PR TITLE
use full-string match to speed up aspnet regex match

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -6,7 +6,7 @@ import { cloneWithOffset } from '../units/offset';
 import { createLocal } from '../create/local';
 
 // ASP.NET json date format regex
-var aspNetRegex = /(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
+var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere


### PR DESCRIPTION
Fixes: https://github.com/moment/moment/issues/2936

C# duration match was _almost_ complete enough to match full-strings, just needed to allow for the extra digits in microseconds. Getting to put in `^` `$` resolves the speed problem reported @ #2936.