### PR TITLE
Adding support for rollup import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "ender"
     ],
     "main": "./moment.js",
+    "jsnext:main": "./src/moment.js",
     "typings": "./moment.d.ts",
     "engines": {
         "node": "*"


### PR DESCRIPTION
Rollup uses "jsnext:main" property in package.json for ES6 modules.