### PR TITLE
Parse Dutch abbreviated month name without dot

### DIFF
--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -1,11 +1,15 @@
 //! moment.js locale configuration
 //! locale : Dutch [nl]
-//! author : Joris Röling : https://github.com/jjupiter
+//! author : Joris Röling : https://github.com/jorisroling
+//! author : Jacob Middag : https://github.com/middagj
 
 import moment from '../moment';
 
 var monthsShortWithDots = 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split('_'),
     monthsShortWithoutDots = 'jan_feb_mrt_apr_mei_jun_jul_aug_sep_okt_nov_dec'.split('_');
+
+var monthsParse = [/^jan/i, /^feb/i, /^maart|mrt.?$/i, /^apr/i, /^mei$/i, /^jun[i.]?$/i, /^jul[i.]?$/i, /^aug/i, /^sep/i, /^okt/i, /^nov/i, /^dec/i];
+var monthsRegex = /^(januari|februari|maart|april|mei|april|ju[nl]i|augustus|september|oktober|november|december|jan\.?|feb\.?|mrt\.?|apr\.?|ju[nl]\.?|aug\.?|sep\.?|okt\.?|nov\.?|dec\.?)/i;
 
 export default moment.defineLocale('nl', {
     months : 'januari_februari_maart_april_mei_juni_juli_augustus_september_oktober_november_december'.split('_'),
@@ -16,7 +20,16 @@ export default moment.defineLocale('nl', {
             return monthsShortWithDots[m.month()];
         }
     },
-    monthsParseExact : true,
+
+    monthsRegex: monthsRegex,
+    monthsShortRegex: monthsRegex,
+    monthsStrictRegex: /^(januari|februari|maart|mei|ju[nl]i|april|augustus|september|oktober|november|december)/i,
+    monthsShortStrictRegex: /^(jan\.?|feb\.?|mrt\.?|apr\.?|mei|ju[nl]\.?|aug\.?|sep\.?|okt\.?|nov\.?|dec\.?)/i,
+
+    monthsParse : monthsParse,
+    longMonthsParse : monthsParse,
+    shortMonthsParse : monthsParse,
+
     weekdays : 'zondag_maandag_dinsdag_woensdag_donderdag_vrijdag_zaterdag'.split('_'),
     weekdaysShort : 'zo._ma._di._wo._do._vr._za.'.split('_'),
     weekdaysMin : 'Zo_Ma_Di_Wo_Do_Vr_Za'.split('_'),

--- a/src/test/locale/nl.js
+++ b/src/test/locale/nl.js
@@ -201,7 +201,9 @@ test('calendar all else', function (assert) {
 
 test('month abbreviation', function (assert) {
     assert.equal(moment([2012, 5, 23]).format('D-MMM-YYYY'), '23-jun-2012', 'format month abbreviation surrounded by dashes should not include a dot');
+    assert.equal(moment([2012, 5, 23]).unix(), moment('23-jun-2012', 'D-MMM-YYYY').unix(), 'parse month abbreviation surrounded by dashes without dot');
     assert.equal(moment([2012, 5, 23]).format('D MMM YYYY'), '23 jun. 2012', 'format month abbreviation not surrounded by dashes should include a dot');
+    assert.equal(moment([2012, 5, 23]).unix(), moment('23 jun. 2012', 'D MMM YYYY').unix(), 'parse month abbreviation not surrounded by dashes with dot');
 });
 
 test('weeks year starting sunday formatted', function (assert) {


### PR DESCRIPTION
Issue #3242

Dutch locale removes the dot from the abbreviated if it is used in a dashed notation: DD-MMM-YYYY. However, it doesn't work the other way around, which I think should be possible.

See https://jsfiddle.net/ztroj5zv/ for an example.

This fixes the parsing logic and allow abbreviated months without dots, which is quite common in Dutch. See http://taaladvies.net/taal/advies/vraag/1727/afkortingen_van_de_namen_van_de_maanden/

@jorisroling