### PR TITLE
Using 1000 * 60 * 60 instead of 36e5 to avoid floating point rounding errors

### DIFF
--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -17,7 +17,7 @@ export function Duration (duration) {
     this._milliseconds = +milliseconds +
         seconds * 1e3 + // 1000
         minutes * 6e4 + // 1000 * 60
-        hours * 36e5; // 1000 * 60 * 60
+        hours * 1000 * 60 * 60; //using 1000 * 60 * 60 instead of 36e5 to avoid floating point rounding errors https://github.com/moment/moment/issues/2978
     // Because of dateAddRemove treats 24 hours as different from a
     // day when working around DST, we need to store them separately
     this._days = +days +

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -540,6 +540,13 @@ test('as getters for small units', function (assert) {
     assert.equal(dm.asMinutes(),        13, 'asMinutes()');
 });
 
+test('minutes getter for floating point hours', function (assert) {
+    // Tests for issue #2978.
+    // For certain floating point hours, .minutes() getter produced incorrect values due to the rounding errors
+    assert.equal(moment.duration(2.3, 'h').minutes(), 18, 'minutes()');
+    assert.equal(moment.duration(4.1, 'h').minutes(), 6, 'minutes()');
+});
+
 test('isDuration', function (assert) {
     assert.ok(moment.isDuration(moment.duration(12345678)), 'correctly says true');
     assert.ok(!moment.isDuration(moment()), 'moment object is not a duration');
@@ -628,4 +635,3 @@ test('duration plugins', function (assert) {
     };
     durationObject.foo(5);
 });
-


### PR DESCRIPTION
Fixes #2978
