### PR TITLE
export defineLocale for god sake

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -489,7 +489,8 @@ declare namespace moment {
   export function localeData(language?: string): MomentLanguageData;
 
   export function updateLocale(language: string, locale: MomentLanguage): MomentLanguage;
-
+  export function defineLocale(language: string, locale: any): MomentLanguage;
+  
   export var longDateFormat: any;
   export var relativeTime: any;
   export var meridiem: (hour: number, minute: number, isLowercase: boolean) => string;


### PR DESCRIPTION
because we just simply need it in typescript. tnx
don`t enforce MomentLanguage cause it makes lots of error on your existing locale. that is why I did put any as a type for locale property.