### PR TITLE
Add 'date' as alias to 'day' for startOf() and endOf().

### DIFF
--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -15,6 +15,7 @@ export function startOf (units) {
     case 'week':
     case 'isoWeek':
     case 'day':
+    case 'date':
         this.hours(0);
         /* falls through */
     case 'hour':
@@ -48,5 +49,11 @@ export function endOf (units) {
     if (units === undefined || units === 'millisecond') {
         return this;
     }
+
+    // 'date' is an alias for 'day', so it should be considered as such.
+    if (units === 'date') {
+        units = 'day';
+    }
+
     return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
 }

--- a/src/test/moment/start_end_of.js
+++ b/src/test/moment/start_end_of.js
@@ -189,6 +189,35 @@ test('end of day', function (assert) {
     assert.equal(m.milliseconds(), 999, 'set the seconds');
 });
 
+test('start of date', function (assert) {
+    var m = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).startOf('date'),
+        ms = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).startOf('dates');
+
+    assert.equal(+m, +ms, 'Plural or singular should work');
+    assert.equal(m.year(), 2011, 'keep the year');
+    assert.equal(m.month(), 1, 'keep the month');
+    assert.equal(m.date(), 2, 'keep the day');
+    assert.equal(m.hours(), 0, 'strip out the hours');
+    assert.equal(m.minutes(), 0, 'strip out the minutes');
+    assert.equal(m.seconds(), 0, 'strip out the seconds');
+    assert.equal(m.milliseconds(), 0, 'strip out the milliseconds');
+});
+
+test('end of date', function (assert) {
+    var m = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).endOf('date'),
+        ms = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).endOf('dates');
+
+    assert.equal(+m, +ms, 'Plural or singular should work');
+    assert.equal(m.year(), 2011, 'keep the year');
+    assert.equal(m.month(), 1, 'keep the month');
+    assert.equal(m.date(), 2, 'keep the day');
+    assert.equal(m.hours(), 23, 'set the hours');
+    assert.equal(m.minutes(), 59, 'set the minutes');
+    assert.equal(m.seconds(), 59, 'set the seconds');
+    assert.equal(m.milliseconds(), 999, 'set the seconds');
+});
+
+
 test('start of hour', function (assert) {
     var m = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).startOf('hour'),
         ms = moment(new Date(2011, 1, 2, 3, 4, 5, 6)).startOf('hours'),


### PR DESCRIPTION
Patch for #2974.