### PR TITLE
[tests] Fixes #3463, parseZone not handling Z correctly (tests only)

### DIFF
--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -161,6 +161,7 @@ export function setOffsetToLocal (keepLocalTime) {
 }
 
 export function setOffsetToParsedOffset () {
+    //`this._tzm` can be a modifier of 0, otherwise check if its a truthy value
     if (this._tzm === 0 || this._tzm) {
         this.utcOffset(this._tzm);
     } else if (typeof this._i === 'string') {

--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -161,11 +161,10 @@ export function setOffsetToLocal (keepLocalTime) {
 }
 
 export function setOffsetToParsedOffset () {
-    if (this._tzm) {
+    if (this._tzm === 0 || this._tzm) {
         this.utcOffset(this._tzm);
     } else if (typeof this._i === 'string') {
         var tZone = offsetFromString(matchOffset, this._i);
-
         if (tZone === 0) {
             this.utcOffset(0, true);
         } else {

--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -161,8 +161,7 @@ export function setOffsetToLocal (keepLocalTime) {
 }
 
 export function setOffsetToParsedOffset () {
-    //`this._tzm` can be a modifier of 0, otherwise check if its a truthy value
-    if (this._tzm === 0 || this._tzm) {
+    if (this._tzm != null) {
         this.utcOffset(this._tzm);
     } else if (typeof this._i === 'string') {
         var tZone = offsetFromString(matchOffset, this._i);

--- a/src/test/moment/zones.js
+++ b/src/test/moment/zones.js
@@ -461,9 +461,27 @@ test('timezone format', function (assert) {
 
 test('parse zone without a timezone', function (assert) {
     test.expectedDeprecations();
-    var m = moment.parseZone('2016-02-01T00:00:00');
+    var m1 = moment.parseZone('2016-02-01T00:00:00');
+    var m2 = moment.parseZone('2016-02-01T00:00:00Z');
+    var m3 = moment.parseZone('2016-02-01T00:00:00+00:00'); //Someone might argue this is not necessary, you could even argue that is wrong being here.
+    var m4 = moment.parseZone('2016-02-01T00:00:00+0000'); //Someone might argue this is not necessary, you could even argue that is wrong being here.
     assert.equal(
-        m.format('M D YYYY HH:mm:ss ZZ'),
+        m1.format('M D YYYY HH:mm:ss ZZ'),
+        '2 1 2016 00:00:00 +0000',
+        'Not providing a timezone should keep the time and change the zone to 0'
+    );
+    assert.equal(
+        m2.format('M D YYYY HH:mm:ss ZZ'),
+        '2 1 2016 00:00:00 +0000',
+        'Not providing a timezone should keep the time and change the zone to 0'
+    );
+    assert.equal(
+        m3.format('M D YYYY HH:mm:ss ZZ'),
+        '2 1 2016 00:00:00 +0000',
+        'Not providing a timezone should keep the time and change the zone to 0'
+    );
+    assert.equal(
+        m4.format('M D YYYY HH:mm:ss ZZ'),
         '2 1 2016 00:00:00 +0000',
         'Not providing a timezone should keep the time and change the zone to 0'
     );


### PR DESCRIPTION
This fix assumed that the flow control was failing to correctly handle `0` offsets and was interpreting them as falsey when we didnt it want it to ^^
