### PR TITLE
add weekOfMonth

### DIFF
--- a/src/lib/moment/prototype.js
+++ b/src/lib/moment/prototype.js
@@ -76,9 +76,10 @@ proto.month       = getSetMonth;
 proto.daysInMonth = getDaysInMonth;
 
 // Week
-import { getSetWeek, getSetISOWeek } from '../units/week';
+import { getSetWeek, getSetISOWeek, getWeekOfMonth } from '../units/week';
 proto.week           = proto.weeks        = getSetWeek;
 proto.isoWeek        = proto.isoWeeks     = getSetISOWeek;
+proto.weekOfMonth    = getWeekOfMonth;
 proto.weeksInYear    = getWeeksInYear;
 proto.isoWeeksInYear = getISOWeeksInYear;
 

--- a/src/lib/units/week.js
+++ b/src/lib/units/week.js
@@ -55,6 +55,10 @@ export function getSetWeek (input) {
     return input == null ? week : this.add((input - week) * 7, 'd');
 }
 
+export function getWeekOfMonth (input) {
+    return this.week() - this.startOf('month').week() + 1;
+}
+
 export function getSetISOWeek (input) {
     var week = weekOfYear(this, 1, 4).week;
     return input == null ? week : this.add((input - week) * 7, 'd');

--- a/src/test/moment/weeks.js
+++ b/src/test/moment/weeks.js
@@ -118,6 +118,14 @@ test('weeks setter', function (assert) {
     assert.equal(moment([2012, 0, 15]).week(30).week(), 30, 'Setting Jan 15 2012 to week 30 should work');
 });
 
+test('weekOfMonth', function (assert) {
+    assert.equal(moment([2012, 0,  1]).weekOfMonth(), 1, 'Setting Jan 1 2012 to week 30 should work');
+    assert.equal(moment([2012, 0,  7]).weekOfMonth(), 1, 'Setting Jan 7 2012 to week 30 should work');
+    assert.equal(moment([2012, 0,  8]).weekOfMonth(), 2, 'Setting Jan 8 2012 to week 30 should work');
+    assert.equal(moment([2012, 0, 14]).weekOfMonth(), 2, 'Setting Jan 14 2012 to week 30 should work');
+    assert.equal(moment([2012, 0, 15]).weekOfMonth(), 3, 'Setting Jan 15 2012 to week 30 should work');
+});
+
 test('iso weeks setter', function (assert) {
     assert.equal(moment([2012, 0,  1]).isoWeeks(25).isoWeeks(), 25, 'Setting Jan  1 2012 to week 25 should work');
     assert.equal(moment([2012, 0,  2]).isoWeeks(24).isoWeeks(), 24, 'Setting Jan  2 2012 to week 24 should work');

--- a/src/test/moment/weeks.js
+++ b/src/test/moment/weeks.js
@@ -119,11 +119,11 @@ test('weeks setter', function (assert) {
 });
 
 test('weekOfMonth', function (assert) {
-    assert.equal(moment([2012, 0,  1]).weekOfMonth(), 1, 'Setting Jan 1 2012 to week 30 should work');
-    assert.equal(moment([2012, 0,  7]).weekOfMonth(), 1, 'Setting Jan 7 2012 to week 30 should work');
-    assert.equal(moment([2012, 0,  8]).weekOfMonth(), 2, 'Setting Jan 8 2012 to week 30 should work');
-    assert.equal(moment([2012, 0, 14]).weekOfMonth(), 2, 'Setting Jan 14 2012 to week 30 should work');
-    assert.equal(moment([2012, 0, 15]).weekOfMonth(), 3, 'Setting Jan 15 2012 to week 30 should work');
+    assert.equal(moment([2012, 0,  1]).weekOfMonth(), 1, 'Jan 1 is in the first week of January');
+    assert.equal(moment([2012, 0,  7]).weekOfMonth(), 1, 'Jan 7 is also in the first week of January');
+    assert.equal(moment([2012, 0,  8]).weekOfMonth(), 2, 'Jan 8 is in the second week of January');
+    assert.equal(moment([2012, 0, 14]).weekOfMonth(), 2, 'Jan 14 is in the second week of January');
+    assert.equal(moment([2012, 3, 15]).weekOfMonth(), 3, 'April 15 is in the second week of April');
 });
 
 test('iso weeks setter', function (assert) {


### PR DESCRIPTION
Implements https://github.com/moment/moment/issues/2934

Some questions that occurred to me while working on this:
- Does it make sense to implement this function as a standalone method vs integrating it into `moment.week`?
- Do we also need an `ISO` version of this method, similar to `isoWeek`?
- Are my test cases sufficient?