### PR TITLE
Use relative AMD moment dependency

### DIFF
--- a/templates/locale-header.js
+++ b/templates/locale-header.js
@@ -1,6 +1,6 @@
 ;(function (global, factory) {
    typeof exports === 'object' && typeof module !== 'undefined'
        && typeof require === 'function' ? factory(require('../moment')) :
-   typeof define === 'function' && define.amd ? define(['moment'], factory) :
+   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
    factory(global.moment)
 }(this, function (moment) { 'use strict';


### PR DESCRIPTION
Use a relative AMD dependency so that it's not required to have the `main` defined for the `moment` package.