### PR TITLE
Implement .format(moment.ISO_8601) to be an alias for .toISOString()

### DIFF
--- a/src/lib/moment/format.js
+++ b/src/lib/moment/format.js
@@ -27,6 +27,9 @@ export function format (inputString) {
     if (!inputString) {
         inputString = this.isUtc() ? hooks.defaultFormatUtc : hooks.defaultFormat;
     }
+    if (inputString === hooks.ISO_8601) {
+        return toISOString.call(this);
+    }
     var output = formatMoment(this, inputString);
     return this.localeData().postformat(output);
 }

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -441,3 +441,7 @@ test('Y token', function (assert) {
     assert.equal(moment('9999-01-01', 'Y-MM-DD', true).format('Y'), '9999', 'format 9999 with Y');
     assert.equal(moment('10000-01-01', 'Y-MM-DD', true).format('Y'), '+10000', 'format 10000 with Y');
 });
+
+test('moment.ISO_8601 format', function (assert) {
+    assert.equal(moment('2010-01-02T01:02:03.004Z', moment.ISO_8601).format(moment.ISO_8601), '2010-01-02T01:02:03.004Z', 'moment.ISO_8601 format');
+});


### PR DESCRIPTION
Fixes #3019