### PR TITLE
Locale-aware moment.weekdays issue #2927

### DIFF
--- a/src/lib/locale/lists.js
+++ b/src/lib/locale/lists.js
@@ -27,7 +27,7 @@ function list (format, index, field, count, setter) {
     return out;
 }
 
-// shift the list according to the first day of week from locale data 
+// shift the list according to the first day of week from locale data
 function listLocaleWeekdays (format, index, field, count, setter) {
     if (typeof format === 'boolean' && format) {
         var weekdaysList = list(format, null, field, count, setter);
@@ -54,7 +54,7 @@ export function listMonthsShort (format, index) {
 }
 
 // listWeekdays(true) to sort the list by the first day of week from locale data
-// listWeekdays(true, NUMBER) to get the #NUMBER element in sorted list 
+// listWeekdays(true, NUMBER) to get the #NUMBER element in sorted list
 export function listWeekdays (format, index) {
     return listLocaleWeekdays(format, index, 'weekdays', 7, 'day');
 }

--- a/src/lib/locale/lists.js
+++ b/src/lib/locale/lists.js
@@ -27,6 +27,24 @@ function list (format, index, field, count, setter) {
     return out;
 }
 
+// shift the list according to the first day of week from locale data 
+function listLocaleWeekdays (format, index, field, count, setter) {
+    if (typeof format === 'boolean' && format) {
+        var weekdaysList = list(format, null, field, count, setter);
+        var locale = getLocale();
+        var firstDayOfWeek = locale._week.dow;
+        var i;
+        for (i = 0; i < firstDayOfWeek; i++) {
+            weekdaysList.push(weekdaysList.shift());
+        }
+        if (typeof index === 'number') {
+            return weekdaysList[index];
+        }
+        return weekdaysList;
+    }
+    return list(format, index, field, count, setter);
+}
+
 export function listMonths (format, index) {
     return list(format, index, 'months', 12, 'month');
 }
@@ -35,14 +53,18 @@ export function listMonthsShort (format, index) {
     return list(format, index, 'monthsShort', 12, 'month');
 }
 
+// listWeekdays(true) to sort the list by the first day of week from locale data
+// listWeekdays(true, NUMBER) to get the #NUMBER element in sorted list 
 export function listWeekdays (format, index) {
-    return list(format, index, 'weekdays', 7, 'day');
+    return listLocaleWeekdays(format, index, 'weekdays', 7, 'day');
 }
 
+// similar as listWeekdays()
 export function listWeekdaysShort (format, index) {
-    return list(format, index, 'weekdaysShort', 7, 'day');
+    return listLocaleWeekdays(format, index, 'weekdaysShort', 7, 'day');
 }
 
+// similar as listWeekdays()
 export function listWeekdaysMin (format, index) {
-    return list(format, index, 'weekdaysMin', 7, 'day');
+    return listLocaleWeekdays(format, index, 'weekdaysMin', 7, 'day');
 }

--- a/src/test/moment/listers.js
+++ b/src/test/moment/listers.js
@@ -35,7 +35,7 @@ test('localized', function (assert) {
         weekdaysMinLocale = '4_5_6_7_1_2_3'.split('_'),
         week = {
             dow : 3,
-            doy : 6  
+            doy : 6
         };
 
     moment.locale('numerologists', {
@@ -76,7 +76,6 @@ test('localized', function (assert) {
     assert.equal(moment.weekdays(true, 2), 'six');
     assert.equal(moment.weekdaysShort(true, 2), 'si');
     assert.equal(moment.weekdaysMin(true, 2), '6');
-
 });
 
 test('with functions', function (assert) {

--- a/src/test/moment/listers.js
+++ b/src/test/moment/listers.js
@@ -29,14 +29,22 @@ test('localized', function (assert) {
         monthsShort = 'on_tw_th_fo_fi_si_se_ei_ni_te_el_tw'.split('_'),
         weekdays = 'one_two_three_four_five_six_seven'.split('_'),
         weekdaysShort = 'on_tw_th_fo_fi_si_se'.split('_'),
-        weekdaysMin = '1_2_3_4_5_6_7'.split('_');
+        weekdaysMin = '1_2_3_4_5_6_7'.split('_'),
+        weekdaysLocale = 'four_five_six_seven_one_two_three'.split('_'),
+        weekdaysShortLocale = 'fo_fi_si_se_on_tw_th'.split('_'),
+        weekdaysMinLocale = '4_5_6_7_1_2_3'.split('_'),
+        week = {
+            dow : 3,
+            doy : 6  
+        };
 
     moment.locale('numerologists', {
         months : months,
         monthsShort : monthsShort,
         weekdays : weekdays,
         weekdaysShort: weekdaysShort,
-        weekdaysMin: weekdaysMin
+        weekdaysMin: weekdaysMin,
+        week : week
     });
 
     assert.deepEqual(moment.months(), months);
@@ -56,6 +64,19 @@ test('localized', function (assert) {
     assert.equal(moment.weekdays(2), 'three');
     assert.equal(moment.weekdaysShort(2), 'th');
     assert.equal(moment.weekdaysMin(2), '3');
+
+    assert.deepEqual(moment.weekdays(true), weekdaysLocale);
+    assert.deepEqual(moment.weekdaysShort(true), weekdaysShortLocale);
+    assert.deepEqual(moment.weekdaysMin(true), weekdaysMinLocale);
+
+    assert.equal(moment.weekdays(true, 0), 'four');
+    assert.equal(moment.weekdaysShort(true, 0), 'fo');
+    assert.equal(moment.weekdaysMin(true, 0), '4');
+
+    assert.equal(moment.weekdays(true, 2), 'six');
+    assert.equal(moment.weekdaysShort(true, 2), 'si');
+    assert.equal(moment.weekdaysMin(true, 2), '6');
+
 });
 
 test('with functions', function (assert) {


### PR DESCRIPTION
fix issue #2927  
moment.weekdays(true) to sort list by the first day of week according to locale data
moment.weekdays(true, NUMBER) to get the #NUMBER day in sorted weekdayList
