### PR TITLE
Update moment.d.ts: calendar format function takes `now`

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -14,8 +14,6 @@ declare function moment(date: moment.Moment): moment.Moment;
 declare function moment(date: Object): moment.Moment;
 
 declare namespace moment {
-  type formatFunction = () => string;
-
   interface MomentDateObject {
     years?: number;
     /* One digit */
@@ -136,13 +134,15 @@ declare namespace moment {
     ms?: number;
   }
 
+  type calendarFormatFunction = (now: Moment) => string;
+
   interface MomentCalendar {
-    lastDay?: string | formatFunction;
-    sameDay?: string | formatFunction;
-    nextDay?: string | formatFunction;
-    lastWeek?: string | formatFunction;
-    nextWeek?: string | formatFunction;
-    sameElse?: string | formatFunction;
+    lastDay?: string | calendarFormatFunction;
+    sameDay?: string | calendarFormatFunction;
+    nextDay?: string | calendarFormatFunction;
+    lastWeek?: string | calendarFormatFunction;
+    nextWeek?: string | calendarFormatFunction;
+    sameElse?: string | calendarFormatFunction;
   }
 
   interface MomentRelativeTime {


### PR DESCRIPTION
When using a custom format function for the [calendar](http://momentjs.com/docs/#/displaying/calendar-time/) method, the format function will be passed `now`, which is expected to be a Moment.