### PR TITLE
[misc] typescript: Add 'date' to UnitOfTime

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -211,7 +211,8 @@ declare namespace moment {
               "quarter" | "quarters" | "Q" |
               "month" | "months" | "M" |
               "week" | "weeks" | "w" |
-              "day" | "days" | "d" |
+              "date" | "dates" | "d" |
+              "day" | "days" |
               "hour" | "hours" | "h" |
               "minute" | "minutes" | "m" |
               "second" | "seconds" | "s" |


### PR DESCRIPTION
Apparently this got lost when `UnitOfTime` was created. `Day` in dates only refers to the day of the week, while `Date` refers to the day of the month.

This pull request adds `date` back as an allowed unit.