### PR TITLE
[misc] typescript: Add moment().creationData() declaration

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -217,6 +217,18 @@ declare namespace moment {
               "second" | "seconds" | "s" |
               "millisecond" | "milliseconds" | "ms");
 
+  interface MomentCreationData {
+    input?: string;
+    format?: string;
+    locale?: MomentLocale;
+    isUTC: boolean;
+    strict: boolean;
+  }
+
+  interface MomentLocale  {
+    // Details about the locale structure are not in the documentation so they are omitted here.
+  }
+
   interface Moment {
     format(format: string): string;
     format(): string;
@@ -312,6 +324,7 @@ declare namespace moment {
     isValid(): boolean;
     invalidAt(): number;
 
+    creationData(): MomentCreationData;
     parsingFlags(): MomentParsingFlags;
 
     year(y: number): Moment;


### PR DESCRIPTION
The #creationData() function is documented but it is missing in the Typings.

I couldn't find the structure of the `locale`-property in the documentation, so I omitted it in this first attempt. If anyone gives me a hint, I will add it.
