### PR TITLE
Bug: `parentLocale` option crashes if parent has not been loaded yet

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,9 +177,47 @@ module.exports = function (grunt) {
             },
             'meteor-publish': {
                 command: 'meteor publish'
+            },
+            'test-locales-cleanup': {
+                command: 'rm -f src/locale/aa-aa.js && rm -f src/locale/zz-zz.js'
             }
         }
 
+    });
+
+    grunt.registerTask('make-test-locales', '', function() {
+        var fs = require('fs');
+        var child_locale =
+            "import moment from '../moment';" +
+            "export default moment.defineLocale('aa-aa', {" +
+            "    parentLocale: 'zz-zz'," +
+            "    calendar: {" +
+            "        sameDay: '[AA] HH:mm'" +
+            "    }" +
+            "});";
+        var parent_locale =
+            "import moment from '../moment';" +
+            "export default moment.defineLocale('zz-zz', {" +
+            "    calendar: {" +
+            "        sameDay: '[ZZ] HH:mm'," +
+            "        nextDay: '[ZZ] HH:mm'," +
+            "        nextWeek: '[ZZ] HH:mm'" +
+            "    }" +
+            "});";
+        fs.writeFileSync("src/locale/zz-zz.js", parent_locale);
+        fs.writeFileSync("src/locale/aa-aa.js", child_locale);
+    });
+
+    grunt.registerTask("force",function(set){
+        if (set === "on") {
+            grunt.option("force",true);
+        }
+        else if (set === "off") {
+            grunt.option("force",false);
+        }
+        else if (set === "restore") {
+            grunt.option("force",previous_force_state);
+        }
     });
 
     grunt.loadTasks('tasks');
