### PR TITLE
Fix Typings

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -523,7 +523,7 @@ declare namespace moment {
   export function relativeTimeThreshold(threshold: string, limit: number): boolean;
   export function relativeTimeRounding(fn: (num: number) => number): boolean;
   export function relativeTimeRounding(): (num: number) => number;
-  export function calendarFormat(m: Moment, now: Moment) => string;
+  export function calendarFormat(m: Moment, now: Moment): string;
 
   /**
   * Constant used to enable explicit ISO_8601 format parsing.


### PR DESCRIPTION
The TypeScript typings in 2.14.0 are incorrect and breaking our builds. This should fix the issue.

Thanks for all the hard work ❤️ 