### PR TITLE
[pkg] exports: use module.require for nodejs

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -48,10 +48,10 @@ function loadLocale(name) {
     var oldLocale = null;
     // TODO: Find a better way to register and load all the locales in Node
     if (!locales[name] && (typeof module !== 'undefined') &&
-            module && module.exports) {
+            module && module.require) {
         try {
             oldLocale = globalLocale._abbr;
-            require('./locale/' + name);
+            module.require('./locale/' + name);
             // because defineLocale currently also sets the global locale, we
             // want to undo that for lazy loaded locales
             getSetGlobalLocale(oldLocale);


### PR DESCRIPTION
incase some web package tools inconvenience.

http://stackoverflow.com/questions/25384360/how-to-prevent-moment-js-from-loading-locales-with-webpack/25426019#25426019

https://github.com/webpack/webpack/issues/198

https://nodejs.org/dist/latest-v4.x/docs/api/modules.html#modules_module_require_id


@ichernev