### PR TITLE
Drop non-LTS node releases from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "iojs"
   - "node"
   - "0.12"
-  - "0.11"
   - "0.10"
 sudo: false
 


### PR DESCRIPTION
Per: https://github.com/nodejs/LTS