### PR TITLE
set Sunday as the first day of the week for 'pt-br' locale

### DIFF
--- a/min/moment-with-locales.js
+++ b/min/moment-with-locales.js
@@ -9725,7 +9725,10 @@
             yy : '%d anos'
         },
         ordinalParse: /\d{1,2}º/,
-        ordinal : '%dº'
+        ordinal : '%dº',
+        week : {
+            dow : 0 // Sunday is the first day of the week
+        }
     });
 
 

--- a/src/test/locale/pt-br.js
+++ b/src/test/locale/pt-br.js
@@ -207,6 +207,5 @@ test('weeks year starting sunday format', function (assert) {
 
 test('the first day of week is Sunday', function (assert) {
     var firstDayOfWeek = moment().weekday(0).format('dddd');
-    
     assert.equal(firstDayOfWeek, 'Domingo');
 });

--- a/src/test/locale/pt-br.js
+++ b/src/test/locale/pt-br.js
@@ -205,3 +205,8 @@ test('weeks year starting sunday format', function (assert) {
     assert.equal(moment([2012, 0, 15]).format('w ww wo'), '3 03 3º', 'Jan 15 2012 should be week 3');
 });
 
+test('the first day of week is Sunday', function (assert) {
+    var firstDayOfWeek = moment().weekday(0).format('dddd');
+    
+    assert.equal(firstDayOfWeek, 'Domingo');
+});


### PR DESCRIPTION
- add 'week' object to 'pt-br' locale with property 'dow' as 0.
- add test for it

fixes [#3400](https://github.com/moment/moment/issues/3400)