### PR TITLE
Update norwegian locale

### DIFF
--- a/locale/nb.js
+++ b/locale/nb.js
@@ -35,7 +35,7 @@
         },
         relativeTime : {
             future : 'om %s',
-            past : '%s siden',
+            past : 'for %s siden',
             s : 'noen sekunder',
             m : 'ett minutt',
             mm : '%d minutter',

--- a/locale/nb.js
+++ b/locale/nb.js
@@ -35,7 +35,7 @@
         },
         relativeTime : {
             future : 'om %s',
-            past : 'for %s siden',
+            past : '%s siden',
             s : 'noen sekunder',
             m : 'ett minutt',
             mm : '%d minutter',

--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -29,7 +29,7 @@ export default moment.defineLocale('nb', {
     },
     relativeTime : {
         future : 'om %s',
-        past : 'for %s siden',
+        past : '%s siden',
         s : 'noen sekunder',
         m : 'ett minutt',
         mm : '%d minutter',

--- a/src/locale/nn.js
+++ b/src/locale/nn.js
@@ -28,7 +28,7 @@ export default moment.defineLocale('nn', {
     },
     relativeTime : {
         future : 'om %s',
-        past : 'for %s sidan',
+        past : '%s sidan',
         s : 'nokre sekund',
         m : 'eit minutt',
         mm : '%d minutt',

--- a/src/test/locale/nb.js
+++ b/src/test/locale/nb.js
@@ -139,11 +139,11 @@ test('from', function (assert) {
 
 test('suffix', function (assert) {
     assert.equal(moment(30000).from(0), 'om noen sekunder',  'prefix');
-    assert.equal(moment(0).from(30000), 'for noen sekunder siden', 'suffix');
+    assert.equal(moment(0).from(30000), 'noen sekunder siden', 'suffix');
 });
 
 test('now from now', function (assert) {
-    assert.equal(moment().fromNow(), 'for noen sekunder siden',  'now from now should display as in the past');
+    assert.equal(moment().fromNow(), 'noen sekunder siden',  'now from now should display as in the past');
 });
 
 test('fromNow', function (assert) {

--- a/src/test/locale/nn.js
+++ b/src/test/locale/nn.js
@@ -138,11 +138,11 @@ test('from', function (assert) {
 
 test('suffix', function (assert) {
     assert.equal(moment(30000).from(0), 'om nokre sekund',  'prefix');
-    assert.equal(moment(0).from(30000), 'for nokre sekund sidan', 'suffix');
+    assert.equal(moment(0).from(30000), 'nokre sekund sidan', 'suffix');
 });
 
 test('now from now', function (assert) {
-    assert.equal(moment().fromNow(), 'for nokre sekund sidan',  'now from now should display as in the past');
+    assert.equal(moment().fromNow(), 'nokre sekund sidan',  'now from now should display as in the past');
 });
 
 test('fromNow', function (assert) {


### PR DESCRIPTION
The "for" is not needed for the sentence to make sense in Norwegian, and this will give the developer the chance to omit the "for" if wanted. This is also more consistent compared to the other locales in this repository.