### PR TITLE
Expose parsed date parts. Invalid date if 'a' token parsed but no date parts parsed.

### DIFF
--- a/src/lib/create/from-string-and-format.js
+++ b/src/lib/create/from-string-and-format.js
@@ -70,6 +70,9 @@ export function configFromStringAndFormat(config) {
             config._a[HOUR] > 0) {
         getParsingFlags(config).bigHour = undefined;
     }
+
+    getParsingFlags(config).parsedDateParts = config._a.slice(0);
+    getParsingFlags(config).meridiem = config._meridiem;
     // handle meridiem
     config._a[HOUR] = meridiemFixWrap(config._locale, config._a[HOUR], config._meridiem);
 

--- a/src/lib/create/parsing-flags.js
+++ b/src/lib/create/parsing-flags.js
@@ -10,7 +10,9 @@ function defaultParsingFlags() {
         invalidMonth    : null,
         invalidFormat   : false,
         userInvalidated : false,
-        iso             : false
+        iso             : false,
+        parsedDateParts : [],
+        meridiem        : null
     };
 }
 

--- a/src/lib/create/valid.js
+++ b/src/lib/create/valid.js
@@ -1,10 +1,14 @@
 import extend from '../utils/extend';
 import { createUTC } from './utc';
 import getParsingFlags from '../create/parsing-flags';
+import some from '../utils/some';
 
 export function isValid(m) {
     if (m._isValid == null) {
         var flags = getParsingFlags(m);
+        var parsedParts = some.call(flags.parsedDateParts, function (i) {
+            return i != null;
+        });
         m._isValid = !isNaN(m._d.getTime()) &&
             flags.overflow < 0 &&
             !flags.empty &&
@@ -12,7 +16,8 @@ export function isValid(m) {
             !flags.invalidWeekday &&
             !flags.nullInput &&
             !flags.invalidFormat &&
-            !flags.userInvalidated;
+            !flags.userInvalidated &&
+            (!flags.meridiem || (flags.meridiem && parsedParts));
 
         if (m._strict) {
             m._isValid = m._isValid &&

--- a/src/lib/utils/some.js
+++ b/src/lib/utils/some.js
@@ -1,0 +1,19 @@
+var some;
+if (Array.prototype.some) {
+    some = Array.prototype.some;
+} else {
+    some = function (fun) {
+        var t = Object(this);
+        var len = t.length >>> 0;
+
+        for (var i = 0; i < len; i++) {
+            if (i in t && fun.call(this, t[i], i, t)) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+}
+
+export { some as default };

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -1041,3 +1041,19 @@ test('hmm', function (assert) {
 test('Y token', function (assert) {
     assert.equal(moment('1-1-2010', 'M-D-Y', true).year(), 2010, 'parsing Y');
 });
+
+test('parsing flags retain parsed date parts', function (assert) {
+    var a = moment('10 p', 'hh:mm a');
+    assert.equal(a.parsingFlags().parsedDateParts[3], 10, 'parsed 10 as the hour');
+    assert.equal(a.parsingFlags().parsedDateParts[0], undefined, 'year was not parsed');
+    assert.equal(a.parsingFlags().meridiem, 'p', 'meridiem flag was added');
+    var b = moment('10:30', ['MMDDYY', 'HH:mm']);
+    assert.equal(b.parsingFlags().parsedDateParts[3], 10, 'multiple format parshing matched hour');
+    assert.equal(b.parsingFlags().parsedDateParts[0], undefined, 'array is properly copied, no residual data from first token parse');
+});
+
+test('parsing only meridiem results in invalid date', function (assert) {
+    assert.ok(!moment('alkj', 'hh:mm a').isValid(), 'because an a token is used, a meridiem will be parsed but nothing else was so invalid');
+    assert.ok(moment('02:30 p more extra stuff', 'hh:mm a').isValid(), 'because other tokens were parsed, date is valid');
+    assert.ok(moment('1/1/2016 extra data', ['a', 'M/D/YYYY']).isValid(), 'took second format, does not pick up on meridiem parsed from first format (good copy)');
+});


### PR DESCRIPTION
PR resolves #3037 and #2986 

The date parts parsed are exposed in parsingFlags().parsedDateParts array. Array only has date parts at indexes parsed.

Because actual date parts parsed is being tracked now, it is possible to modify isValid to evaluate as false if no date parts are being parsed, but meridiem indicator was parsed.
This resolves a current behavior where junk data can parse valid if it has the letters 'a' or 'p' in it (or whatever indicates meridiem in the specific locale).
Current behavior:
```js
moment('asdfgh', 'hh:mm a').isValid()
true
```