### PR TITLE
Year setter should keep time when DST changes

### DIFF
--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -63,7 +63,7 @@ hooks.parseTwoDigitYear = function (input) {
 
 // MOMENTS
 
-export var getSetYear = makeGetSet('FullYear', false);
+export var getSetYear = makeGetSet('FullYear', true);
 
 export function getIsLeapYear () {
     return isLeapYear(this.year());

--- a/src/test/moment/getters_setters.js
+++ b/src/test/moment/getters_setters.js
@@ -255,3 +255,69 @@ test('string setters', function (assert) {
     assert.equal(a.seconds(), 8, 'second');
     assert.equal(a.milliseconds(), 9, 'milliseconds');
 });
+
+test('setters across DST +1', function (assert) {
+    var oldUpdateOffset = moment.updateOffset,
+        // Based on a real story somewhere in America/Los_Angeles
+        dstAt = moment('2014-03-09T02:00:00-08:00').parseZone(),
+        m;
+
+    moment.updateOffset = function (mom, keepTime) {
+        if (mom.isBefore(dstAt)) {
+            mom.utcOffset(-8, keepTime);
+        } else {
+            mom.utcOffset(-7, keepTime);
+        }
+    };
+
+    m = moment('2014-03-15T00:00:00-07:00').parseZone();
+    m.year(2013);
+    assert.equal(m.format(), '2013-03-15T00:00:00-08:00', 'year across +1');
+
+    m = moment('2014-03-15T00:00:00-07:00').parseZone();
+    m.month(0);
+    assert.equal(m.format(), '2014-01-15T00:00:00-08:00', 'month across +1');
+
+    m = moment('2014-03-15T00:00:00-07:00').parseZone();
+    m.date(1);
+    assert.equal(m.format(), '2014-03-01T00:00:00-08:00', 'date across +1');
+
+    m = moment('2014-03-09T03:05:00-07:00').parseZone();
+    m.hour(0);
+    assert.equal(m.format(), '2014-03-09T00:05:00-08:00', 'hour across +1');
+
+    moment.updateOffset = oldUpdateOffset;
+});
+
+test('setters across DST -1', function (assert) {
+    var oldUpdateOffset = moment.updateOffset,
+        // Based on a real story somewhere in America/Los_Angeles
+        dstAt = moment('2014-11-02T02:00:00-07:00').parseZone(),
+        m;
+
+    moment.updateOffset = function (mom, keepTime) {
+        if (mom.isBefore(dstAt)) {
+            mom.utcOffset(-7, keepTime);
+        } else {
+            mom.utcOffset(-8, keepTime);
+        }
+    };
+
+    m = moment('2014-11-15T00:00:00-08:00').parseZone();
+    m.year(2013);
+    assert.equal(m.format(), '2013-11-15T00:00:00-07:00', 'year across -1');
+
+    m = moment('2014-11-15T00:00:00-08:00').parseZone();
+    m.month(0);
+    assert.equal(m.format(), '2014-01-15T00:00:00-07:00', 'month across -1');
+
+    m = moment('2014-11-15T00:00:00-08:00').parseZone();
+    m.date(1);
+    assert.equal(m.format(), '2014-11-01T00:00:00-07:00', 'date across -1');
+
+    m = moment('2014-11-02T03:30:00-08:00').parseZone();
+    m.hour(0);
+    assert.equal(m.format(), '2014-11-02T00:30:00-07:00', 'hour across -1');
+
+    moment.updateOffset = oldUpdateOffset;
+});

--- a/src/test/moment/start_end_of.js
+++ b/src/test/moment/start_end_of.js
@@ -294,6 +294,10 @@ test('startOf across DST +1', function (assert) {
     };
 
     m = moment('2014-03-15T00:00:00-07:00').parseZone();
+    m.startOf('y');
+    assert.equal(m.format(), '2014-01-01T00:00:00-08:00', 'startOf(\'year\') across +1');
+
+    m = moment('2014-03-15T00:00:00-07:00').parseZone();
     m.startOf('M');
     assert.equal(m.format(), '2014-03-01T00:00:00-08:00', 'startOf(\'month\') across +1');
 
@@ -327,6 +331,10 @@ test('startOf across DST -1', function (assert) {
             mom.utcOffset(-8, keepTime);
         }
     };
+
+    m = moment('2014-11-15T00:00:00-08:00').parseZone();
+    m.startOf('y');
+    assert.equal(m.format(), '2014-01-01T00:00:00-07:00', 'startOf(\'year\') across -1');
 
     m = moment('2014-11-15T00:00:00-08:00').parseZone();
     m.startOf('M');


### PR DESCRIPTION
Consider:

```javascript
moment.tz("2016-03-28T00:00:00","Europe/London").year(2015).format()  //  "2015-03-27T23:00:00+00:00"
```
It should have been `"2015-03-28T00:00:00+00:00"`

While this only manifests when using moment-timezone, the problem is in moment itself.  The `keepTime` flag of the year unit should be set to `true`, as it is for months, days, and hours.

Fixed this, added some unit tests, and added similar tests around other units and related scenarios.