### PR TITLE
Don't validate line endings

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -53,7 +53,6 @@
     "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
     "disallowKeywords": ["with"],
     "disallowMultipleLineStrings": true,
-    "validateLineBreaks": "LF",
     "validateIndentation": 4,
     "disallowTrailingWhitespace": true,
     "disallowTrailingComma": true,


### PR DESCRIPTION
Per #3011 - Don't validate line endings because it causes excessive warnings and fails the build on Windows.