### PR TITLE
[bugfix] duration: parser: Support ms durations in .NET syntax

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -6,7 +6,7 @@ import { cloneWithOffset } from '../units/offset';
 import { createLocal } from '../create/local';
 
 // ASP.NET json date format regex
-var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/;
+var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)(\.\d*)?)?$/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
@@ -38,11 +38,11 @@ export function createDuration (input, key) {
         sign = (match[1] === '-') ? -1 : 1;
         duration = {
             y  : 0,
-            d  : toInt(match[DATE])        * sign,
-            h  : toInt(match[HOUR])        * sign,
-            m  : toInt(match[MINUTE])      * sign,
-            s  : toInt(match[SECOND])      * sign,
-            ms : toInt(match[MILLISECOND]) * sign
+            d  : toInt(match[DATE])               * sign,
+            h  : toInt(match[HOUR])               * sign,
+            m  : toInt(match[MINUTE])             * sign,
+            s  : toInt(match[SECOND])             * sign,
+            ms : toInt(match[MILLISECOND] * 1000) * sign // the millisecond decimal point is included in the match
         };
     } else if (!!(match = isoRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : 1;

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -1,5 +1,6 @@
 import { Duration, isDuration } from './constructor';
 import toInt from '../utils/to-int';
+import absRound from '../utils/abs-round';
 import hasOwnProp from '../utils/has-own-prop';
 import { DATE, HOUR, MINUTE, SECOND, MILLISECOND } from '../units/constants';
 import { cloneWithOffset } from '../units/offset';
@@ -38,11 +39,11 @@ export function createDuration (input, key) {
         sign = (match[1] === '-') ? -1 : 1;
         duration = {
             y  : 0,
-            d  : toInt(match[DATE])               * sign,
-            h  : toInt(match[HOUR])               * sign,
-            m  : toInt(match[MINUTE])             * sign,
-            s  : toInt(match[SECOND])             * sign,
-            ms : toInt(match[MILLISECOND] * 1000) * sign // the millisecond decimal point is included in the match
+            d  : toInt(match[DATE])                         * sign,
+            h  : toInt(match[HOUR])                         * sign,
+            m  : toInt(match[MINUTE])                       * sign,
+            s  : toInt(match[SECOND])                       * sign,
+            ms : toInt(absRound(match[MILLISECOND] * 1000)) * sign // the millisecond decimal point is included in the match
         };
     } else if (!!(match = isoRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : 1;

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -222,6 +222,19 @@ test('instatiation from serialized C# TimeSpan without milliseconds', function (
     assert.equal(moment.duration('1.02:03:04').milliseconds(), 0, '0 milliseconds');
 });
 
+test('instantiation from serialized C# TimeSpan with low millisecond precision', function (assert) {
+    assert.equal(moment.duration('00:00:15.72').years(), 0, '0 years');
+    assert.equal(moment.duration('00:00:15.72').days(), 0, '0 days');
+    assert.equal(moment.duration('00:00:15.72').hours(), 0, '0 hours');
+    assert.equal(moment.duration('00:00:15.72').minutes(), 0, '0 minutes');
+    assert.equal(moment.duration('00:00:15.72').seconds(), 15, '15 seconds');
+    assert.equal(moment.duration('00:00:15.72').milliseconds(), 720, '720 milliseconds');
+
+    assert.equal(moment.duration('00:00:15.7').milliseconds(), 700, '700 milliseconds');
+
+    assert.equal(moment.duration('00:00:15.').milliseconds(), 0, '0 milliseconds');
+});
+
 test('instatiation from serialized C# TimeSpan maxValue', function (assert) {
     var d = moment.duration('10675199.02:48:05.4775807');
 

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -178,15 +178,15 @@ test('instatiation from serialized C# TimeSpan with days', function (assert) {
     assert.equal(moment.duration('1.02:03:04.9999999').days(), 1, '1 day');
     assert.equal(moment.duration('1.02:03:04.9999999').hours(), 2, '2 hours');
     assert.equal(moment.duration('1.02:03:04.9999999').minutes(), 3, '3 minutes');
-    assert.equal(moment.duration('1.02:03:04.9999999').seconds(), 4, '4 seconds');
-    assert.equal(moment.duration('1.02:03:04.9999999').milliseconds(), 999, '999 milliseconds');
+    assert.equal(moment.duration('1.02:03:04.9999999').seconds(), 5, '5 seconds');
+    assert.equal(moment.duration('1.02:03:04.9999999').milliseconds(), 0, '0 milliseconds');
 
     assert.equal(moment.duration('1 02:03:04.9999999').years(), 0, '0 years');
     assert.equal(moment.duration('1 02:03:04.9999999').days(), 1, '1 day');
     assert.equal(moment.duration('1 02:03:04.9999999').hours(), 2, '2 hours');
     assert.equal(moment.duration('1 02:03:04.9999999').minutes(), 3, '3 minutes');
-    assert.equal(moment.duration('1 02:03:04.9999999').seconds(), 4, '4 seconds');
-    assert.equal(moment.duration('1 02:03:04.9999999').milliseconds(), 999, '999 milliseconds');
+    assert.equal(moment.duration('1 02:03:04.9999999').seconds(), 5, '5 seconds');
+    assert.equal(moment.duration('1 02:03:04.9999999').milliseconds(), 0, '0 milliseconds');
 });
 
 test('instatiation from serialized C# TimeSpan without days', function (assert) {
@@ -194,14 +194,17 @@ test('instatiation from serialized C# TimeSpan without days', function (assert) 
     assert.equal(moment.duration('01:02:03.9999999').days(), 0, '0 days');
     assert.equal(moment.duration('01:02:03.9999999').hours(), 1, '1 hour');
     assert.equal(moment.duration('01:02:03.9999999').minutes(), 2, '2 minutes');
-    assert.equal(moment.duration('01:02:03.9999999').seconds(), 3, '3 seconds');
-    assert.equal(moment.duration('01:02:03.9999999').milliseconds(), 999, '999 milliseconds');
+    assert.equal(moment.duration('01:02:03.9999999').seconds(), 4, '4 seconds');
+    assert.equal(moment.duration('01:02:03.9999999').milliseconds(), 0, '0 milliseconds');
 
-    assert.equal(moment.duration('23:59:59.9999999').days(), 0, '0 days');
-    assert.equal(moment.duration('23:59:59.9999999').hours(), 23, '23 hours');
+    assert.equal(moment.duration('23:59:59.9999999').days(), 1, '1 days');
+    assert.equal(moment.duration('23:59:59.9999999').hours(), 0, '0 hours');
+    assert.equal(moment.duration('23:59:59.9999999').minutes(), 0, '0 minutes');
+    assert.equal(moment.duration('23:59:59.9999999').seconds(), 0, '0 seconds');
+    assert.equal(moment.duration('23:59:59.9999999').milliseconds(), 0, '0 milliseconds');
 
-    assert.equal(moment.duration('500:59:59.9999999').days(), 20, '500 hours overflows to 20 days');
-    assert.equal(moment.duration('500:59:59.9999999').hours(), 20, '500 hours overflows to 20 hours');
+    assert.equal(moment.duration('500:59:59.8888888').days(), 20, '500 hours overflows to 20 days');
+    assert.equal(moment.duration('500:59:59.8888888').hours(), 20, '500 hours overflows to 20 hours');
 });
 
 test('instatiation from serialized C# TimeSpan without days or milliseconds', function (assert) {
@@ -235,6 +238,20 @@ test('instantiation from serialized C# TimeSpan with low millisecond precision',
     assert.equal(moment.duration('00:00:15.').milliseconds(), 0, '0 milliseconds');
 });
 
+test('instantiation from serialized C# TimeSpan with high millisecond precision', function (assert) {
+    assert.equal(moment.duration('00:00:15.7200000').seconds(), 15, '15 seconds');
+    assert.equal(moment.duration('00:00:15.7200000').milliseconds(), 720, '720 milliseconds');
+
+    assert.equal(moment.duration('00:00:15.7209999').seconds(), 15, '15 seconds');
+    assert.equal(moment.duration('00:00:15.7209999').milliseconds(), 721, '721 milliseconds');
+
+    assert.equal(moment.duration('00:00:15.7205000').seconds(), 15, '15 seconds');
+    assert.equal(moment.duration('00:00:15.7205000').milliseconds(), 721, '721 milliseconds');
+
+    assert.equal(moment.duration('-00:00:15.7205000').seconds(), -15, '15 seconds');
+    assert.equal(moment.duration('-00:00:15.7205000').milliseconds(), -721, '721 milliseconds');
+});
+
 test('instatiation from serialized C# TimeSpan maxValue', function (assert) {
     var d = moment.duration('10675199.02:48:05.4775807');
 
@@ -245,7 +262,7 @@ test('instatiation from serialized C# TimeSpan maxValue', function (assert) {
     assert.equal(d.hours(), 2, '2 hours');
     assert.equal(d.minutes(), 48, '48 minutes');
     assert.equal(d.seconds(), 5, '5 seconds');
-    assert.equal(d.milliseconds(), 477, '477 milliseconds');
+    assert.equal(d.milliseconds(), 478, '478 milliseconds');
 });
 
 test('instatiation from serialized C# TimeSpan minValue', function (assert) {
@@ -258,7 +275,7 @@ test('instatiation from serialized C# TimeSpan minValue', function (assert) {
     assert.equal(d.hours(), -2, '2 hours');
     assert.equal(d.minutes(), -48, '48 minutes');
     assert.equal(d.seconds(), -5, '5 seconds');
-    assert.equal(d.milliseconds(), -477, '477 milliseconds');
+    assert.equal(d.milliseconds(), -478, '478 milliseconds');
 });
 
 test('instantiation from ISO 8601 duration', function (assert) {


### PR DESCRIPTION
Fixes #3266 

~~Note: The rounding behavior described in https://github.com/moment/moment/issues/3266#issuecomment-229423853 is not currently included in this PR, because it would break a number of existing tests. For example, with the proposed rounding behavior, the duration parsed in [this test](https://github.com/moment/moment/blob/9c04c825ca7d3435c56badb1dc62d844d7ac1c32/src/test/moment/duration.js#L181) would have `seconds = 5` and `milliseconds = 0`.~~

~~I can add the rounding behavior and change those tests if desired, but that might be considered a breaking change, so I thought it was worth bringing up the issue first. At the moment, extra millisecond digits are simply truncated rather than being rounded.~~

*edit*: The rounding behavior has been added to this PR.