### PR TITLE
[misc] typescript: Add isoWeekdays(str), locales, defaultFormatUtc

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -346,6 +346,7 @@ declare namespace moment {
     weekday(d: number): Moment;
     isoWeekday(): number;
     isoWeekday(d: number): Moment;
+    isoWeekday(d: string): Moment;
     weekYear(): number;
     weekYear(d: number): Moment;
     isoWeekYear(): number;
@@ -407,6 +408,8 @@ declare namespace moment {
     locale(language: string): Moment;
     locale(reset: boolean): Moment;
     locale(): string;
+
+    locales(): string[];
 
     localeData(language: string): Moment;
     localeData(reset: boolean): Moment;
@@ -531,6 +534,7 @@ declare namespace moment {
   export function ISO_8601(): void;
 
   export var defaultFormat: string;
+  export var defaultFormatUtc: string;
 }
 
 export = moment;


### PR DESCRIPTION
I was looking into upgrading the declaration file on DefinitelyTyped so it matched version 2.14. 
After I had done most of that, I noticed that you have a more up-to-date version of the declaration file here. 

You had implemented most of the changes that I found, but there was still 3 small things missing from the declaration file here. 

Added locales, new since 2.12
Added a new overload of isoWeekday, which is possible since the input is passed through `parseIsoWeekday` since 2.14
Added defaultFormatUtc, new since 2.13.