### PR TITLE
No deprecations in tests

### DIFF
--- a/src/lib/utils/deprecate.js
+++ b/src/lib/utils/deprecate.js
@@ -13,6 +13,9 @@ export function deprecate(msg, fn) {
     var firstTime = true;
 
     return extend(function () {
+        if (hooks.deprecationHandler != null) {
+            hooks.deprecationHandler(null, msg);
+        }
         if (firstTime) {
             warn(msg + '\nArguments: ' + Array.prototype.slice.call(arguments).join(', ') + '\n' + (new Error()).stack);
             firstTime = false;
@@ -24,6 +27,9 @@ export function deprecate(msg, fn) {
 var deprecations = {};
 
 export function deprecateSimple(name, msg) {
+    if (hooks.deprecationHandler != null) {
+        hooks.deprecationHandler(name, msg);
+    }
     if (!deprecations[name]) {
         warn(msg);
         deprecations[name] = true;
@@ -31,3 +37,4 @@ export function deprecateSimple(name, msg) {
 }
 
 hooks.suppressDeprecationWarnings = false;
+hooks.deprecationHandler = null;

--- a/src/test/helpers/deprecation-handler.js
+++ b/src/test/helpers/deprecation-handler.js
@@ -1,0 +1,52 @@
+import each from './each';
+
+export function setupDeprecationHandler(test, moment, scope) {
+    test._expectedDeprecations = null;
+    test._observedDeprecations = null;
+    test._oldSupress = moment.suppressDeprecationWarnings;
+    moment.suppressDeprecationWarnings = true;
+    test.expectedDeprecations = function () {
+        test._expectedDeprecations = arguments;
+        test._observedDeprecations = [];
+    };
+    moment.deprecationHandler = function (name, msg) {
+        var deprecationId = matchedDeprecation(name, msg, test._expectedDeprecations);
+        if (deprecationId === -1) {
+            throw new Error('Unexpected deprecation thrown name=' +
+                    name + ' msg=' + msg);
+        }
+        test._observedDeprecations[deprecationId] = 1;
+    };
+}
+
+export function teardownDeprecationHandler(test, moment, scope) {
+    moment.suppressDeprecationWarnings = test._oldSupress;
+
+    if (test._expectedDeprecations != null) {
+        var missedDeprecations = [];
+        each(test._expectedDeprecations, function (deprecationPattern, id) {
+            if (test._observedDeprecations[id] !== 1) {
+                missedDeprecations.push(deprecationPattern);
+            }
+        });
+        if (missedDeprecations.length !== 0) {
+            throw new Error('Expected deprecation warnings did not happen: ' +
+                    missedDeprecations.join(' '));
+        }
+    }
+}
+
+function matchedDeprecation(name, msg, deprecations) {
+    if (deprecations == null) {
+        return -1;
+    }
+    for (var i = 0; i < deprecations.length; ++i) {
+        if (name != null && name === deprecations[i]) {
+            return i;
+        }
+        if (msg != null && msg.substring(0, deprecations[i].length) === deprecations[i]) {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/src/test/locale/lt.js
+++ b/src/test/locale/lt.js
@@ -106,12 +106,12 @@ test('format week', function (assert) {
 
 test('format week on US calendar', function (assert) {
     // Tests, whether the weekday names are correct, even if the week does not start on Monday
-    moment.locale('lt', {week: {dow: 0, doy: 6}});
+    moment.updateLocale('lt', {week: {dow: 0, doy: 6}});
     var expected = 'sekmadienis Sek S_pirmadienis Pir P_antradienis Ant A_trečiadienis Tre T_ketvirtadienis Ket K_penktadienis Pen Pn_šeštadienis Šeš Š'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }
-    moment.locale('lt', {week: {dow: 1, doy: 4}});
+    moment.updateLocale('lt', null);
 });
 
 test('from', function (assert) {

--- a/src/test/moment/add_subtract.js
+++ b/src/test/moment/add_subtract.js
@@ -80,6 +80,9 @@ test('add long singular reverse args', function (assert) {
 
 test('add string long reverse args', function (assert) {
     var a = moment(), b;
+
+    test.expectedDeprecations('moment().add(period, number)');
+
     a.year(2011);
     a.month(9);
     a.date(12);
@@ -104,6 +107,9 @@ test('add string long reverse args', function (assert) {
 
 test('add string long singular reverse args', function (assert) {
     var a = moment(), b;
+
+    test.expectedDeprecations('moment().add(period, number)');
+
     a.year(2011);
     a.month(9);
     a.date(12);
@@ -128,6 +134,8 @@ test('add string long singular reverse args', function (assert) {
 
 test('add string short reverse args', function (assert) {
     var a = moment();
+    test.expectedDeprecations('moment().add(period, number)');
+
     a.year(2011);
     a.month(9);
     a.date(12);
@@ -210,8 +218,10 @@ test('add string short', function (assert) {
     assert.equal(a.add(1, 'Q').month(), 1, 'Add quarter');
 });
 
-test('add strings string short args', function (assert) {
+test('add strings string short reversed', function (assert) {
     var a = moment();
+    test.expectedDeprecations('moment().add(period, number)');
+
     a.year(2011);
     a.month(9);
     a.date(12);
@@ -231,8 +241,10 @@ test('add strings string short args', function (assert) {
     assert.equal(a.add('Q', '1').month(), 1, 'Add quarter');
 });
 
-test('subtract strings string short args', function (assert) {
+test('subtract strings string short reversed', function (assert) {
     var a = moment();
+    test.expectedDeprecations('moment().subtract(period, number)');
+
     a.year(2011);
     a.month(9);
     a.date(12);

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -664,6 +664,7 @@ test('parsing week year/week/weekday (dow 6, doy 12)', function (assert) {
     assert.equal(moment.utc('2010-01', 'gggg-ww').format(), '2009-12-26T00:00:00+00:00', '2010 week 1 (1st Jan Fri)');
     assert.equal(moment.utc('2011-01', 'gggg-ww').format(), '2011-01-01T00:00:00+00:00', '2011 week 1 (1st Jan Sat)');
     assert.equal(moment.utc('2012-01', 'gggg-ww').format(), '2011-12-31T00:00:00+00:00', '2012 week 1 (1st Jan Sun)');
+    moment.defineLocale('dow:6,doy:12', null);
 });
 
 test('parsing ISO with Z', function (assert) {
@@ -952,6 +953,7 @@ test('parsing localized weekdays', function (assert) {
         ver('1999 37 Di', 'gggg ww dd', '1999 09 19', 'localized d uses 0-indexed days: 0 = sund');
     }
     finally {
+        moment.defineLocale('dow:1,doy:4', null);
         moment.locale('en');
     }
 });

--- a/src/test/moment/deprecate.js
+++ b/src/test/moment/deprecate.js
@@ -5,6 +5,8 @@ import moment from '../../moment';
 module('deprecate');
 
 test('deprecate', function (assert) {
+    // NOTE: hooks inside deprecate.js and moment are different, so this is can
+    // not be test.expectedDeprecations(...)
     var fn = function () {};
     var deprecatedFn = deprecate('testing deprecation', fn);
     deprecatedFn();

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -280,6 +280,8 @@ test('toString acts as toISOString', function (assert) {
 });
 
 test('toIsoString deprecation', function (assert) {
+    test.expectedDeprecations('toIsoString()');
+
     assert.equal(moment.duration({}).toIsoString(), moment.duration({}).toISOString(), 'toIsoString delegates to toISOString');
 });
 

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -242,7 +242,7 @@ test('week year formats', function (assert) {
         '405-12-31': '0405-52'
     }, i, isoWeekYear, formatted5, formatted4, formatted2;
 
-    moment.locale('dow:1,doy:4', {week: {dow: 1, doy: 4}});
+    moment.defineLocale('dow:1,doy:4', {week: {dow: 1, doy: 4}});
 
     for (i in cases) {
         isoWeekYear = cases[i].split('-')[0];
@@ -253,6 +253,7 @@ test('week year formats', function (assert) {
         formatted2 = moment(i, 'YYYY-MM-DD').format('gg');
         assert.equal(isoWeekYear.slice(2, 4), formatted2, i + ': gg should be ' + isoWeekYear + ', but ' + formatted2);
     }
+    moment.defineLocale('dow:1,doy:4', null);
 });
 
 test('iso weekday formats', function (assert) {
@@ -266,7 +267,7 @@ test('iso weekday formats', function (assert) {
 });
 
 test('weekday formats', function (assert) {
-    moment.locale('dow: 3,doy: 5', {week: {dow: 3, doy: 5}});
+    moment.defineLocale('dow: 3,doy: 5', {week: {dow: 3, doy: 5}});
     assert.equal(moment([1985, 1,  6]).format('e'), '0', 'Feb  6 1985 is Wednesday -- 0th day');
     assert.equal(moment([2029, 8, 20]).format('e'), '1', 'Sep 20 2029 is Thursday  -- 1st day');
     assert.equal(moment([2013, 3, 26]).format('e'), '2', 'Apr 26 2013 is Friday    -- 2nd day');
@@ -274,6 +275,7 @@ test('weekday formats', function (assert) {
     assert.equal(moment([1970, 0,  4]).format('e'), '4', 'Jan  4 1970 is Sunday    -- 4th day');
     assert.equal(moment([2001, 4, 14]).format('e'), '5', 'May 14 2001 is Monday    -- 5th day');
     assert.equal(moment([2000, 0,  4]).format('e'), '6', 'Jan  4 2000 is Tuesday   -- 6th day');
+    moment.defineLocale('dow: 3,doy: 5', null);
 });
 
 test('toString is just human readable format', function (assert) {
@@ -282,13 +284,13 @@ test('toString is just human readable format', function (assert) {
 });
 
 test('toJSON skips postformat', function (assert) {
-    moment.locale('postformat', {
+    moment.defineLocale('postformat', {
         postformat: function (s) {
             s.replace(/./g, 'X');
         }
     });
     assert.equal(moment.utc([2000, 0, 1]).toJSON(), '2000-01-01T00:00:00.000Z', 'toJSON doesn\'t postformat');
-    moment.locale('postformat', null);
+    moment.defineLocale('postformat', null);
 });
 
 test('calendar day timezone', function (assert) {

--- a/src/test/moment/getters_setters.js
+++ b/src/test/moment/getters_setters.js
@@ -36,6 +36,8 @@ test('getters programmatic', function (assert) {
 
 test('setters plural', function (assert) {
     var a = moment();
+    test.expectedDeprecations('years accessor', 'months accessor', 'dates accessor');
+
     a.years(2011);
     a.months(9);
     a.dates(12);

--- a/src/test/moment/invalid.js
+++ b/src/test/moment/invalid.js
@@ -37,6 +37,8 @@ test('invalid operations', function (assert) {
         invalid,
         valid = moment();
 
+    test.expectedDeprecations('moment().min', 'moment().max');
+
     for (i = 0; i < invalids.length; ++i) {
         invalid = invalids[i];
 

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -139,10 +139,12 @@ test('library localeData', function (assert) {
 });
 
 test('library deprecations', function (assert) {
+    test.expectedDeprecations('moment.lang');
     moment.lang('dude', {months: ['Movember']});
     assert.equal(moment.locale(), 'dude', 'setting the lang sets the locale');
     assert.equal(moment.lang(), moment.locale());
     assert.equal(moment.langData(), moment.localeData(), 'langData is localeData');
+    moment.defineLocale('dude', null);
 });
 
 test('defineLocale', function (assert) {
@@ -150,18 +152,21 @@ test('defineLocale', function (assert) {
     moment.defineLocale('dude', {months: ['Movember']});
     assert.equal(moment().locale(), 'dude', 'defineLocale also sets it');
     assert.equal(moment().locale('dude').locale(), 'dude', 'defineLocale defines a locale');
+    moment.defineLocale('dude', null);
 });
 
 test('locales', function (assert) {
     moment.defineLocale('dude', {months: ['Movember']});
     assert.equal(true, !!~moment.locales().indexOf('dude'), 'locales returns an array of defined locales');
     assert.equal(true, !!~moment.locales().indexOf('en'), 'locales should always include english');
+    moment.defineLocale('dude', null);
 });
 
 test('library convenience', function (assert) {
     moment.locale('something', {week: {dow: 3}});
     moment.locale('something');
     assert.equal(moment.locale(), 'something', 'locale can be used to create the locale too');
+    moment.defineLocale('something', null);
 });
 
 test('firstDayOfWeek firstDayOfYear locale getters', function (assert) {
@@ -169,6 +174,7 @@ test('firstDayOfWeek firstDayOfYear locale getters', function (assert) {
     moment.locale('something');
     assert.equal(moment.localeData().firstDayOfWeek(), 3, 'firstDayOfWeek');
     assert.equal(moment.localeData().firstDayOfYear(), 4, 'firstDayOfYear');
+    moment.defineLocale('something', null);
 });
 
 test('instance locale method', function (assert) {
@@ -239,6 +245,7 @@ test('changing the global locale doesn\'t affect existing duration instances', f
 });
 
 test('duration deprecations', function (assert) {
+    test.expectedDeprecations('moment().lang()');
     assert.equal(moment.duration().lang(), moment.duration().localeData(), 'duration.lang is the same as duration.localeData');
 });
 
@@ -330,6 +337,7 @@ test('instance locale used with from', function (assert) {
 test('instance localeData', function (assert) {
     moment.defineLocale('dude', {week: {dow: 3}});
     assert.equal(moment().locale('dude').localeData()._week.dow, 3);
+    moment.defineLocale('dude', null);
 });
 
 test('month name callback function', function (assert) {
@@ -357,6 +365,8 @@ test('month name callback function', function (assert) {
 });
 
 test('changing parts of a locale config', function (assert) {
+    test.expectedDeprecations('defineLocaleOverride');
+
     moment.locale('partial-lang', {
         months : 'a b c d e f g h i j k l'.split(' ')
     });
@@ -368,6 +378,8 @@ test('changing parts of a locale config', function (assert) {
     });
 
     assert.equal(moment([2011, 0, 1]).format('MMMM MMM'), 'a A', 'should be able to set locale values after creating the localeuage');
+
+    moment.defineLocale('partial-lang', null);
 });
 
 test('start/endOf week feature for first-day-is-monday locales', function (assert) {
@@ -380,6 +392,7 @@ test('start/endOf week feature for first-day-is-monday locales', function (asser
     moment.locale('monday-lang');
     assert.equal(moment([2013, 0, 1]).startOf('week').day(), 1, 'for locale monday-lang first day of the week should be monday');
     assert.equal(moment([2013, 0, 1]).endOf('week').day(), 0, 'for locale monday-lang last day of the week should be sunday');
+    moment.defineLocale('monday-lang', null);
 });
 
 test('meridiem parsing', function (assert) {
@@ -393,6 +406,7 @@ test('meridiem parsing', function (assert) {
     moment.locale('meridiem-parsing');
     assert.equal(moment('2012-01-01 3b', 'YYYY-MM-DD ha').hour(), 15, 'Custom parsing of meridiem should work');
     assert.equal(moment('2012-01-01 3d', 'YYYY-MM-DD ha').hour(), 3, 'Custom parsing of meridiem should work');
+    moment.defineLocale('meridiem-parsing', null);
 });
 
 test('invalid date formatting', function (assert) {
@@ -402,12 +416,14 @@ test('invalid date formatting', function (assert) {
 
     assert.equal(moment.invalid().format(), 'KHAAAAAAAAAAAN!');
     assert.equal(moment.invalid().format('YYYY-MM-DD'), 'KHAAAAAAAAAAAN!');
+    moment.defineLocale('has-invalid', null);
 });
 
 test('return locale name', function (assert) {
     var registered = moment.locale('return-this', {});
 
     assert.equal(registered, 'return-this', 'returns the locale configured');
+    moment.locale('return-this', null);
 });
 
 test('changing the global locale doesn\'t affect existing instances', function (assert) {
@@ -417,6 +433,7 @@ test('changing the global locale doesn\'t affect existing instances', function (
 });
 
 test('setting a language on instance returns the original moment for chaining', function (assert) {
+    test.expectedDeprecations('moment().lang()');
     var mom = moment();
 
     assert.equal(mom.lang('fr'), mom, 'setting the language (lang) returns the original moment for chaining');
@@ -424,6 +441,7 @@ test('setting a language on instance returns the original moment for chaining', 
 });
 
 test('lang(key) changes the language of the instance', function (assert) {
+    test.expectedDeprecations('moment().lang()');
     var m = moment().month(0);
     m.lang('fr');
     assert.equal(m.locale(), 'fr', 'm.lang(key) changes instance locale');
@@ -447,6 +465,7 @@ test('moment().locale with missing key doesn\'t change locale', function (assert
 });
 
 test('moment().lang with missing key doesn\'t change locale', function (assert) {
+    test.expectedDeprecations('moment().lang()');
     assert.equal(moment().lang('boo').localeData(), moment.localeData(),
             'preserve global locale in case of bad locale id');
 });

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -110,8 +110,7 @@ test('ordinal', function (assert) {
     moment.defineLocale('ordinal-2', {
         ordinal : '%dx'
     });
-    moment.defineLocale('ordinal-2', {
-        parentLocale: 'ordinal-2',
+    moment.updateLocale('ordinal-2', {
         ordinal : function (num) {
             return num + 'y';
         }

--- a/src/test/moment/preparse_postformat.js
+++ b/src/test/moment/preparse_postformat.js
@@ -41,6 +41,9 @@ module('preparse and postformat', {
                 });
             }
         });
+    },
+    teardown: function () {
+        moment.defineLocale('symbol', null);
     }
 });
 

--- a/src/test/moment/utc.js
+++ b/src/test/moment/utc.js
@@ -13,7 +13,7 @@ test('utc and local', function (assert) {
 
     // local
     m.local();
-    if (m.zone() > 180) {
+    if (m.utcOffset() < -180) {
         assert.equal(m.date(), 1, 'the date should be correct for local');
         assert.equal(m.day(), 2, 'the day should be correct for local');
     } else {

--- a/src/test/moment/week_year.js
+++ b/src/test/moment/week_year.js
@@ -66,16 +66,18 @@ test('week year', function (assert) {
 
 // Verifies that the week number, week day computation is correct for all dow, doy combinations
 test('week year roundtrip', function (assert) {
-    var dow, doy, wd, m;
+    var dow, doy, wd, m, localeName;
     for (dow = 0; dow < 7; ++dow) {
         for (doy = dow; doy < dow + 7; ++doy) {
             for (wd = 0; wd < 7; ++wd) {
-                moment.locale('dow: ' + dow + ', doy: ' + doy, {week: {dow: dow, doy: doy}});
+                localeName = 'dow: ' + dow + ', doy: ' + doy;
+                moment.locale(localeName, {week: {dow: dow, doy: doy}});
                 // We use the 10th week as the 1st one can spill to the previous year
                 m = moment('2015 10 ' + wd, 'gggg w d', true);
                 assert.equal(m.format('gggg w d'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
                 m = moment('2015 10 ' + wd, 'gggg w e', true);
                 assert.equal(m.format('gggg w e'), '2015 10 ' + wd, 'dow: ' + dow + ' doy: ' + doy + ' wd: ' + wd);
+                moment.defineLocale(localeName, null);
             }
         }
     }
@@ -90,6 +92,7 @@ test('week numbers 2012/2013', function (assert) {
     assert.equal(2, moment('2013-01-11', 'YYYY-MM-DD').week(), '2013-01-11 is week 2'); // 53 -- should be 2
     assert.equal(3, moment('2013-01-12', 'YYYY-MM-DD').week(), '2013-01-12 is week 3'); // 1 -- should be 3
     assert.equal(52, moment('2012-01-01', 'YYYY-MM-DD').weeksInYear(), 'weeks in 2012 are 52'); // 52
+    moment.defineLocale('dow: 6, doy: 12', null);
 });
 
 test('weeks numbers dow:1 doy:4', function (assert) {
@@ -134,6 +137,7 @@ test('weeks numbers dow:1 doy:4', function (assert) {
     assert.equal(moment([2011,  0,  3]).week(),  1, 'Jan  3 2011 should be week 1');
     assert.equal(moment([2011,  0,  9]).week(),  1, 'Jan  9 2011 should be week 1');
     assert.equal(moment([2011,  0, 10]).week(),  2, 'Jan 10 2011 should be week 2');
+    moment.defineLocale('dow: 1, doy: 4', null);
 });
 
 test('weeks numbers dow:6 doy:12', function (assert) {
@@ -176,6 +180,7 @@ test('weeks numbers dow:6 doy:12', function (assert) {
     assert.equal(moment([2011, 0,  8]).week(), 2, 'Jan  8 2011 should be week 2');
     assert.equal(moment([2011, 0, 14]).week(), 2, 'Jan 14 2011 should be week 2');
     assert.equal(moment([2011, 0, 15]).week(), 3, 'Jan 15 2011 should be week 3');
+    moment.defineLocale('dow: 6, doy: 12', null);
 });
 
 test('weeks numbers dow:1 doy:7', function (assert) {
@@ -220,6 +225,7 @@ test('weeks numbers dow:1 doy:7', function (assert) {
     assert.equal(moment([2011,  0,  3]).week(), 2, 'Jan  3 2011 should be week 2');
     assert.equal(moment([2011,  0,  9]).week(), 2, 'Jan  9 2011 should be week 2');
     assert.equal(moment([2011,  0, 10]).week(), 3, 'Jan 10 2011 should be week 3');
+    moment.defineLocale('dow: 1, doy: 7', null);
 });
 
 test('weeks numbers dow:0 doy:6', function (assert) {
@@ -264,6 +270,7 @@ test('weeks numbers dow:0 doy:6', function (assert) {
     assert.equal(moment([2011,  0,  2]).week(), 2, 'Jan  2 2011 should be week 2');
     assert.equal(moment([2011,  0,  8]).week(), 2, 'Jan  8 2011 should be week 2');
     assert.equal(moment([2011,  0,  9]).week(), 3, 'Jan  9 2011 should be week 3');
+    moment.defineLocale('dow: 0, doy: 6', null);
 });
 
 test('week year overflows', function (assert) {

--- a/src/test/moment/zone_switching.js
+++ b/src/test/moment/zone_switching.js
@@ -17,6 +17,7 @@ test('local to utc, keepLocalTime = false', function (assert) {
 });
 
 test('local to zone, keepLocalTime = true', function (assert) {
+    test.expectedDeprecations('moment().zone');
     var m = moment(),
         fmt = 'YYYY-DD-MM HH:mm:ss',
         z;
@@ -31,6 +32,7 @@ test('local to zone, keepLocalTime = true', function (assert) {
 });
 
 test('local to zone, keepLocalTime = false', function (assert) {
+    test.expectedDeprecations('moment().zone');
     var m = moment(),
         z;
 
@@ -65,6 +67,7 @@ test('utc to local, keepLocalTime = false', function (assert) {
 });
 
 test('zone to local, keepLocalTime = true', function (assert) {
+    test.expectedDeprecations('moment().zone');
     // Don't test near the spring DST transition
     if (isNearSpringDST()) {
         expect(0);
@@ -87,6 +90,7 @@ test('zone to local, keepLocalTime = true', function (assert) {
 });
 
 test('zone to local, keepLocalTime = false', function (assert) {
+    test.expectedDeprecations('moment().zone');
     var m = moment(),
         z;
 

--- a/src/test/moment/zones.js
+++ b/src/test/moment/zones.js
@@ -1,7 +1,11 @@
 import { module, test } from '../qunit';
 import moment from '../../moment';
 
-module('zones');
+module('zones', {
+    'setup': function () {
+        test.expectedDeprecations('moment().zone');
+    }
+});
 
 test('set zone', function (assert) {
     var zone = moment();
@@ -360,6 +364,7 @@ test('isDST', function (assert) {
 });
 
 test('zone names', function (assert) {
+    test.expectedDeprecations();
     assert.equal(moment().zoneAbbr(),   '', 'Local zone abbr should be empty');
     assert.equal(moment().format('z'),  '', 'Local zone formatted abbr should be empty');
     assert.equal(moment().zoneName(),   '', 'Local zone name should be empty');
@@ -422,6 +427,7 @@ test('parse zone static', function (assert) {
 });
 
 test('parse zone with more arguments', function (assert) {
+    test.expectedDeprecations();
     var m;
     m = moment.parseZone('2013 01 01 05 -13:00', 'YYYY MM DD HH ZZ');
     assert.equal(m.format(), '2013-01-01T05:00:00-13:00', 'accept input and format');

--- a/src/test/qunit.js
+++ b/src/test/qunit.js
@@ -2,6 +2,7 @@
 
 import moment from '../moment';
 import { defineCommonLocaleTests } from './helpers/common-locale';
+import { setupDeprecationHandler, teardownDeprecationHandler } from './helpers/deprecation-handler';
 
 export var test = QUnit.test;
 
@@ -14,11 +15,13 @@ export function module (name, lifecycle) {
             moment.createFromInputFallback = function (config) {
                 throw new Error('input not handled by moment: ' + config._i);
             };
+            setupDeprecationHandler(test, moment, 'core');
             if (lifecycle && lifecycle.setup) {
                 lifecycle.setup();
             }
         },
         teardown : function () {
+            teardownDeprecationHandler(test, moment, 'core');
             if (lifecycle && lifecycle.teardown) {
                 lifecycle.teardown();
             }
@@ -33,12 +36,14 @@ export function localeModule (name, lifecycle) {
             moment.createFromInputFallback = function (config) {
                 throw new Error('input not handled by moment: ' + config._i);
             };
+            setupDeprecationHandler(test, moment, 'locale');
             if (lifecycle && lifecycle.setup) {
                 lifecycle.setup();
             }
         },
         teardown : function () {
             moment.locale('en');
+            teardownDeprecationHandler(test, moment, 'locale');
             if (lifecycle && lifecycle.teardown) {
                 lifecycle.teardown();
             }


### PR DESCRIPTION
Instead of printing random warnings when running tests (now), check what deprecations is the tested code supposed to throw, and only raise an exception if there is a mismatch.

Fixes #2719
Obsoletes: #3012 