### PR TITLE
deprecate isDSTShifted

### DIFF
--- a/src/lib/moment/prototype.js
+++ b/src/lib/moment/prototype.js
@@ -128,7 +128,6 @@ proto.local                = setOffsetToLocal;
 proto.parseZone            = setOffsetToParsedOffset;
 proto.hasAlignedHourOffset = hasAlignedHourOffset;
 proto.isDST                = isDaylightSavingTime;
-proto.isDSTShifted         = isDaylightSavingTimeShifted;
 proto.isLocal              = isLocal;
 proto.isUtcOffset          = isUtcOffset;
 proto.isUtc                = isUtc;
@@ -145,5 +144,6 @@ proto.dates  = deprecate('dates accessor is deprecated. Use date instead.', getS
 proto.months = deprecate('months accessor is deprecated. Use month instead', getSetMonth);
 proto.years  = deprecate('years accessor is deprecated. Use year instead', getSetYear);
 proto.zone   = deprecate('moment().zone is deprecated, use moment().utcOffset instead. https://github.com/moment/moment/issues/1779', getSetZone);
+proto.isDSTShifted = deprecate('isDSTShifted is deprecated. See http://momentjs.com/guides/#/warnings/dst-shifted/ for more information', isDaylightSavingTimeShifted);
 
 export default proto;

--- a/src/test/moment/invalid.js
+++ b/src/test/moment/invalid.js
@@ -37,7 +37,7 @@ test('invalid operations', function (assert) {
         invalid,
         valid = moment();
 
-    test.expectedDeprecations('moment().min', 'moment().max');
+    test.expectedDeprecations('moment().min', 'moment().max', 'isDSTShifted');
 
     for (i = 0; i < invalids.length; ++i) {
         invalid = invalids[i];


### PR DESCRIPTION
Not sure if the group will agree on this one, but I think we should just deprecate isDSTShifted.

It doesn't work for moments that have been mutated (#2942), it doesn't work with moments using moment timezone (moment/moment-timezone#131), because it relies on browser behavior, it can't be  unit tested, and it's confusing: http://stackoverflow.com/questions/36939900/moment-timezone-utc-offset-difference

IIRC @mj1856  and I have both looked at this function and tried to come up with a way to fix it. I think we both concluded that due to issues with overflow, it wasn't really feasible. Or maybe Matt looked at something else related to DST - I'm not sure.

It's possible there's a way to fix it, I'm open to suggestion. But if nobody is going to fix it, and it doesn't work, it doesn't make sense to keep it.

I know I added a link to a webpage that doesn't exist in that deprecation warning. If we decide to merge this I'll update docs.