### PR TITLE
[misc] benchmarks: Add add, subtract, endOf, query benchmarks

### DIFF
--- a/benchmarks/add.js
+++ b/benchmarks/add.js
@@ -1,0 +1,22 @@
+var Benchmark = require('benchmark'),
+    moment = require("./../moment.js"),
+    base = moment('2013-05-25');
+
+var unitsUnderTest = ["milliseconds", "seconds", "minutes", "hours", "days", "weeks", "months", "quarters", "years"];
+var tests = unitsUnderTest.reduce(function (testsSoFar, unit) {
+    testsSoFar["add " + unit] = generateTestForUnit(unit);
+    return testsSoFar;
+}, {});
+
+function generateTestForUnit(unit) {
+    return {
+        setup: function(){var base = base; var unit = unit;},
+        fn: function(){base.add(8, unit);},
+        async: true
+    };
+}
+
+module.exports = {
+    name: 'add',
+    tests: tests
+};

--- a/benchmarks/endOf.js
+++ b/benchmarks/endOf.js
@@ -1,0 +1,22 @@
+var Benchmark = require('benchmark'),
+    moment = require("./../moment.js"),
+    base = moment('2013-05-25');
+
+var unitsUnderTest = ["second", "minute", "hour", "date", "day", "isoWeek", "week", "month", "quarter", "year"];
+var tests = unitsUnderTest.reduce(function (testsSoFar, unit) {
+    testsSoFar["endOf " + unit] = generateTestForUnit(unit);
+    return testsSoFar;
+}, {});
+
+function generateTestForUnit(unit) {
+    return {
+        setup: function(){var base = base; var unit = unit;},
+        fn: function(){base.endOf(unit);},
+        async: true
+    };
+}
+
+module.exports = {
+    name: 'endOf',
+    tests: tests
+};

--- a/benchmarks/query.js
+++ b/benchmarks/query.js
@@ -1,0 +1,40 @@
+var Benchmark = require('benchmark'),
+    moment = require("./../moment.js"),
+    base = moment('2013-05-25');
+
+
+module.exports = {
+    name: 'clone',
+    tests: {
+        isBefore_true: {
+            onComplete: function(){},
+            fn: function(){base.isBefore('2013-06-25');},
+            async: true
+        },
+        isBefore_self: {
+            onComplete: function(){},
+            fn: function(){base.isBefore('2013-05-25');},
+            async: true
+        },
+        isBefore_false: {
+            onComplete: function(){},
+            fn: function(){base.isBefore('2013-04-25');},
+            async: true
+        },
+        isAfter_true: {
+            onComplete: function(){},
+            fn: function(){base.isAfter('2013-04-25');},
+            async: true
+        },
+        isAfter_self: {
+            onComplete: function(){},
+            fn: function(){base.isAfter('2013-05-25');},
+            async: true
+        },
+        isAfter_false: {
+            onComplete: function(){},
+            fn: function(){base.isAfter('2013-06-25');},
+            async: true
+        }
+    }
+};

--- a/benchmarks/startOf.js
+++ b/benchmarks/startOf.js
@@ -1,0 +1,22 @@
+var Benchmark = require('benchmark'),
+    moment = require("./../moment.js"),
+    base = moment('2013-05-25');
+
+var unitsUnderTest = ["second", "minute", "hour", "date", "day", "isoWeek", "week", "month", "quarter", "year"];
+var tests = unitsUnderTest.reduce(function (testsSoFar, unit) {
+    testsSoFar["startOf " + unit] = generateTestForUnit(unit);
+    return testsSoFar;
+}, {});
+
+function generateTestForUnit(unit) {
+    return {
+        setup: function(){var base = base; var unit = unit;},
+        fn: function(){base.startOf(unit);},
+        async: true
+    };
+}
+
+module.exports = {
+    name: 'startOf',
+    tests: tests
+};

--- a/benchmarks/subtract.js
+++ b/benchmarks/subtract.js
@@ -1,0 +1,22 @@
+var Benchmark = require('benchmark'),
+    moment = require("./../moment.js"),
+    base = moment('2013-05-25');
+
+var unitsUnderTest = ["milliseconds", "seconds", "minutes", "hours", "days", "weeks", "months", "quarters", "years"];
+var tests = unitsUnderTest.reduce(function (testsSoFar, unit) {
+    testsSoFar["subtract " + unit] = generateTestForUnit(unit);
+    return testsSoFar;
+}, {});
+
+function generateTestForUnit(unit) {
+    return {
+        setup: function(){var base = base; var unit = unit;},
+        fn: function(){base.subtract(8, unit);},
+        async: true
+    };
+}
+
+module.exports = {
+    name: 'subtract',
+    tests: tests
+};


### PR DESCRIPTION
I had a specific need to test and understand the relative cost of several operations in moment for one of the applications I am working on. I felt it would make sense to offer some of these benchmarks back upstream. 