### PR TITLE
Make Documentation link more obvious on npmjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
 
-## [Documentation](http://momentjs.com/docs/)
+**[Documentation](http://momentjs.com/docs/)**
 
 ## Port to ECMAScript 6 (version 2.10.0)
 


### PR DESCRIPTION
It's a minor feedback, but when you look at the readme on https://www.npmjs.com/package/moment , it's really not obvious that "Documentation" was a link (because it's a title).
maybe it's a bug to raise at npmjs itself, but this PR would fix it.