### PR TITLE
[locale] bs hr me sl sr sr-cyrl: Change 'DD. MM. YYYY' to 'DD.MM.YYYY' in L

### DIFF
--- a/src/locale/bs.js
+++ b/src/locale/bs.js
@@ -69,7 +69,7 @@ export default moment.defineLocale('bs', {
     longDateFormat : {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
-        L : 'DD. MM. YYYY',
+        L : 'DD.MM.YYYY',
         LL : 'D. MMMM YYYY',
         LLL : 'D. MMMM YYYY H:mm',
         LLLL : 'dddd, D. MMMM YYYY H:mm'
@@ -131,4 +131,3 @@ export default moment.defineLocale('bs', {
         doy : 7  // The week that contains Jan 1st is the first week of the year.
     }
 });
-

--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -71,7 +71,7 @@ export default moment.defineLocale('hr', {
     longDateFormat : {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
-        L : 'DD. MM. YYYY',
+        L : 'DD.MM.YYYY',
         LL : 'D. MMMM YYYY',
         LLL : 'D. MMMM YYYY H:mm',
         LLLL : 'dddd, D. MMMM YYYY H:mm'
@@ -133,4 +133,3 @@ export default moment.defineLocale('hr', {
         doy : 7  // The week that contains Jan 1st is the first week of the year.
     }
 });
-

--- a/src/locale/me.js
+++ b/src/locale/me.js
@@ -38,7 +38,7 @@ export default moment.defineLocale('me', {
     longDateFormat: {
         LT: 'H:mm',
         LTS : 'H:mm:ss',
-        L: 'DD. MM. YYYY',
+        L: 'DD.MM.YYYY',
         LL: 'D. MMMM YYYY',
         LLL: 'D. MMMM YYYY H:mm',
         LLLL: 'dddd, D. MMMM YYYY H:mm'

--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -86,7 +86,7 @@ export default moment.defineLocale('sl', {
     longDateFormat : {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
-        L : 'DD. MM. YYYY',
+        L : 'DD.MM.YYYY',
         LL : 'D. MMMM YYYY',
         LLL : 'D. MMMM YYYY H:mm',
         LLLL : 'dddd, D. MMMM YYYY H:mm'

--- a/src/locale/sr-cyrl.js
+++ b/src/locale/sr-cyrl.js
@@ -38,7 +38,7 @@ export default moment.defineLocale('sr-cyrl', {
     longDateFormat: {
         LT: 'H:mm',
         LTS : 'H:mm:ss',
-        L: 'DD. MM. YYYY',
+        L: 'DD.MM.YYYY',
         LL: 'D. MMMM YYYY',
         LLL: 'D. MMMM YYYY H:mm',
         LLLL: 'dddd, D. MMMM YYYY H:mm'
@@ -98,4 +98,3 @@ export default moment.defineLocale('sr-cyrl', {
         doy : 7  // The week that contains Jan 1st is the first week of the year.
     }
 });
-

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -38,7 +38,7 @@ export default moment.defineLocale('sr', {
     longDateFormat: {
         LT: 'H:mm',
         LTS : 'H:mm:ss',
-        L: 'DD. MM. YYYY',
+        L: 'DD.MM.YYYY',
         LL: 'D. MMMM YYYY',
         LLL: 'D. MMMM YYYY H:mm',
         LLLL: 'dddd, D. MMMM YYYY H:mm'
@@ -98,4 +98,3 @@ export default moment.defineLocale('sr', {
         doy : 7  // The week that contains Jan 1st is the first week of the year.
     }
 });
-

--- a/src/test/locale/bs.js
+++ b/src/test/locale/bs.js
@@ -37,11 +37,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14. 02. 2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. februar 2010'],
             ['LLL',                                '14. februar 2010 15:25'],
             ['LLLL',                               'nedjelja, 14. februar 2010 15:25'],
-            ['l',                                  '14. 2. 2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. feb. 2010'],
             ['lll',                                '14. feb. 2010 15:25'],
             ['llll',                               'ned., 14. feb. 2010 15:25']
@@ -239,4 +239,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2.', 'Jan  8 2012 should be week 2');
     assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3.', 'Jan  9 2012 should be week 3');
 });
-

--- a/src/test/locale/hr.js
+++ b/src/test/locale/hr.js
@@ -37,11 +37,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14. 02. 2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. veljača 2010'],
             ['LLL',                                '14. veljača 2010 15:25'],
             ['LLLL',                               'nedjelja, 14. veljača 2010 15:25'],
-            ['l',                                  '14. 2. 2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. velj. 2010'],
             ['lll',                                '14. velj. 2010 15:25'],
             ['llll',                               'ned., 14. velj. 2010 15:25']
@@ -239,4 +239,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2.', 'Jan  8 2012 should be week 2');
     assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3.', 'Jan  9 2012 should be week 3');
 });
-

--- a/src/test/locale/me.js
+++ b/src/test/locale/me.js
@@ -38,11 +38,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14. 02. 2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. februar 2010'],
             ['LLL',                                '14. februar 2010 15:25'],
             ['LLLL',                               'nedjelja, 14. februar 2010 15:25'],
-            ['l',                                  '14. 2. 2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. feb. 2010'],
             ['lll',                                '14. feb. 2010 15:25'],
             ['llll',                               'ned., 14. feb. 2010 15:25']
@@ -244,4 +244,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2.', 'Jan  8 2012 should be week 2');
     assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3.', 'Jan  9 2012 should be week 3');
 });
-

--- a/src/test/locale/sl.js
+++ b/src/test/locale/sl.js
@@ -37,11 +37,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14. 02. 2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. februar 2010'],
             ['LLL',                                '14. februar 2010 15:25'],
             ['LLLL',                               'nedelja, 14. februar 2010 15:25'],
-            ['l',                                  '14. 2. 2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. feb. 2010'],
             ['lll',                                '14. feb. 2010 15:25'],
             ['llll',                               'ned., 14. feb. 2010 15:25']
@@ -330,4 +330,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2.', 'Jan  8 2012 should be week 2');
     assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3.', 'Jan  9 2012 should be week 3');
 });
-

--- a/src/test/locale/sr-cyrl.js
+++ b/src/test/locale/sr-cyrl.js
@@ -38,11 +38,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14. 02. 2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. фебруар 2010'],
             ['LLL',                                '14. фебруар 2010 15:25'],
             ['LLLL',                               'недеља, 14. фебруар 2010 15:25'],
-            ['l',                                  '14. 2. 2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. феб. 2010'],
             ['lll',                                '14. феб. 2010 15:25'],
             ['llll',                               'нед., 14. феб. 2010 15:25']
@@ -241,4 +241,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2.', 'Jan  8 2012 should be week 2');
     assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3.', 'Jan  9 2012 should be week 3');
 });
-

--- a/src/test/locale/sr.js
+++ b/src/test/locale/sr.js
@@ -38,11 +38,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14. 02. 2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. februar 2010'],
             ['LLL',                                '14. februar 2010 15:25'],
             ['LLLL',                               'nedelja, 14. februar 2010 15:25'],
-            ['l',                                  '14. 2. 2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. feb. 2010'],
             ['lll',                                '14. feb. 2010 15:25'],
             ['llll',                               'ned., 14. feb. 2010 15:25']
@@ -241,4 +241,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2.', 'Jan  8 2012 should be week 2');
     assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3.', 'Jan  9 2012 should be week 3');
 });
-


### PR DESCRIPTION
First time making a PR for moment and I tried to follow the contributing guidelines as much as possible. Since #3329 changed format, the PR failed those tests. Is there a need to rewrite those tests so that the new convention is followed? Thanks

Signed-off-by: shaishavgandhi05 <shaishgandhi@gmail.com>