### PR TITLE
fix bug when used in typescript and browser-side

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -533,4 +533,6 @@ declare namespace moment {
   export var defaultFormat: string;
 }
 
-export = moment;
+declare module "moment" {
+    export = moment;
+}


### PR DESCRIPTION
code example:
```ts
/// <reference types="moment"/>
moment();
```
the error message is `can not find moment`
so I compare it with some similar library's typings, eg, socket.io-client(https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/socket.io-client/socket.io-client.d.ts) it declares a module('socket.io-client'), so I tried to do something similar, it did fix the error.

and it doesn't affect:(nodejs-side)
```ts
import * as moment from "moment";
moment();
``` 