### PR TITLE
[bugfix] parsing: Fix parseZone without timezone in string, fixes #3083

### DIFF
--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -164,7 +164,13 @@ export function setOffsetToParsedOffset () {
     if (this._tzm) {
         this.utcOffset(this._tzm);
     } else if (typeof this._i === 'string') {
-        this.utcOffset(offsetFromString(matchOffset, this._i));
+        var tZone = offsetFromString(matchOffset, this._i);
+
+        if (tZone === 0) {
+            this.utcOffset(0, true);
+        } else {
+            this.utcOffset(offsetFromString(matchOffset, this._i));
+        }
     }
     return this;
 }

--- a/src/test/moment/zones.js
+++ b/src/test/moment/zones.js
@@ -458,3 +458,13 @@ test('timezone format', function (assert) {
     assert.equal(moment().zone(+90).format('ZZ'), '-0130', '+90 -> -0130');
     assert.equal(moment().zone(+120).format('ZZ'), '-0200', '+120 -> -0200');
 });
+
+test('parse zone without a timezone', function (assert) {
+    test.expectedDeprecations();
+    var m = moment.parseZone('2016-02-01T00:00:00');
+    assert.equal(
+        m.format('M D YYYY HH:mm:ss ZZ'),
+        '2 1 2016 00:00:00 +0000',
+        'Not providing a timezone should keep the time and change the zone to 0'
+    );
+});


### PR DESCRIPTION
Calling parseZone without a timezone had unexpected results. Followed guidelines from #3083 for correcting the issue.

Fixes: #3083