### PR TITLE
Add missing signatures for Moment.utcOffset method in TypeScript definition file

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -405,6 +405,9 @@ declare namespace moment {
     utcOffset(): number;
     utcOffset(b: number): Moment;
     utcOffset(b: string): Moment;
+    utcOffset(b: number, keepLocalTime: boolean): Moment;
+    utcOffset(b: string, keepLocalTime: boolean): Moment;
+
     daysInMonth(): number;
     isDST(): boolean;
 

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -197,6 +197,10 @@ moment(1318874398806).unix();
 moment([2000]).isLeapYear();
 moment().zone();
 moment().utcOffset();
+moment().utcOffset(0);
+moment().utcOffset("+0000");
+moment().utcOffset(0, true);
+moment().utcOffset("+0000", true);
 moment("2012-2", "YYYY-MM").daysInMonth();
 moment([2011, 2, 12]).isDST();
 


### PR DESCRIPTION
To fix issue #3464 