### PR TITLE
Suppress deprecation warnings in unit tests

### DIFF
--- a/src/test/moment/deprecate.js
+++ b/src/test/moment/deprecate.js
@@ -1,11 +1,13 @@
 import { module, test, expect } from '../qunit';
 import { deprecate } from '../../lib/utils/deprecate';
+import { hooks } from '../../lib/utils/hooks';
 import moment from '../../moment';
 
 module('deprecate');
 
 test('deprecate', function (assert) {
     var fn = function () {};
+    hooks.suppressDeprecationWarnings = true;
     var deprecatedFn = deprecate('testing deprecation', fn);
     deprecatedFn();
 

--- a/src/test/qunit.js
+++ b/src/test/qunit.js
@@ -10,6 +10,7 @@ export var expect = QUnit.expect;
 export function module (name, lifecycle) {
     QUnit.module(name, {
         setup : function () {
+            moment.suppressDeprecationWarnings = true;
             moment.locale('en');
             moment.createFromInputFallback = function (config) {
                 throw new Error('input not handled by moment: ' + config._i);
@@ -29,6 +30,7 @@ export function module (name, lifecycle) {
 export function localeModule (name, lifecycle) {
     QUnit.module('locale:' + name, {
         setup : function () {
+            moment.suppressDeprecationWarnings = true;
             moment.locale(name);
             moment.createFromInputFallback = function (config) {
                 throw new Error('input not handled by moment: ' + config._i);


### PR DESCRIPTION
It's not helpful to have deprecation warnings show up in the test output.