### PR TITLE
Fix locale set

### DIFF
--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -10,6 +10,9 @@ export function set (config) {
         if (isFunction(prop)) {
             this[i] = prop;
         } else {
+            if (typeof prop === 'object') {
+                extend(this[i], prop);
+            }
             this['_' + i] = prop;
         }
     }


### PR DESCRIPTION
I have a locale config worked fine in v2.10.6.
But when I updated moment to v2.13, I got a issue on it.

There are my code snippets:

```
moment.locale('zh', {
    ...
    week: {
      dow: 1 // Monday is the first day of the week.
    }
   ...
});
moment.locale('zh')
```

It would got an NaN when I called `moment().format('wo')`

And I found moment lost some default config when get a Locale config.