### PR TITLE
Call calendar format function with moment context

### DIFF
--- a/src/lib/moment/calendar.js
+++ b/src/lib/moment/calendar.js
@@ -15,7 +15,7 @@ export function calendar (time, formats) {
             diff < 2 ? 'nextDay' :
             diff < 7 ? 'nextWeek' : 'sameElse';
 
-    var output = formats && (isFunction(formats[format]) ? formats[format]() : formats[format]);
+    var output = formats && (isFunction(formats[format]) ? formats[format].call(this, now) : formats[format]);
 
     return this.format(output || this.localeData().calendar(format, this, createLocal(now)));
 }


### PR DESCRIPTION
What: the code:
```
moment().days(-1000).calendar(null, {
   sameElse: function() {
       return '[hoy a la' + ((this.hours() !== 1) ? 's' : '') + '] LT';
   }
});
```
Where: on http://momentjs.com/docs/#/displaying/calendar-time/ in the Chrome console.
What I got: It raises `Uncaught TypeError: this.hours is not a function`

I expected use callback like in the example on http://momentjs.com/docs/#/customization/calendar/ .

This PR makes the compatible call with https://github.com/moment/moment/blob/develop/src/lib/locale/calendar.js#L14