### PR TITLE
Fix issue with DST transition in Chinese locale

### DIFF
--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -67,7 +67,7 @@ export default moment.defineLocale('zh-cn', {
         nextWeek : function () {
             var startOfWeek, prefix;
             startOfWeek = moment().startOf('week');
-            prefix = this.unix() - startOfWeek.unix() >= 7 * 24 * 3600 ? '[下]' : '[本]';
+            prefix = this.diff(startOfWeek, 'days') >= 7 ? '[下]' : '[本]';
             return this.minutes() === 0 ? prefix + 'dddAh点整' : prefix + 'dddAh点mm';
         },
         lastWeek : function () {


### PR DESCRIPTION
Fixes #3016 by using the `diff` function instead of subtracting unix timestamps.

This was failing when crossing a DST boundary, such as the one upcoming for March 13th in the USA.