### PR TITLE
Add k and kk formatting tokens

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -1,6 +1,6 @@
 import zeroFill from '../utils/zero-fill';
 
-export var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
+export var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
 
 var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g;
 
@@ -89,4 +89,3 @@ export function expandFormat(format, locale) {
 
     return format;
 }
-

--- a/src/lib/units/hour.js
+++ b/src/lib/units/hour.js
@@ -14,8 +14,13 @@ function hFormat() {
     return this.hours() % 12 || 12;
 }
 
+function kFormat() {
+    return this.hours() || 24;
+}
+
 addFormatToken('H', ['HH', 2], 0, 'hour');
 addFormatToken('h', ['hh', 2], 0, hFormat);
+addFormatToken('k', ['kk', 2], 0, kFormat);
 
 addFormatToken('hmm', 0, 0, function () {
     return '' + hFormat.apply(this) + zeroFill(this.minutes(), 2);

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -418,6 +418,15 @@ test('Hmm and Hmmss', function (assert) {
     assert.equal(moment('18:34:56', 'HH:mm:ss').format('Hmmss'), '183456');
 });
 
+test('k and kk', function (assert) {
+    assert.equal(moment('01:23:45', 'HH:mm:ss').format('k'), '1');
+    assert.equal(moment('12:34:56', 'HH:mm:ss').format('k'), '12');
+    assert.equal(moment('01:23:45', 'HH:mm:ss').format('kk'), '01');
+    assert.equal(moment('12:34:56', 'HH:mm:ss').format('kk'), '12');
+    assert.equal(moment('00:34:56', 'HH:mm:ss').format('kk'), '24');
+    assert.equal(moment('00:00:00', 'HH:mm:ss').format('kk'), '24');
+});
+
 test('Y token', function (assert) {
     assert.equal(moment('2010-01-01', 'YYYY-MM-DD', true).format('Y'), '2010', 'format 2010 with Y');
     assert.equal(moment('-123-01-01', 'Y-MM-DD', true).format('Y'), '-123', 'format -123 with Y');


### PR DESCRIPTION
This fixes issue #2762.

The consensus from that issue seemed to be that the presence of the `kk` token should not modify the value of other tokens, so that is the behavior that is implemented here.

It should be noted that this decision introduces a bit of an inconsistency, given that the parsing behavior introduced [here](/moment/moment/pull/1965) does change the day when an hour of 24 is present.

In other words,

```js
moment('2016-04-09T24:00:00')
// yields a moment representing midnight at the start of April 10th, introduced in #1965

moment('2016-04-09T24:00:00').format('YYYY-MM-DD[T]kk:mm:ss')
// "2016-04-10T24:00:00" (different from the original format string that was parsed)
```

---

I'm not extremely familiar with the internal codebase, so please let me know if there's anything that I did incorrectly or that I should add.