### PR TITLE
optimize configFromStringAndFormat

### DIFF
--- a/src/lib/create/from-string-and-format.js
+++ b/src/lib/create/from-string-and-format.js
@@ -65,9 +65,9 @@ export function configFromStringAndFormat(config) {
     }
 
     // clear _12h flag if hour is <= 12
-    if (getParsingFlags(config).bigHour === true &&
-            config._a[HOUR] <= 12 &&
-            config._a[HOUR] > 0) {
+    if (config._a[HOUR] <= 12 &&
+        getParsingFlags(config).bigHour === true &&
+        config._a[HOUR] > 0) {
         getParsingFlags(config).bigHour = undefined;
     }
     // handle meridiem


### PR DESCRIPTION
You might consider optimizing configFromStringAndFormat function by changing the order of tests in if statement in line 68. I ran all unit tests and found that the second check (config._a[HOUR] <= 12) is more often false comparing to the others, so by putting it in the first place the computation time in other tests can be saved most of the time.

So I found real performance benefit for two unit tests on V8 4.4 (I ran them with Benchmark.js library since jsperf is down). Both improvements are statistically significant.
![selection_014](https://cloud.githubusercontent.com/assets/7926726/14566859/96b99526-0331-11e6-9d8e-8c0217bc3287.png)

If you want to try tests, just download them from https://s3.eu-central-1.amazonaws.com/momenttests/testsMoment.zip

To run the tests, call:

> node run.js

Even though this is a simple change, it seems to improve performance without affecting the readability of the code.