### PR TITLE
Use npmignore when publising npm packages

### DIFF
--- a/scripts/npm_prepublish.sh
+++ b/scripts/npm_prepublish.sh
@@ -38,6 +38,7 @@ cp -r $src/locale $dest
 cp -r $src/min $dest
 cp $src/ender.js $dest
 cp $src/package.js $dest
+cp $src/.npmignore $dest
 
 rm -rf $src
 


### PR DESCRIPTION
Hello,

I've noticed that `min/tests.js` is still present in npm package even if [it was added to npmignore](https://github.com/moment/moment/commit/eb35595035ebd10b2505c8f249f57fb79b468543). I think the publication is made with `scripts/npm_prepublish.sh`. So,I've added to this file a copy of the `.npmignore` file.