### PR TITLE
Fix #1756 Resolved thread-safe issue on server side.

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -53,7 +53,7 @@ function makeFormatFunction(format) {
     }
 
     return function (mom) {
-        var output = '';
+        var output = '', i;
         for (i = 0; i < length; i++) {
             output += array[i] instanceof Function ? array[i].call(mom, format) : array[i];
         }


### PR DESCRIPTION
As mentioned in #1756, there is a thread-safe issue when we use Moment on the server side of the multi-threaded model (e.g. [Rhino](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino)).

I noticed the scope of  variable `i`  in `makeFormatFunction` function is too wide. The variable is shared in multiple threads. It causes unpredictable behavior.