### PR TITLE
Add missing types to unitOfTime union

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -210,6 +210,7 @@ declare namespace moment {
   type UnitOfTime = ("year" | "years" | "y" |
               "quarter" | "quarters" | "Q" |
               "month" | "months" | "M" |
+              "date" | "dates" | "D" |
               "week" | "weeks" | "w" |
               "day" | "days" | "d" |
               "hour" | "hours" | "h" |


### PR DESCRIPTION
```moment().set('date' , 1)``` yields the first day of the month as documented at http://momentjs.com/docs/#/get-set/set/
I tried the 'dates' and 'D' alternatives in moment@2.14.1 and they have the same behavior.