### PR TITLE
[locale] ss: Fix siSwati locale name in comment

### DIFF
--- a/src/locale/ss.js
+++ b/src/locale/ss.js
@@ -1,5 +1,5 @@
 //! moment.js locale configuration
-//! locale : Swazi [ss]
+//! locale : siSwati [ss]
 //! author : Nicolai Davies<mail@nicolai.io> : https://github.com/nicolaidavies
 
 


### PR DESCRIPTION
During the cleanup of the comments, the name was changed from siSwati to Swazi. 

A Swazi is a person and siSwati is the language.