### PR TITLE
Temporarily fix jscs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "grunt-contrib-uglify": "latest",
         "grunt-contrib-watch": "latest",
         "grunt-env": "latest",
-        "grunt-jscs": "latest",
+        "grunt-jscs": "~2.7.0",
         "grunt-karma": "latest",
         "grunt-nuget": "latest",
         "grunt-benchmark": "latest",


### PR DESCRIPTION
JSCS dropped a major release three days ago that causes the build to break.

When I change the configuration that is breaking the build on my local machine, the build continues, but I get about a zillion code style errors. There must have been other breaking changes as well.

This fixes it temporarily by using the old package.

Based on what I'm seeing on the JSCS website, we should convert to ESLint, as it has been deprecated in favor of that anyways. See medium post: https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2#.u8qquoisi

For now though, someone needs to merge this so the build works.