### PR TITLE
[bugfix] toJSON: Fix isValid so that toJSON works after a moment is frozen

### DIFF
--- a/src/lib/create/valid.js
+++ b/src/lib/create/valid.js
@@ -9,7 +9,7 @@ export function isValid(m) {
         var parsedParts = some.call(flags.parsedDateParts, function (i) {
             return i != null;
         });
-        m._isValid = !isNaN(m._d.getTime()) &&
+        var isNowValid = !isNaN(m._d.getTime()) &&
             flags.overflow < 0 &&
             !flags.empty &&
             !flags.invalidMonth &&
@@ -20,10 +20,17 @@ export function isValid(m) {
             (!flags.meridiem || (flags.meridiem && parsedParts));
 
         if (m._strict) {
-            m._isValid = m._isValid &&
+            isNowValid = isNowValid &&
                 flags.charsLeftOver === 0 &&
                 flags.unusedTokens.length === 0 &&
                 flags.bigHour === undefined;
+        }
+
+        if (!Object.isFrozen(m)) {
+            m._isValid = isNowValid;
+        }
+        else {
+            return isNowValid;
         }
     }
     return m._isValid;

--- a/src/test/moment/to_type.js
+++ b/src/test/moment/to_type.js
@@ -27,3 +27,15 @@ test('toDate returns a copy of the internal date', function (assert) {
     m.year(0);
     assert.notEqual(d, m.toDate());
 });
+
+test('toJSON', function (assert) {
+    var expected = new Date().toISOString();
+    assert.deepEqual(moment(expected).toJSON(), expected, 'toJSON invalid');
+});
+
+test('toJSON works when moment is frozen', function (assert) {
+    var expected = new Date().toISOString();
+    var m = moment(expected);
+    Object.freeze(m);
+    assert.deepEqual(m.toJSON(), expected, 'toJSON when frozen invalid');
+});


### PR DESCRIPTION
A small fix so that moments can be serialized with `JSON.stringify` after `Object.freeze` has been used on it.