### PR TITLE
typings: Added default localized formats available for values in format()

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -237,6 +237,16 @@ declare namespace moment {
   }
 
   interface Moment {
+    format(format: 'LT'): string;
+    format(format: 'LTS'): string;
+    format(format: 'L' ): string;
+    format(format: 'l'): string;
+    format(format: 'LL'): string;
+    format(format: 'll'): string;
+    format(format: 'LLL'): string;
+    format(format: 'lll'): string;
+    format(format: 'LLLL'): string;
+    format(format: 'llll'): string;
     format(format: string): string;
     format(): string;
 
@@ -461,10 +471,8 @@ declare namespace moment {
   export function utc(): Moment;
   export function utc(date: number): Moment;
   export function utc(date: number[]): Moment;
-  export function utc(date: string, format?: string, strict?: boolean): Moment;
-  export function utc(date: string, format?: string, language?: string, strict?: boolean): Moment;
-  export function utc(date: string, formats: string[], strict?: boolean): Moment;
-  export function utc(date: string, formats: string[], language?: string, strict?: boolean): Moment;
+  export function utc(date: string, format?: moment.MomentFormatSpecification, strict?: boolean): Moment;
+  export function utc(date: string, format?: moment.MomentFormatSpecification, language?: string, strict?: boolean): Moment;
   export function utc(date: Date): Moment;
   export function utc(date: Moment): Moment;
   export function utc(date: Object): Moment;

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -155,6 +155,7 @@ a3.hours();
 var a4 = moment([2010, 1, 14, 15, 25, 50, 125]);
 a4.format("dddd, MMMM Do YYYY, h:mm:ss a");
 a4.format("ddd, hA");
+a4.format('LLLL');
 
 moment().format('\\L');
 moment().format('[today] DDDD');


### PR DESCRIPTION
This is a small change to add the default localized formats as signature methods for `format`.    This is mainly just a convenience change to make it apparent to TypeScript users, that there are some default formats available without having to drop back to the docs.  (Which are amazing by the way!)

The other small change was to make `moment.utc()` match the definition for `moment()`.


Also... thanks for making this wonderful library, anytime I have to do more than 3 things with a Date in JavaScript I just grab `moment`. 👍 ❤️ 