### PR TITLE
Add parsing negative components in durations when ISO 8601

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -10,7 +10,7 @@ var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
-var isoRegex = /^(-)?P(?:(?:(-)?([0-9,.]*)Y)?(?:(-)?([0-9,.]*)M)?(?:(-)?([0-9,.]*)D)?(?:T(?:(-)?([0-9,.]*)H)?(?:(-)?([0-9,.]*)M)?(?:(-)?([0-9,.]*)S)?)?|(-)?([0-9,.]*)W)$/;
+var isoRegex = /^(-)?P(?:(?:((?:-)?[0-9,.]*)Y)?(?:((?:-)?[0-9,.]*)M)?(?:((?:-)?[0-9,.]*)D)?(?:T(?:((?:-)?[0-9,.]*)H)?(?:((?:-)?[0-9,.]*)M)?(?:((?:-)?[0-9,.]*)S)?)?|((?:-)?[0-9,.]*)W)$/;
 
 export function createDuration (input, key) {
     var duration = input,
@@ -45,21 +45,14 @@ export function createDuration (input, key) {
         };
     } else if (!!(match = isoRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : 1;
-        var ySign = (match[2] === '-') ? -sign : sign;
-        var MSign = (match[4] === '-') ? -sign : sign;
-        var dSign = (match[6] === '-') ? -sign : sign;
-        var hSign = (match[8] === '-') ? -sign : sign;
-        var mSign = (match[10] === '-') ? -sign : sign;
-        var sSign = (match[12] === '-') ? -sign : sign;
-        var wSign = (match[14] === '-') ? -sign : sign;
         duration = {
-            y : parseIso(match[3], ySign),
-            M : parseIso(match[5], MSign),
-            d : parseIso(match[7], dSign),
-            h : parseIso(match[9], hSign),
-            m : parseIso(match[11], mSign),
-            s : parseIso(match[13], sSign),
-            w : parseIso(match[15], wSign)
+            y : parseIso(match[2], sign),
+            M : parseIso(match[3], sign),
+            d : parseIso(match[4], sign),
+            h : parseIso(match[5], sign),
+            m : parseIso(match[6], sign),
+            s : parseIso(match[7], sign),
+            w : parseIso(match[8], sign)
         };
     } else if (duration == null) {// checks for null or undefined
         duration = {};

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -10,7 +10,7 @@ var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
-var isoRegex = /^(-)?P(?:(?:([0-9,.]*)Y)?(?:([0-9,.]*)M)?(?:([0-9,.]*)D)?(?:T(?:([0-9,.]*)H)?(?:([0-9,.]*)M)?(?:([0-9,.]*)S)?)?|([0-9,.]*)W)$/;
+var isoRegex = /^(-)?P(?:(?:(-)?([0-9,.]*)Y)?(?:(-)?([0-9,.]*)M)?(?:(-)?([0-9,.]*)D)?(?:T(?:(-)?([0-9,.]*)H)?(?:(-)?([0-9,.]*)M)?(?:(-)?([0-9,.]*)S)?)?|(-)?([0-9,.]*)W)$/;
 
 export function createDuration (input, key) {
     var duration = input,
@@ -45,14 +45,21 @@ export function createDuration (input, key) {
         };
     } else if (!!(match = isoRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : 1;
+        var ySign = (match[2] === '-') ? -sign : sign;
+        var MSign = (match[4] === '-') ? -sign : sign;
+        var dSign = (match[6] === '-') ? -sign : sign;
+        var hSign = (match[8] === '-') ? -sign : sign;
+        var mSign = (match[10] === '-') ? -sign : sign;
+        var sSign = (match[12] === '-') ? -sign : sign;
+        var wSign = (match[14] === '-') ? -sign : sign;
         duration = {
-            y : parseIso(match[2], sign),
-            M : parseIso(match[3], sign),
-            d : parseIso(match[4], sign),
-            h : parseIso(match[5], sign),
-            m : parseIso(match[6], sign),
-            s : parseIso(match[7], sign),
-            w : parseIso(match[8], sign)
+            y : parseIso(match[3], ySign),
+            M : parseIso(match[5], MSign),
+            d : parseIso(match[7], dSign),
+            h : parseIso(match[9], hSign),
+            m : parseIso(match[11], mSign),
+            s : parseIso(match[13], sSign),
+            w : parseIso(match[15], wSign)
         };
     } else if (duration == null) {// checks for null or undefined
         duration = {};

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -307,6 +307,12 @@ test('`isodate` (python) test cases', function (assert) {
     assert.equal(moment.duration('-P2Y').asSeconds(), moment.duration({y: -2}).asSeconds(), 'python isodate 22');
     assert.equal(moment.duration('-P3Y6M4DT12H30M5S').asSeconds(), moment.duration({y: -3, M: -6, d: -4, h: -12, m: -30, s: -5}).asSeconds(), 'python isodate 23');
     assert.equal(moment.duration('-P1DT2H3M4S').asSeconds(), moment.duration({d: -1, h: -2, m: -3, s: -4}).asSeconds(), 'python isodate 24');
+    assert.equal(moment.duration('PT-6H3M').asSeconds(), moment.duration({h: -6, m: 3}).asSeconds(), 'python isodate 25');
+    assert.equal(moment.duration('-PT-6H3M').asSeconds(), moment.duration({h: 6, m: -3}).asSeconds(), 'python isodate 26');
+    assert.equal(moment.duration('-P-3Y-6M-4DT-12H-30M-5S').asSeconds(), moment.duration({y: 3, M: 6, d: 4, h: 12, m: 30, s: 5}).asSeconds(), 'python isodate 27');
+    assert.equal(moment.duration('P-3Y-6M-4DT-12H-30M-5S').asSeconds(), moment.duration({y: -3, M: -6, d: -4, h: -12, m: -30, s: -5}).asSeconds(), 'python isodate 28');
+    assert.equal(moment.duration('-P-2W').asSeconds(), moment.duration({w: 2}).asSeconds(), 'python isodate 29');
+    assert.equal(moment.duration('P-2W').asSeconds(), moment.duration({w: -2}).asSeconds(), 'python isodate 30');
 });
 
 test('ISO 8601 misuse cases', function (assert) {
@@ -317,7 +323,6 @@ test('ISO 8601 misuse cases', function (assert) {
     assert.equal(moment.duration('PT.5S').asSeconds(), 0.5, 'accept no leading zero for decimal');
     assert.equal(moment.duration('PT1,S').asSeconds(), 1, 'accept trailing decimal separator');
     assert.equal(moment.duration('PT1M0,,5S').asSeconds(), 60, 'extra decimal separators are ignored as 0');
-    assert.equal(moment.duration('P-1DS').asSeconds(), 0, 'wrong position of negative');
 });
 
 test('humanize', function (assert) {


### PR DESCRIPTION
This is to resolve issue #2408 where formats such as 'P-6D' were not supported for durations. It supports negating each component of the duration. If the whole duration has already been negated (-P6D -> -6 days), then it will make the component positive ('-P-6D' -> 6 days). The issue showed "-P-6H+3M" as an example, but the lack of a 'T' does not fit with the rest of the standard. In light of this, the changes allow for "-PT-6H+3M" instead.