### PR TITLE
[locale] jv: Fix full locale name -- Japanese to JaVanese

### DIFF
--- a/locale/jv.js
+++ b/locale/jv.js
@@ -1,5 +1,5 @@
 //! moment.js locale configuration
-//! locale : Japanese [jv]
+//! locale : Javanese [jv]
 //! author : Rony Lantip : https://github.com/lantip
 //! reference: http://jv.wikipedia.org/wiki/Basa_Jawa
 


### PR DESCRIPTION
There was a typo in the Javanese localization (JaPanese instead of JaVanese), which percolated all the way to the momentjs.com site source, causing "Japanese" to appear twice in the list.