### PR TITLE
[bugfix] Fix invalid moments returning valid dates to method calls

### DIFF
--- a/src/lib/moment/constructor.js
+++ b/src/lib/moment/constructor.js
@@ -60,7 +60,9 @@ var updateInProgress = false;
 export function Moment(config) {
     copyConfig(this, config);
     this._d = new Date(config._d != null ? config._d.getTime() : NaN);
-    if (!this.isValid()) this._d = new Date(NaN);
+    if (!this.isValid()) {
+        this._d = new Date(NaN);
+    }
     // Prevent infinite loop in case updateOffset creates new moment
     // objects.
     if (updateInProgress === false) {

--- a/src/lib/moment/constructor.js
+++ b/src/lib/moment/constructor.js
@@ -60,6 +60,7 @@ var updateInProgress = false;
 export function Moment(config) {
     copyConfig(this, config);
     this._d = new Date(config._d != null ? config._d.getTime() : NaN);
+    if (!this.isValid()) this._d = new Date(NaN);
     // Prevent infinite loop in case updateOffset creates new moment
     // objects.
     if (updateInProgress === false) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -1102,6 +1102,6 @@ test('parsing only meridiem results in invalid date', function (assert) {
 });
 
 test('invalid dates return invalid for methods that access the _d prop', function (assert) {
-    var momentAsDate = moment(['2015', '12', '1']).toDate()
+    var momentAsDate = moment(['2015', '12', '1']).toDate();
     assert.equal(momentAsDate, 'Invalid Date', 'toDate returns invalid');
 });

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -1100,3 +1100,8 @@ test('parsing only meridiem results in invalid date', function (assert) {
     assert.ok(moment('02:30 p more extra stuff', 'hh:mm a').isValid(), 'because other tokens were parsed, date is valid');
     assert.ok(moment('1/1/2016 extra data', ['a', 'M/D/YYYY']).isValid(), 'took second format, does not pick up on meridiem parsed from first format (good copy)');
 });
+
+test('invalid dates return invalid for methods that access the _d prop', function (assert) {
+    var momentAsDate = moment(['2015', '12', '1']).toDate()
+    assert.equal(momentAsDate, 'Invalid Date', 'toDate returns invalid');
+});


### PR DESCRIPTION
- `toDate`, `valueOf`, and `unix` methods now return invalid when called on invalid moments
- Addresses #3430 
