### PR TITLE
[bugfix] locales: Enable locale-datnwithout moment ta getters without moment (fixes #3284)

### DIFF
--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -99,7 +99,7 @@ function parseIsoWeekday(input, locale) {
 
 export var defaultLocaleWeekdays = 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_');
 export function localeWeekdays (m, format) {
-    if (typeof m === 'undefined') {
+    if (!m) {
         return this._weekdays;
     }
     return isArray(this._weekdays) ? this._weekdays[m.day()] :
@@ -108,18 +108,12 @@ export function localeWeekdays (m, format) {
 
 export var defaultLocaleWeekdaysShort = 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_');
 export function localeWeekdaysShort (m) {
-    if (typeof m === 'undefined') {
-        return this._weekdaysShort;
-    }
-    return this._weekdaysShort[m.day()];
+    return (m) ? this._weekdaysShort[m.day()] : this._weekdaysShort;
 }
 
 export var defaultLocaleWeekdaysMin = 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_');
 export function localeWeekdaysMin (m) {
-    if (typeof m === 'undefined') {
-        return this._weekdaysMin;
-    }
-    return this._weekdaysMin[m.day()];
+    return (m) ? this._weekdaysMin[m.day()] : this._weekdaysMin;
 }
 
 function handleStrictParse(weekdayName, format, strict) {

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -99,17 +99,26 @@ function parseIsoWeekday(input, locale) {
 
 export var defaultLocaleWeekdays = 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_');
 export function localeWeekdays (m, format) {
+    if (typeof m === 'undefined') {
+        return this._weekdays;
+    }
     return isArray(this._weekdays) ? this._weekdays[m.day()] :
         this._weekdays[this._weekdays.isFormat.test(format) ? 'format' : 'standalone'][m.day()];
 }
 
 export var defaultLocaleWeekdaysShort = 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_');
 export function localeWeekdaysShort (m) {
+    if (typeof m === 'undefined') {
+        return this._weekdaysShort;
+    }
     return this._weekdaysShort[m.day()];
 }
 
 export var defaultLocaleWeekdaysMin = 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_');
 export function localeWeekdaysMin (m) {
+    if (typeof m === 'undefined') {
+        return this._weekdaysMin;
+    }
     return this._weekdaysMin[m.day()];
 }
 

--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -69,12 +69,18 @@ addParseToken(['MMM', 'MMMM'], function (input, array, config, token) {
 var MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/;
 export var defaultLocaleMonths = 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_');
 export function localeMonths (m, format) {
+    if (typeof m === 'undefined') {
+        return this._months;
+    }
     return isArray(this._months) ? this._months[m.month()] :
         this._months[(this._months.isFormat || MONTHS_IN_FORMAT).test(format) ? 'format' : 'standalone'][m.month()];
 }
 
 export var defaultLocaleMonthsShort = 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_');
 export function localeMonthsShort (m, format) {
+    if (typeof m === 'undefined') {
+        return this._monthsShort;
+    }
     return isArray(this._monthsShort) ? this._monthsShort[m.month()] :
         this._monthsShort[MONTHS_IN_FORMAT.test(format) ? 'format' : 'standalone'][m.month()];
 }

--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -12,6 +12,7 @@ import isArray from '../utils/is-array';
 import indexOf from '../utils/index-of';
 import { createUTC } from '../create/utc';
 import getParsingFlags from '../create/parsing-flags';
+import isUndefined from '../utils/is-undefined';
 
 export function daysInMonth(year, month) {
     return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
@@ -69,7 +70,7 @@ addParseToken(['MMM', 'MMMM'], function (input, array, config, token) {
 var MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/;
 export var defaultLocaleMonths = 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_');
 export function localeMonths (m, format) {
-    if (typeof m === 'undefined') {
+    if (!m) {
         return this._months;
     }
     return isArray(this._months) ? this._months[m.month()] :
@@ -78,7 +79,7 @@ export function localeMonths (m, format) {
 
 export var defaultLocaleMonthsShort = 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_');
 export function localeMonthsShort (m, format) {
-    if (typeof m === 'undefined') {
+    if (!m) {
         return this._monthsShort;
     }
     return isArray(this._monthsShort) ? this._monthsShort[m.month()] :

--- a/src/test/moment/listers.js
+++ b/src/test/moment/listers.js
@@ -98,3 +98,26 @@ test('with functions', function (assert) {
     assert.deepEqual(moment.monthsShort('-MMM-', 2), 'threesy');
     assert.deepEqual(moment.monthsShort(2), 'three');
 });
+
+test('with locale data', function (assert) {
+    var months = 'one_two_three_four_five_six_seven_eight_nine_ten_eleven_twelve'.split('_'),
+        monthsShort = 'on_tw_th_fo_fi_si_se_ei_ni_te_el_tw'.split('_'),
+        weekdays = 'one_two_three_four_five_six_seven'.split('_'),
+        weekdaysShort = 'on_tw_th_fo_fi_si_se'.split('_'),
+        weekdaysMin = '1_2_3_4_5_6_7'.split('_'),
+        weekdaysLocale = 'four_five_six_seven_one_two_three'.split('_'),
+        weekdaysShortLocale = 'fo_fi_si_se_on_tw_th'.split('_'),
+        weekdaysMinLocale = '4_5_6_7_1_2_3'.split('_'),
+        week = {
+            dow : 3,
+            doy : 6
+        };
+        
+    var customLocale = moment.localeData('numerologists');
+
+    assert.deepEqual(customLocale.months(), months);
+    assert.deepEqual(customLocale.monthsShort(), monthsShort);
+    assert.deepEqual(customLocale.weekdays(), weekdays);
+    assert.deepEqual(customLocale.weekdaysShort(), weekdaysShort);
+    assert.deepEqual(customLocale.weekdaysMin(), weekdaysMin);
+});

--- a/src/test/moment/listers.js
+++ b/src/test/moment/listers.js
@@ -112,7 +112,7 @@ test('with locale data', function (assert) {
             dow : 3,
             doy : 6
         };
-        
+
     var customLocale = moment.localeData('numerologists');
 
     assert.deepEqual(customLocale.months(), months);


### PR DESCRIPTION
This possibly fixes the issue #3284. Can you please verify it @icambron ?

In the absence of a moment parameter, it returns a locale specific list.