### PR TITLE
More DST fixes in unit tests

### DIFF
--- a/src/test/helpers/common-locale.js
+++ b/src/test/helpers/common-locale.js
@@ -46,7 +46,7 @@ export function defineCommonLocaleTests(locale, options) {
         for (h = 0; h < 24; ++h) {
             for (m = 0; m < 60; m += 15) {
                 t1 = moment.utc([2000, 0, 1, h, m]);
-                t2 = moment(t1.format('A h:mm'), 'A h:mm');
+                t2 = moment.utc(t1.format('A h:mm'), 'A h:mm');
                 assert.equal(t2.format('HH:mm'), t1.format('HH:mm'),
                         'meridiem at ' + t1.format('HH:mm'));
             }

--- a/src/test/locale/pa-in.js
+++ b/src/test/locale/pa-in.js
@@ -311,18 +311,6 @@ test('lenient ordinal parsing of number', function (assert) {
     }
 });
 
-test('meridiem', function (assert) {
-    var h, m, t1, t2;
-    for (h = 0; h < 24; ++h) {
-        for (m = 0; m < 60; m += 15) {
-            t1 = moment.utc([2000, 0, 1, h, m]);
-            t2 = moment(t1.format('A h:mm'), 'A h:mm');
-            assert.equal(t2.format('HH:mm'), t1.format('HH:mm'),
-                    'meridiem at ' + t1.format('HH:mm'));
-        }
-    }
-});
-
 test('strict ordinal parsing', function (assert) {
     var i, ordinalStr, testMoment;
     for (i = 1; i <= 31; ++i) {

--- a/src/test/moment/calendar.js
+++ b/src/test/moment/calendar.js
@@ -6,12 +6,12 @@ import moment from '../../moment';
 module('calendar');
 
 test('passing a function', function (assert) {
-    var a  = moment().hours(2).minutes(0).seconds(0);
+    var a  = moment().hours(13).minutes(0).seconds(0);
     assert.equal(moment(a).calendar(null, {
         'sameDay': function () {
             return 'h:mmA';
         }
-    }), '2:00AM', 'should equate');
+    }), '1:00PM', 'should equate');
 });
 
 


### PR DESCRIPTION
This fixes a few more test failure that occurred on the day of the spring-forward transition.

Specifically:

- "meridiem invariant" test, ran on every locale, was using a local time unnecessarily, so used UTC instead.
  - one locale had a dup of this common test, so I removed it
- "passing a function" test on the `calendar` object had a local time.  Moved it from 02:00 to 13:00.