### PR TITLE
deps: peg grunt to ~0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "devDependencies": {
         "uglify-js": "latest",
         "es6-promise": "latest",
-        "grunt": "latest",
+        "grunt": "~0.4",
         "grunt-cli": "latest",
         "benchmark": "latest",
         "esperanto": "latest",


### PR DESCRIPTION
Dev deps cannot pass with grunt > 0.4

1.0 will fail without deps themselves updating. PEgging the grunt dep
ensures that npm install will work without error

fixes #3091