### PR TITLE
Adds two new methods to get the next or previous day

### DIFF
--- a/src/lib/moment/prototype.js
+++ b/src/lib/moment/prototype.js
@@ -84,13 +84,15 @@ proto.isoWeeksInYear = getISOWeeksInYear;
 
 // Day
 import { getSetDayOfMonth } from '../units/day-of-month';
-import { getSetDayOfWeek, getSetISODayOfWeek, getSetLocaleDayOfWeek } from '../units/day-of-week';
+import { getSetDayOfWeek, getSetISODayOfWeek, getSetLocaleDayOfWeek, getSetNext, getSetPrevious } from '../units/day-of-week';
 import { getSetDayOfYear } from '../units/day-of-year';
 proto.date       = getSetDayOfMonth;
 proto.day        = proto.days             = getSetDayOfWeek;
 proto.weekday    = getSetLocaleDayOfWeek;
 proto.isoWeekday = getSetISODayOfWeek;
 proto.dayOfYear  = getSetDayOfYear;
+proto.next       = getSetNext;
+proto.previous   = getSetPrevious;
 
 // Hour
 import { getSetHour } from '../units/hour';

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -260,6 +260,44 @@ export function getSetISODayOfWeek (input) {
     }
 }
 
+export function getSetNext (input, offset) {
+    offset = offset ? offset * 7 : 0;
+    if (!this.isValid()) {
+        return input != null ? this : NaN;
+    }
+    var day = this._isUTC ? this._d.getUTCDay() : this._d.getDay();
+    if (input != null) {
+        input = parseWeekday(input, this.localeData()) % 7;
+        var change = (input >= 0 ? input : input * -1) - day + offset;
+        if (input > day) {
+            return this.add(change, 'd');
+        } else {
+            return this.add(change + 7, 'd');
+        }
+    } else {
+        return this.add(7, 'd');
+    }
+}
+
+export function getSetPrevious (input, offset) {
+    offset = offset ? offset * 7 : 0;
+    if (!this.isValid()) {
+        return input != null ? this : NaN;
+    }
+    var day = this._isUTC ? this._d.getUTCDay() : this._d.getDay();
+    if (input != null) {
+        input = parseWeekday(input, this.localeData()) % 7;
+        var change = day - (input >= 0 ? input : input * -1) + offset;
+        if (input < day) {
+            return this.subtract(change, 'd');
+        } else {
+            return this.subtract(change + 7, 'd');
+        }
+    } else {
+        return this.subtract(7, 'd');
+    }
+}
+
 var defaultWeekdaysRegex = matchWord;
 export function weekdaysRegex (isStrict) {
     if (this._weekdaysParseExact) {

--- a/src/test/moment/getters_setters.js
+++ b/src/test/moment/getters_setters.js
@@ -240,6 +240,28 @@ test('day setter', function (assert) {
     assert.equal(moment(a).day(17).date(), 26, 'set from wednesday to second next wednesday');
 });
 
+test('next day setter', function (assert) {
+    var a = moment([2016, 9, 13]);
+    assert.equal(moment(a).next().date(), 20, 'set from thursday to thursday one week later');
+    assert.equal(moment(a).next(0).date(), 16, 'set from thursday to sunday');
+    assert.equal(moment(a).next(5).date(), 14, 'set from thursday to immediate next friday');
+
+    assert.equal(moment(a).next(0,1).date(), 23, 'set from thursday to sunday one week from now');
+    assert.equal(moment(a).next(4,2).date(), 3, 'set from thursday to thursday in two weeks');
+    assert.equal(moment(a).next(14,1).date(), 23, 'set from thursday to the second sunday from then');
+});
+
+test('previous day setter', function (assert) {
+    var a = moment([2016, 9, 13]);
+    assert.equal(moment(a).previous().date(), 6, 'set from thursday to thursday one week before');
+    assert.equal(moment(a).previous(0).date(), 9, 'set from thursday to last sunday');
+    assert.equal(moment(a).previous(5).date(), 7, 'set from thursday to last friday');
+
+    assert.equal(moment(a).previous(0,1).date(), 2, 'set from thursday to sunday one week before');
+    assert.equal(moment(a).previous(4,2).date(), 22, 'set from thursday to thursday in two weeks');
+    assert.equal(moment(a).previous(14,1).date(), 2, 'set from thursday to the second sunday from then');
+});
+
 test('object set ordering', function (assert) {
     var a = moment([2016,3,30]);
     assert.equal(a.set({date:31, month:4}).date(), 31, 'setter order automatically arranged by size');


### PR DESCRIPTION
Discussed in #2522, these two new methods (`next()` and `previous()`) should help those who want to calculate 'last Wednesday' or 'Sunday in two weeks'. It's similar to `day()` in usage, but isn't confined to the current week. So on Saturday, every day you request using `next()` will be in the next week (assuming Sunday as 0). In addition, it takes a second parameter which determines the offset in weeks.

**Next and previous methods**
These methods take two parameters, day (string or number) and offset in weeks (number). It defaults to the current day, exactly one week from now. The optional offset in weeks shifts the result by 7 days forward or backward.
```javascript
moment().next(day, offset)
moment().previous(day, offset)
```

**Examples**
Given today's date (2016-10-17) we can do the following:
```javascript
moment().next() // Monday 24th
moment().next("Wednesday") // Wednesday 19th
moment().next(0, 1) // Sunday 30th
moment().previous() // Monday 10th
moment().previous(4, 2) // September 29th
```

