### PR TITLE
Fix usage suggestions for min and max

### DIFF
--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -4,7 +4,7 @@ import { createLocal } from '../create/local';
 import { createInvalid } from '../create/valid';
 
 export var prototypeMin = deprecate(
-     'moment().min is deprecated, use moment.min instead. https://github.com/moment/moment/issues/1548',
+     'moment().min is deprecated, use moment.max instead. https://github.com/moment/moment/issues/1548',
      function () {
          var other = createLocal.apply(null, arguments);
          if (this.isValid() && other.isValid()) {
@@ -16,7 +16,7 @@ export var prototypeMin = deprecate(
  );
 
 export var prototypeMax = deprecate(
-    'moment().max is deprecated, use moment.max instead. https://github.com/moment/moment/issues/1548',
+    'moment().max is deprecated, use moment.min instead. https://github.com/moment/moment/issues/1548',
     function () {
         var other = createLocal.apply(null, arguments);
         if (this.isValid() && other.isValid()) {


### PR DESCRIPTION
The deprecation warnings for instance `min` and `max` give incorrect substitutions. Per the current documentation `moment().min` and `moment.max()` should be replaced by `moment.max` and `moment.min` respectively. We learned this the hard way.

<img width="962" alt="screen shot 2016-02-03 at 1 32 52 pm" src="https://cloud.githubusercontent.com/assets/332880/12797803/ac0cc38e-ca7a-11e5-8f03-3a8adf7fec70.png">

https://jsfiddle.net/s5ex3qh7/
(open the console to see the deprecation warning)