### PR TITLE
[bugfix] Fix #3500: ISO 8601 parsing should match the full string, not the beginning of the string.

### DIFF
--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -5,8 +5,8 @@ import getParsingFlags from './parsing-flags';
 
 // iso 8601 regex
 // 0000-00-00 0000-W00 or 0000-W00-0 + T + 00 or 00:00 or 00:00:00 or 00:00:00.000 + +00:00 or +0000 or +00)
-var extendedIsoRegex = /^\s*((?:[+-]\d{6}|\d{4})-(?:\d\d-\d\d|W\d\d-\d|W\d\d|\d\d\d|\d\d))(?:(T| )(\d\d(?::\d\d(?::\d\d(?:[.,]\d+)?)?)?)([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?/;
-var basicIsoRegex = /^\s*((?:[+-]\d{6}|\d{4})(?:\d\d\d\d|W\d\d\d|W\d\d|\d\d\d|\d\d))(?:(T| )(\d\d(?:\d\d(?:\d\d(?:[.,]\d+)?)?)?)([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?/;
+var extendedIsoRegex = /^\s*((?:[+-]\d{6}|\d{4})-(?:\d\d-\d\d|W\d\d-\d|W\d\d|\d\d\d|\d\d))(?:(T| )(\d\d(?::\d\d(?::\d\d(?:[.,]\d+)?)?)?)([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?$/;
+var basicIsoRegex = /^\s*((?:[+-]\d{6}|\d{4})(?:\d\d\d\d|W\d\d\d|W\d\d|\d\d\d|\d\d))(?:(T| )(\d\d(?:\d\d(?:\d\d(?:[.,]\d+)?)?)?)([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?$/;
 
 var tzRegex = /Z|[+-]\d\d(?::?\d\d)?/;
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -614,6 +614,7 @@ test('non iso 8601 strings', function (assert) {
     assert.ok(!moment('2015W10T1015', moment.ISO_8601, true).isValid(), 'incomplete week date with time (basic)');
     assert.ok(!moment('2015-10-08T1015', moment.ISO_8601, true).isValid(), 'mixing extended and basic format');
     assert.ok(!moment('20151008T10:15', moment.ISO_8601, true).isValid(), 'mixing basic and extended format');
+    assert.ok(!moment('2015-10-1', moment.ISO_8601, true).isValid(), 'missing zero padding for day');
 });
 
 test('parsing iso week year/week/weekday', function (assert) {

--- a/src/test/moment/is_same.js
+++ b/src/test/moment/is_same.js
@@ -140,9 +140,9 @@ test('is same millisecond', function (assert) {
 });
 
 test('is same with utc offset moments', function (assert) {
-    assert.ok(moment.parseZone('2013-02-01T-05:00').isSame(moment('2013-02-01'), 'year'), 'zoned vs local moment');
+    assert.ok(moment.parseZone('2013-02-01T00:00:00-05:00').isSame(moment('2013-02-01'), 'year'), 'zoned vs local moment');
     assert.ok(moment('2013-02-01').isSame(moment('2013-02-01').utcOffset('-05:00'), 'year'), 'local vs zoned moment');
-    assert.ok(moment.parseZone('2013-02-01T-05:00').isSame(moment.parseZone('2013-02-01T-06:30'), 'year'),
+    assert.ok(moment.parseZone('2013-02-01T00:00:00-05:00').isSame(moment.parseZone('2013-02-01T00:00:00-06:30'), 'year'),
             'zoned vs (differently) zoned moment');
 });
 

--- a/src/test/moment/is_same_or_after.js
+++ b/src/test/moment/is_same_or_after.js
@@ -161,9 +161,9 @@ test('is same or after millisecond', function (assert) {
 });
 
 test('is same or after with utc offset moments', function (assert) {
-    assert.ok(moment.parseZone('2013-02-01T-05:00').isSameOrAfter(moment('2013-02-01'), 'year'), 'zoned vs local moment');
+    assert.ok(moment.parseZone('2013-02-01T00:00:00-05:00').isSameOrAfter(moment('2013-02-01'), 'year'), 'zoned vs local moment');
     assert.ok(moment('2013-02-01').isSameOrAfter(moment('2013-02-01').utcOffset('-05:00'), 'year'), 'local vs zoned moment');
-    assert.ok(moment.parseZone('2013-02-01T-05:00').isSameOrAfter(moment.parseZone('2013-02-01T-06:30'), 'year'),
+    assert.ok(moment.parseZone('2013-02-01T00:00:00-05:00').isSameOrAfter(moment.parseZone('2013-02-01T00:00:00-06:30'), 'year'),
             'zoned vs (differently) zoned moment');
 });
 

--- a/src/test/moment/is_same_or_before.js
+++ b/src/test/moment/is_same_or_before.js
@@ -161,10 +161,12 @@ test('is same or before millisecond', function (assert) {
 });
 
 test('is same with utc offset moments', function (assert) {
-    assert.ok(moment.parseZone('2013-02-01T-05:00').isSameOrBefore(moment('2013-02-01'), 'year'), 'zoned vs local moment');
+    assert.ok(moment.parseZone('2013-02-01T00:00:00-05:00').isSameOrBefore(moment('2013-02-01'), 'year'), 'zoned vs local moment');
     assert.ok(moment('2013-02-01').isSameOrBefore(moment('2013-02-01').utcOffset('-05:00'), 'year'), 'local vs zoned moment');
-    assert.ok(moment.parseZone('2013-02-01T-05:00').isSameOrBefore(moment.parseZone('2013-02-01T-06:30'), 'year'),
-            'zoned vs (differently) zoned moment');
+    assert.ok(
+      moment.parseZone('2013-02-01T00:00:00-05:00').isSameOrBefore(moment.parseZone('2013-02-01T00:00:00-06:30'), 'year'),
+      'zoned vs (differently) zoned moment'
+    );
 });
 
 test('is same with invalid moments', function (assert) {


### PR DESCRIPTION
Before the fix, date strings which started with a valid ISO pattern but ended with non-conforming data would pass as valid ISO dates and not trigger the deprecation warning, causing garbage-in/garbage-out bugs and silent failure.

Example of a garbage date which was considered Valid ISO before:

```
 2016-01-Just a bunch of junk
```

Example of silent failure cases:

```
2016-12-4 would be match the "YYYY-MM" ISO pattern, so would silently become "2016-12-1". 
2000-01-01T11:00:00 PM would match the "  2000-01-01T11:00:00" ISO pattern, silently turning 11 PM into 11 AM. 
```

Non of the above cases trigger the "non-ISO deprecation warning", either. 

Because of the nature of how the related tests are put together, the newly added test _passes_ even before the fix is applied.

This happens because the "non-ISO" tests are tested against the same ISO regex which is being fixed.

Because the broken regex is also used in the test, it allowed the non ISO date to be validated before the fix.
---

This fix exposed another problem with non-ISO dates in the test suite, so it causes 3 other test failures, which are now fixed, too. The other test failures are in:

  test/moment/is_same_or_before.js
  test/moment/is_same_or_after.js

All concern dates which look like this:

   2013-02-01T-05:00

From what I can tell, it is not valid IS0 8601 to include a timezone offset without a time. The references I checked included:
- The moment test suite, which has an extensive set of ISO 8601 cases to test
- IS0 8601 wikipedia page
- Attempt an IS0 8601 ABNF grammar http://www.egenconsulting.com/ietfcns.nsf/0bd281b2cc02b86a852564060002ca3d/cfcc618830db7cc5852563fb00584230?OpenDocument

These tests were updated to avoid this invalid date format after @icambron agreed the dates were not ISO format but should be. 
