### PR TITLE
Bug Fix #2704 - isoWeekday(String) inconsistent with isoWeekday(Number)

### DIFF
--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -82,6 +82,19 @@ function parseWeekday(input, locale) {
     return null;
 }
 
+function parseIsoWeekday(input, locale) {
+    if (typeof input !== 'string' || !isNaN(input)) {
+        return parseWeekday(input, locale);
+    }
+
+    input = locale.weekdaysParse(input);
+    if (typeof input === 'number') {
+        return input % 7 ? input : input + 7;
+    }
+
+    return null;
+}
+
 // LOCALES
 
 export var defaultLocaleWeekdays = 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_');
@@ -231,10 +244,17 @@ export function getSetISODayOfWeek (input) {
     if (!this.isValid()) {
         return input != null ? this : NaN;
     }
+
     // behaves the same as moment#day except
     // as a getter, returns 7 instead of 0 (1-7 range instead of 0-6)
     // as a setter, sunday should belong to the previous week.
-    return input == null ? this.day() || 7 : this.day(this.day() % 7 ? input : input - 7);
+
+    if (input != null) {
+        var weekday = parseIsoWeekday(input, this.localeData());
+        return this.day(this.day() % 7 ? weekday : weekday - 7);
+    } else {
+        return this.day() || 7;
+    }
 }
 
 export var defaultWeekdaysRegex = matchWord;

--- a/src/test/moment/weekday.js
+++ b/src/test/moment/weekday.js
@@ -53,6 +53,25 @@ test('iso weekday setter', function (assert) {
     assert.equal(moment(a).isoWeekday(14).date(), 23, 'set from sun to next sun');
 });
 
+test('iso weekday setter with day name', function (assert) {
+    moment.locale('en');
+
+    var a = moment([2011, 0, 10]);
+    assert.equal(moment(a).isoWeekday('Monday').date(),   10, 'set from mon to mon');
+    assert.equal(moment(a).isoWeekday('Thursday').date(), 13, 'set from mon to thu');
+    assert.equal(moment(a).isoWeekday('Sunday').date(),   16, 'set from mon to sun');
+
+    a = moment([2011, 0, 13]);
+    assert.equal(moment(a).isoWeekday('Monday').date(),   10, 'set from thu to mon');
+    assert.equal(moment(a).isoWeekday('Thursday').date(), 13, 'set from thu to thu');
+    assert.equal(moment(a).isoWeekday('Sunday').date(),   16, 'set from thu to sun');
+
+    a = moment([2011, 0, 16]);
+    assert.equal(moment(a).isoWeekday('Monday').date(),   10, 'set from sun to mon');
+    assert.equal(moment(a).isoWeekday('Thursday').date(), 13, 'set from sun to thu');
+    assert.equal(moment(a).isoWeekday('Sunday').date(),   16, 'set from sun to sun');
+});
+
 test('weekday first day of week Sunday (dow 0)', function (assert) {
     moment.locale('dow: 0,doy: 6', {week: {dow: 0, doy: 6}});
     assert.equal(moment([1985, 1,  3]).weekday(), 0, 'Feb  3 1985 is Sunday    -- 0th day');


### PR DESCRIPTION
Bug fix for issue #2704 as requested by @mj1856 