### PR TITLE
toDate returns a copy of the internal date object

### DIFF
--- a/src/lib/moment/to-type.js
+++ b/src/lib/moment/to-type.js
@@ -7,7 +7,7 @@ export function unix () {
 }
 
 export function toDate () {
-    return this._offset ? new Date(this.valueOf()) : this._d;
+    return this._offset ? new Date(this.valueOf()) : new Date(this._d);
 }
 
 export function toArray () {

--- a/src/lib/moment/to-type.js
+++ b/src/lib/moment/to-type.js
@@ -7,7 +7,7 @@ export function unix () {
 }
 
 export function toDate () {
-    return this._offset ? new Date(this.valueOf()) : new Date(this._d);
+    return new Date(this.valueOf());
 }
 
 export function toArray () {

--- a/src/test/moment/to_type.js
+++ b/src/test/moment/to_type.js
@@ -20,3 +20,10 @@ test('toArray', function (assert) {
     var expected = [2014, 11, 26, 11, 46, 58, 17];
     assert.deepEqual(moment(expected).toArray(), expected, 'toArray invalid');
 });
+
+test('toDate returns a copy of the internal date', function (assert) {
+    var m = moment();
+    var d = m.toDate();
+    m.year(0);
+    assert.notEqual(d, m.toDate());
+});


### PR DESCRIPTION
moment#toDate currently returns the internal date object, which can lead to strange behaviour if the moment object is then modified. See [this fiddle for an example](https://jsfiddle.net/67uaf0zu/).