### PR TITLE
change add subtract to handle decimal values by rounding

### DIFF
--- a/src/lib/moment/add-subtract.js
+++ b/src/lib/moment/add-subtract.js
@@ -3,6 +3,8 @@ import { setMonth } from '../units/month';
 import { createDuration } from '../duration/create';
 import { deprecateSimple } from '../utils/deprecate';
 import { hooks } from '../utils/hooks';
+import absRound from '../utils/abs-round';
+
 
 // TODO: remove 'name' arg after deprecation is removed
 function createAdder(direction, name) {
@@ -23,8 +25,8 @@ function createAdder(direction, name) {
 
 export function addSubtract (mom, duration, isAdding, updateOffset) {
     var milliseconds = duration._milliseconds,
-        days = duration._days,
-        months = duration._months;
+        days = absRound(duration._days),
+        months = absRound(duration._months);
 
     if (!mom.isValid()) {
         // No op

--- a/src/lib/utils/abs-round.js
+++ b/src/lib/utils/abs-round.js
@@ -1,0 +1,7 @@
+export default function absRound (number) {
+    if (number < 0) {
+        return Math.round(-1 * number) * -1;
+    } else {
+        return Math.round(number);
+    }
+}

--- a/src/test/moment/add_subtract.js
+++ b/src/test/moment/add_subtract.js
@@ -323,3 +323,23 @@ test('add across DST', function (assert) {
     assert.equal(c.hours(), 5, 'adding months over DST difference should result in the same hour');
     assert.equal(e.hours(), 5, 'adding quarters over DST difference should result in the same hour');
 });
+
+test('add decimal values of days and months', function (assert) {
+    assert.equal(moment([2016,3,3]).add(1.5, 'days').date(), 5, 'adding 1.5 days is rounded to adding 2 day');
+    assert.equal(moment([2016,3,3]).add(-1.5, 'days').date(), 1, 'adding -1.5 days is rounded to adding -2 day');
+    assert.equal(moment([2016,3,1]).add(-1.5, 'days').date(), 30, 'adding -1.5 days on first of month wraps around');
+    assert.equal(moment([2016,3,3]).add(1.5, 'months').month(), 5, 'adding 1.5 months adds 2 month');
+    assert.equal(moment([2016,3,3]).add(-1.5, 'months').month(), 1, 'adding -1.5 months adds -1 month');
+    assert.equal(moment([2016,0,3]).add(-1.5, 'months').month(), 10, 'adding -1.5 months at start of year wraps back');
+    assert.equal(moment([2016,3,3]).subtract(1.5, 'days').date(),1, 'subtract 1.5 days is rounded to subtract 2 day');
+    assert.equal(moment([2016,3,2]).subtract(1.5, 'days').date(), 31, 'subtract 1.5 days subtracts 2 days');
+    assert.equal(moment([2016,1,1]).subtract(1.1, 'days').date(), 31, 'subtract 1.1 days wraps to previous month');
+    assert.equal(moment([2016,3,3]).subtract(-1.5, 'days').date(), 5, 'subtract -1.5 days is rounded to subtract -1 day');
+    assert.equal(moment([2016,3,30]).subtract(-1.5, 'days').date(), 2, 'subtract -1.5 days on last of month wraps around');
+    assert.equal(moment([2016,3,3]).subtract(1.5, 'months').month(), 1, 'subtract 1.5 months subtract 2 months');
+    assert.equal(moment([2016,3,3]).subtract(-1.5, 'months').month(), 5, 'subtract -1.5 months subtract -1 month');
+    assert.equal(moment([2016,11,31]).subtract(-1.5, 'months').month(),1, 'subtract -1.5 months at end of year wraps back');
+    assert.equal(moment([2016, 0,1]).add(1.5, 'years').format('YYYY-MM-DD'), '2017-07-01', 'add 1.5 years adds 1 year six months');
+    assert.equal(moment([2016, 0,1]).add(1.6, 'years').format('YYYY-MM-DD'), '2017-08-01', 'add 1.6 years becomes 1.6*12 = 19.2, round, 19 months');
+    assert.equal(moment([2016,0,1]).add(1.1, 'quarters').format('YYYY-MM-DD'), '2016-04-01', 'add 1.1 quarters 1.1*3=3.3, round, 3 months');
+});


### PR DESCRIPTION
Normalizes behavior of add and subtract when a decimal value is passed.
Current behavior:
```javascript
moment('2016-04-03').add(1.5, 'days').format() = "2016-04-04T00:00:00-05:00"  // (adds 1)
moment('2016-04-03').add(-1.5, 'days').format() = "2016-04-01T00:00:00-05:00"  // (adds -2)
moment('2016-04-03').subtract(1.5, 'days').format() = "2016-04-01T00:00:00-05:00"  // (subtracts 2)
moment('2016-04-03').subtract(-1.5, 'days').format() = "2016-04-04T00:00:00-05:00"  // (subtracts -1)
```

Behavior after PR:
```javascript
moment('2016-04-03').add(1.5, 'days').format() = "2016-04-04T00:00:00-05:00"  // (adds 1)
moment('2016-04-03').add(-1.5, 'days').format() = "2016-04-02T00:00:00-05:00"  // (adds -1)
moment('2016-04-03').subtract(1.5, 'days').format() = "2016-04-02T00:00:00-05:00"  // (subtracts 1)
moment('2016-04-03').subtract(-1.5, 'days').format() = "2016-04-04T00:00:00-05:00"  // (subtracts -1)
```
The same behavior happens with months.

I understand where this could be interpreted as a breaking change, so I certainly won't be offended if you don't take it, but I think it definitely causes the API to behave in a manner closer to what the user would expect.
