### PR TITLE
fix passing date with format string to ignore format string

### DIFF
--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -43,11 +43,11 @@ export function prepareConfig (config) {
         return new Moment(checkOverflow(input));
     } else if (isArray(format)) {
         configFromStringAndArray(config);
-    } else if (format) {
-        configFromStringAndFormat(config);
     } else if (isDate(input)) {
         config._d = input;
-    } else {
+    } else if (format) {
+        configFromStringAndFormat(config);
+    }  else {
         configFromInput(config);
     }
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -72,6 +72,7 @@ test('unix', function (assert) {
 
 test('date', function (assert) {
     assert.ok(moment(new Date()).toDate() instanceof Date, 'new Date()');
+    assert.equal(moment(new Date(2016,0,1), 'YYYY-MM-DD').format('YYYY-MM-DD'), '2016-01-01', 'If date is provided, format string is ignored');
 });
 
 test('date mutation', function (assert) {


### PR DESCRIPTION
Fix moment/moment#3228 where passing a date object with a format string would cause the date to be coerced to string and the interpreted by the string format. Now just uses the date and ignores the format.