### PR TITLE
fix bug where diff returns -0 in month-related diffs

### DIFF
--- a/src/lib/moment/diff.js
+++ b/src/lib/moment/diff.js
@@ -57,5 +57,6 @@ function monthDiff (a, b) {
         adjust = (b - anchor) / (anchor2 - anchor);
     }
 
-    return -(wholeMonthDiff + adjust);
+    //check for negative zero, return zero if negative zero
+    return -(wholeMonthDiff + adjust) || 0;
 }

--- a/src/test/moment/diff.js
+++ b/src/test/moment/diff.js
@@ -232,3 +232,12 @@ test('year diffs', function (assert) {
     equal(assert, moment([2012, 0, 1]).diff([2013, 6, 1, 12], 'years', true), -1.5 - (0.5 / 31) / 12, 'Jan 1 2012 to Jul 1 2013 noon should be 1.5+(0.5 / 31) / 12 years');
     equal(assert, moment([2012, 1, 29]).diff([2013, 1, 28], 'years', true), -1, 'Feb 29 2012 to Feb 28 2013 should be 1-(1 / 28.5) / 12 years');
 });
+
+test('negative zero', function (assert) {
+    function isNegative (n) {
+            return (1 / n) < 0;
+        }
+    assert.ok(!isNegative(moment([2012, 0, 1]).diff(moment([2012, 0, 1]), 'months')), 'month diff on same date is zero, not -0');
+    assert.ok(!isNegative(moment([2012, 0, 1]).diff(moment([2012, 0, 1]), 'years')), 'year diff on same date is zero, not -0');
+    assert.ok(!isNegative(moment([2012, 0, 1]).diff(moment([2012, 0, 1]), 'quarters')), 'quarter diff on same date is zero, not -0');
+});


### PR DESCRIPTION
Fixes #2908.

I wish there were simpler code for this, but as far as I am aware the only way to get rid of the negative zero is to explicitly check for it and replace it with zero.

Fun fact - this bug created a stack overflow question with a ton of upvotes: http://stackoverflow.com/questions/31599665/javascript-detecting-the-difference-between-positive-zero-and-negative-zero

Edit: Tim made my code good. Lesson learned.