### PR TITLE
Add missing isoWeek to UnitOfTime type definition

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -210,7 +210,7 @@ declare namespace moment {
   type UnitOfTime = ("year" | "years" | "y" |
               "quarter" | "quarters" | "Q" |
               "month" | "months" | "M" |
-              "week" | "weeks" | "w" |
+              "week" | "weeks" | "w" | "isoWeek" |
               "day" | "days" | "d" |
               "hour" | "hours" | "h" |
               "minute" | "minutes" | "m" |


### PR DESCRIPTION
Add missing definition for isoWeek to UnitOfTime type definition.