@@ -188,7 +226,7 @@ module.exports = function (grunt) {
     require('load-grunt-tasks')(grunt);
 
     // Default task.
-    grunt.registerTask('default', ['lint', 'test:node']);
+    grunt.registerTask('default', ['exec:test-locales-cleanup', 'lint', 'test:node']);
 
     // linting
     grunt.registerTask('lint', ['jshint', 'jscs']);
@@ -196,6 +234,7 @@ module.exports = function (grunt) {
     // test tasks
     grunt.registerTask('test', ['test:node']);
     grunt.registerTask('test:node', ['transpile', 'qtest']);
+    grunt.registerTask('test:grunt', ['exec:test-locales-cleanup', 'make-test-locales', 'transpile:aa-aa', 'qtest_custom_build']);
     // TODO: For some weird reason karma doesn't like the files in
     // build/umd/min/* but works with min/*, so update-index, then git checkout
     grunt.registerTask('test:server', ['transpile', 'update-index', 'karma:server']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -187,7 +187,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('make-test-locales', '', function() {
         var fs = require('fs');
-        var child_locale =
+        var childLocale =
             "import moment from '../moment';" +
             "export default moment.defineLocale('aa-aa', {" +
             "    parentLocale: 'zz-zz'," +
@@ -195,7 +195,7 @@ module.exports = function (grunt) {
             "        sameDay: '[AA] HH:mm'" +
             "    }" +
             "});";
-        var parent_locale =
+        var parentLocale =
             "import moment from '../moment';" +
             "export default moment.defineLocale('zz-zz', {" +
             "    calendar: {" +
@@ -204,20 +204,8 @@ module.exports = function (grunt) {
             "        nextWeek: '[ZZ] HH:mm'" +
             "    }" +
             "});";
-        fs.writeFileSync("src/locale/zz-zz.js", parent_locale);
-        fs.writeFileSync("src/locale/aa-aa.js", child_locale);
-    });
-
-    grunt.registerTask("force",function(set){
-        if (set === "on") {
-            grunt.option("force",true);
-        }
-        else if (set === "off") {
-            grunt.option("force",false);
-        }
-        else if (set === "restore") {
-            grunt.option("force",previous_force_state);
-        }
+        fs.writeFileSync("src/locale/zz-zz.js", parentLocale);
+        fs.writeFileSync("src/locale/aa-aa.js", childLocale);
     });
 
     grunt.loadTasks('tasks');

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -11,7 +11,12 @@ import { baseConfig } from './base-config';
 
 // internal storage for locale config files
 var locales = {};
-// {'zh-tw': [{name:'zh-tw', config:config}, {name:'zh-mo', config:config}}
+// {'zh-tw': [{name:'zh-hk', config:config}, {name:'zh-mo', config:config}}
+// # ISSUES with "out of order parent locale":
+// * moment-with-locales.js fails to load child locale.
+// * `moment.locale('zh-hk')` will fail in modularized environments.
+// * `grunt transpile:zh-hk` will fail.
+
 var localeFamilies = {};
 var globalLocale;
 
@@ -117,7 +122,7 @@ export function defineLocale (name, config) {
         getSetGlobalLocale(name);
 
         if (localeFamilies[name]) {
-            localeFamilies[name].forEach(function(x) {
+            localeFamilies[name].forEach(function (x) {
                 defineLocale(x.name, x.config);
             });
         }

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -11,6 +11,8 @@ import { baseConfig } from './base-config';
 
 // internal storage for locale config files
 var locales = {};
+// {'zh-tw': [{name:'zh-tw', config:config}, {name:'zh-mo', config:config}}
+var localeFamilies = {};
 var globalLocale;
 
 function normalizeLocale(key) {
@@ -97,15 +99,28 @@ export function defineLocale (name, config) {
             if (locales[config.parentLocale] != null) {
                 parentConfig = locales[config.parentLocale]._config;
             } else {
-                // treat as if there is no base config
-                deprecateSimple('parentLocaleUndefined',
-                        'specified parentLocale is not defined yet. See http://momentjs.com/guides/#/warnings/parent-locale/');
+                if (localeFamilies[config.parentLocale]) {
+                    localeFamilies[config.parentLocale].push({
+                        name: name, config: config
+                    });
+                } else {
+                    localeFamilies[config.parentLocale] = [{
+                        name: name, config: config
+                    }];
+                }
+                return null;
             }
         }
         locales[name] = new Locale(mergeConfigs(parentConfig, config));
 
         // backwards compat for now: also set the locale
         getSetGlobalLocale(name);
+
+        if (localeFamilies[name]) {
+            localeFamilies[name].forEach(function(x) {
+                defineLocale(x.name, x.config);
+            });
+        }
 
         return locales[name];
     } else {

--- a/src/test/moment/grunt.js
+++ b/src/test/moment/grunt.js
@@ -1,0 +1,11 @@
+import { module, test } from '../qunit';
+import moment from '../../moment';
+
+module('grunt builds fine');
+
+test('load order', function (assert) {
+    moment.locale('aa-aa');
+    var anchor = moment.utc('2015-05-05T12:00:00', moment.ISO_8601);
+    assert.equal(anchor.clone().add(3, 'hours').calendar(anchor), 'AA 15:00', 'Child can redefine values');
+    assert.equal(anchor.clone().add(1, 'day').calendar(anchor), 'ZZ 12:00', 'Can fallback to parent value');
+});

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -163,3 +163,36 @@ test('months', function (assert) {
     });
     assert.ok(moment.utc('2015-01-01', 'YYYY-MM-DD').format('MMMM'), 'First', 'months uses child');
 });
+
+test('load order', function (assert) {
+    moment.defineLocale('aaa-child', {
+        parentLocale: 'zzz-parent',
+        calendar: {
+            sameDay: '[Today] HH:mm',
+            nextDay: '[Tomorrow] HH:mm',
+            nextWeek: '[Next week] HH:mm'
+        }
+    });
+
+    moment.defineLocale('zzz-parent', {
+        calendar : {
+            sameDay: '[Today at] HH:mm',
+            nextDay: '[Tomorrow at] HH:mm',
+            nextWeek: '[Next week at] HH:mm',
+            lastDay: '[Yesterday at] HH:mm',
+            lastWeek: '[Last week at] HH:mm',
+            sameElse: '[whatever]'
+        }
+    });
+
+    moment.locale('child-cal');
+    var anchor = moment.utc('2015-05-05T12:00:00', moment.ISO_8601);
+    assert.equal(anchor.clone().add(3, 'hours').calendar(anchor), 'Today 15:00', 'today uses child version');
+    assert.equal(anchor.clone().add(1, 'day').calendar(anchor), 'Tomorrow 12:00', 'tomorrow uses child version');
+    assert.equal(anchor.clone().add(3, 'days').calendar(anchor), 'Next week 12:00', 'next week uses child version');
+
+    assert.equal(anchor.clone().subtract(1, 'day').calendar(anchor), 'Yesterday at 12:00', 'yesterday uses parent version');
+    assert.equal(anchor.clone().subtract(3, 'days').calendar(anchor), 'Last week at 12:00', 'last week uses parent version');
+    assert.equal(anchor.clone().subtract(7, 'days').calendar(anchor), 'whatever', 'sameElse uses parent version -');
+    assert.equal(anchor.clone().add(7, 'days').calendar(anchor), 'whatever', 'sameElse uses parent version +');
+});

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -163,36 +163,3 @@ test('months', function (assert) {
     });
     assert.ok(moment.utc('2015-01-01', 'YYYY-MM-DD').format('MMMM'), 'First', 'months uses child');
 });
-
-test('load order', function (assert) {
-    moment.defineLocale('aaa-child', {
-        parentLocale: 'zzz-parent',
-        calendar: {
-            sameDay: '[Today] HH:mm',
-            nextDay: '[Tomorrow] HH:mm',
-            nextWeek: '[Next week] HH:mm'
-        }
-    });
-
-    moment.defineLocale('zzz-parent', {
-        calendar : {
-            sameDay: '[Today at] HH:mm',
-            nextDay: '[Tomorrow at] HH:mm',
-            nextWeek: '[Next week at] HH:mm',
-            lastDay: '[Yesterday at] HH:mm',
-            lastWeek: '[Last week at] HH:mm',
-            sameElse: '[whatever]'
-        }
-    });
-
-    moment.locale('child-cal');
-    var anchor = moment.utc('2015-05-05T12:00:00', moment.ISO_8601);
-    assert.equal(anchor.clone().add(3, 'hours').calendar(anchor), 'Today 15:00', 'today uses child version');
-    assert.equal(anchor.clone().add(1, 'day').calendar(anchor), 'Tomorrow 12:00', 'tomorrow uses child version');
-    assert.equal(anchor.clone().add(3, 'days').calendar(anchor), 'Next week 12:00', 'next week uses child version');
-
-    assert.equal(anchor.clone().subtract(1, 'day').calendar(anchor), 'Yesterday at 12:00', 'yesterday uses parent version');
-    assert.equal(anchor.clone().subtract(3, 'days').calendar(anchor), 'Last week at 12:00', 'last week uses parent version');
-    assert.equal(anchor.clone().subtract(7, 'days').calendar(anchor), 'whatever', 'sameElse uses parent version -');
-    assert.equal(anchor.clone().add(7, 'days').calendar(anchor), 'whatever', 'sameElse uses parent version +');
-});

--- a/tasks/qtest_custom_build.js
+++ b/tasks/qtest_custom_build.js
@@ -1,0 +1,48 @@
+module.exports = function (grunt) {
+    grunt.task.registerTask('qtest_custom_build', 'run tests locally on moment-with-locales', function () {
+        var done = this.async();
+
+        var testrunner = require('qunit');
+
+        testrunner.options.log.assertions = false;
+        testrunner.options.log.tests = false;
+        testrunner.options.log.summary = false;
+        testrunner.options.log.testing = false;
+        testrunner.options.maxBlockDuration = 120000;
+
+        var tests;
+
+        // if (grunt.option('only') != null) {
+        //     tests = grunt.file.expand.apply(null, grunt.option('only').split(',').map(function (file) {
+        //         if (file === 'moment') {
+        //             return 'build/umd/test/moment/*.js';
+        //         } else if (file === 'locale') {
+        //             return 'build/umd/test/locale/*.js';
+        //         } else {
+        //             return 'build/umd/test/' + file + '.js';
+        //         }
+        //     }));
+        // } else {
+        //     tests = grunt.file.expand('build/umd/test/moment/*.js',
+        //         'build/umd/test/locale/*.js');
+        // }
+
+        tests = ['build/umd/test/moment/grunt.js'];
+
+        testrunner.run({
+            code: 'build/umd/min/moment-with-locales.custom.js',
+            tests: tests
+        }, function (err, report) {
+            if (err) {
+                console.log('woot', err, report);
+                done(err);
+                return;
+            }
+            err = null;
+            if (report.failed !== 0) {
+                err = new Error(report.failed + ' tests failed');
+            }
+            done(err);
+        });
+    });
+};


### PR DESCRIPTION
Here's a test case that crashes with `Unexpected deprecation thrown name=parentLocaleUndefined msg=specified parentLocale is not defined yet.`

That breaks the real-life scenario where localisation `zh-hk` depends on `zh-tw`. But child localisation definition goes before parent in the minimised file.