### PR TITLE
fixing day sequence to match the real day

### DIFF
--- a/src/locale/ar-ma.js
+++ b/src/locale/ar-ma.js
@@ -44,7 +44,7 @@ export default moment.defineLocale('ar-ma', {
         yy : '%d سنوات'
     },
     week : {
-        dow : 6, // Saturday is the first day of the week.
+        dow : 1, // Saturday is the first day of the week.
         doy : 12  // The week that contains Jan 1st is the first week of the year.
     }
 });

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -88,7 +88,7 @@ export default moment.defineLocale('ar-sa', {
         }).replace(/,/g, '،');
     },
     week : {
-        dow : 6, // Saturday is the first day of the week.
+        dow : 1, // Saturday is the first day of the week.
         doy : 12  // The week that contains Jan 1st is the first week of the year.
     }
 });

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -121,7 +121,7 @@ export default moment.defineLocale('ar', {
         }).replace(/,/g, '،');
     },
     week : {
-        dow : 6, // Saturday is the first day of the week.
+        dow : 1, // Saturday is the first day of the week.
         doy : 12  // The week that contains Jan 1st is the first week of the year.
     }
 });


### PR DESCRIPTION
changed from src
we need to fix the day sequence to match the real day and not just visually. the problem is the calendar appears to be like 
August 2016
Fr    Sa    Su    Mo    Tu    We    Th
31    1     2       3      4      5      6

Friday is supposed to be the 5th of the month
