### PR TITLE
#3085 Remove unexpected behavior when calling moment with an empty object

### DIFF
--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -90,7 +90,7 @@ export function createLocalOrUTC (input, format, locale, strict, isUTC) {
         locale = undefined;
     }
 
-    if (input !== null && !isDate(input)) {
+    if (input !== null && !isDate(input) && (!isUTC)) {
         if (isObject(input) || isArray(input)) {
             input = (Object.keys(input).length === 0 ? undefined : input);
         }

--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -88,6 +88,12 @@ export function createLocalOrUTC (input, format, locale, strict, isUTC) {
         strict = locale;
         locale = undefined;
     }
+
+    if (input !== null && typeof(input) === 'object' && (!isUTC)) {
+        if (Object.prototype.toString.call(input) !== '[object Date]') {
+            input = (Object.keys(input).length === 0 ? undefined : input);
+        }
+    }
     // object construction must be done this way.
     // https://github.com/moment/moment/issues/1423
     c._isAMomentObject = true;

--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -1,4 +1,5 @@
 import isArray from '../utils/is-array';
+import isObject from '../utils/is-object.js';
 import isDate from '../utils/is-date';
 import map from '../utils/map';
 import { createInvalid } from './valid';
@@ -89,8 +90,8 @@ export function createLocalOrUTC (input, format, locale, strict, isUTC) {
         locale = undefined;
     }
 
-    if (input !== null && typeof(input) === 'object' && (!isUTC)) {
-        if (Object.prototype.toString.call(input) !== '[object Date]') {
+    if (input !== null && !isDate(input)) {
+        if (isObject(input) || isArray(input)) {
             input = (Object.keys(input).length === 0 ? undefined : input);
         }
     }

--- a/src/test/moment/now.js
+++ b/src/test/moment/now.js
@@ -48,28 +48,17 @@ test('now - custom value', function (assert) {
 
     try {
         assert.ok(moment().toISOString() === customTimeStr, 'moment() constructor should use the function defined by moment.now, but it did not');
+        assert.ok(moment({}).format() === moment().format(), 'moment({}).format() should return same string as calling moment().format(), but it did not');
+        assert.ok(moment([]).format() === moment().format(), 'moment([]).format() should return same string as calling moment().format(), but it did not');
+        assert.ok(moment({}).toISOString() === customTimeStr, 'moment({}).toISOString() should return same string as calling moment().toISOString(), but it did not');
+        assert.ok(moment([]).toISOString() === customTimeStr, 'moment([]).toISOString() should return same string as calling moment().toISOString(), but it did not');
+        assert.ok(moment({}).utc().format() === moment().utc().format(), 'moment({}).utc().format() should return same string as calling moment().utc().format, but it did not');
+        assert.ok(moment([]).utc().format() === moment().utc().format(), 'moment([]).utc().format() should return same string as calling moment().utc().format, but it did not');
+        assert.ok(moment({}).utc().toISOString() === customTimeStr, 'moment({}).utc().toISOString() should return same string as calling moment().utc().toISOString(), but it did not');
+        assert.ok(moment([]).utc().toISOString() === customTimeStr, 'moment([]).utc().toISOString() should return same string as calling moment().utc().toISOString(), but it did not');
         assert.ok(moment.utc().toISOString() === customTimeStr, 'moment() constructor should use the function defined by moment.now, but it did not');
+        assert.ok(moment.utc([]).toISOString() === '2015-01-01T00:00:00.000Z', 'moment() constructor should fall back to the date defined by moment.now when an empty array is given, but it did not');
     } finally {
         moment.now = oldFn;
     }
-});
-
-test('now - empty object', function (assert) {
-    var defaultNowTime = moment.now(),
-        defaultUtcTime = moment.utc(),
-        emptyObjNowTime = moment.now({}),
-        emptyObjUtcTime = moment.utc({});
-
-    assert.ok(Math.abs(defaultNowTime - emptyObjNowTime) <= 1, 'moment.now({}) should give the same result as calling moment.now(), but it did not');
-    assert.ok(Math.abs(defaultUtcTime - emptyObjUtcTime) <= 1, 'moment.utc({}) should give the same result as calling moment.utc(), but it did not');
-});
-
-test('now - empty array', function (assert) {
-    var defaultNowTime = moment.now(),
-        defaultUtcTime = moment.utc(),
-        emptyArrNowTime = moment.now([]),
-        emptyArrUtcTime = moment.utc([]);
-
-    assert.ok(Math.abs(defaultNowTime - emptyArrNowTime) <= 1, 'moment.now([]) should give the same result as calling moment.now(), but it did not');
-    assert.ok(Math.abs(defaultUtcTime - emptyArrUtcTime) <= 1, 'moment.utc([]) should give the same result as calling moment.utc(), but it did not');
 });

--- a/src/test/moment/now.js
+++ b/src/test/moment/now.js
@@ -49,8 +49,27 @@ test('now - custom value', function (assert) {
     try {
         assert.ok(moment().toISOString() === customTimeStr, 'moment() constructor should use the function defined by moment.now, but it did not');
         assert.ok(moment.utc().toISOString() === customTimeStr, 'moment() constructor should use the function defined by moment.now, but it did not');
-        assert.ok(moment.utc([]).toISOString() === '2015-01-01T00:00:00.000Z', 'moment() constructor should fall back to the date defined by moment.now when an empty array is given, but it did not');
     } finally {
         moment.now = oldFn;
     }
+});
+
+test('now - empty object', function (assert) {
+    var defaultNowTime = moment.now(),
+        defaultUtcTime = moment.utc(),
+        emptyObjNowTime = moment.now({}),
+        emptyObjUtcTime = moment.utc({});
+
+    assert.ok(Math.abs(defaultNowTime - emptyObjNowTime) <= 1, 'moment.now({}) should give the same result as calling moment.now(), but it did not');
+    assert.ok(Math.abs(defaultUtcTime - emptyObjUtcTime) <= 1, 'moment.utc({}) should give the same result as calling moment.utc(), but it did not');
+});
+
+test('now - empty array', function (assert) {
+    var defaultNowTime = moment.now(),
+        defaultUtcTime = moment.utc(),
+        emptyArrNowTime = moment.now([]),
+        emptyArrUtcTime = moment.utc([]);
+
+    assert.ok(Math.abs(defaultNowTime - emptyArrNowTime) <= 1, 'moment.now([]) should give the same result as calling moment.now(), but it did not');
+    assert.ok(Math.abs(defaultUtcTime - emptyArrUtcTime) <= 1, 'moment.utc([]) should give the same result as calling moment.utc(), but it did not');
 });


### PR DESCRIPTION
As mentioned in #3085, calling `moment({})` or `moment([])` resulted in different behavior than calling `moment()`, which we agreed was unexpected behavior. By setting the input to the same as it would be as if no empty array or object was passed in, the behavior is more consistent.
