### PR TITLE
[bugfix] parseZone should handle UTC

### DIFF
--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -48,12 +48,19 @@ addParseToken(['Z', 'ZZ'], function (input, array, config) {
 var chunkOffset = /([\+\-]|\d\d)/gi;
 
 function offsetFromString(matcher, string) {
-    var matches = ((string || '').match(matcher) || []);
+    var matches = (string || '').match(matcher);
+
+    if (matches === null) {
+        return null;
+    }
+
     var chunk   = matches[matches.length - 1] || [];
     var parts   = (chunk + '').match(chunkOffset) || ['-', 0, 0];
     var minutes = +(parts[1] * 60) + toInt(parts[2]);
 
-    return parts[0] === '+' ? minutes : -minutes;
+    return minutes === 0 ?
+      0 :
+      parts[0] === '+' ? minutes : -minutes;
 }
 
 // Return a moment from input, that is local/utc/zone equivalent to model.
@@ -104,6 +111,9 @@ export function getSetOffset (input, keepLocalTime) {
     if (input != null) {
         if (typeof input === 'string') {
             input = offsetFromString(matchShortOffset, input);
+            if (input === null) {
+                return this;
+            }
         } else if (Math.abs(input) < 16) {
             input = input * 60;
         }
@@ -165,11 +175,11 @@ export function setOffsetToParsedOffset () {
         this.utcOffset(this._tzm);
     } else if (typeof this._i === 'string') {
         var tZone = offsetFromString(matchOffset, this._i);
-
-        if (tZone === 0) {
+        if (tZone != null) {
+            this.utcOffset(tZone);
+        }
+        else {
             this.utcOffset(0, true);
-        } else {
-            this.utcOffset(offsetFromString(matchOffset, this._i));
         }
     }
     return this;

--- a/src/test/moment/utc_offset.js
+++ b/src/test/moment/utc_offset.js
@@ -439,6 +439,12 @@ test('parse zone', function (assert) {
     assert.equal(m.hours(), 0);
 });
 
+test('parse UTC zone', function (assert) {
+    var m = moment('2013-01-01T05:00:00+00:00').parseZone();
+    assert.equal(m.utcOffset(), 0);
+    assert.equal(m.hours(), 5);
+});
+
 test('parse zone static', function (assert) {
     var m = moment.parseZone('2013-01-01T00:00:00-13:00');
     assert.equal(m.utcOffset(), -13 * 60);


### PR DESCRIPTION
Fix for #3520 and #3521, where `parseZone` doesn't handle UTC correctly. Specifically, we need to treat parsing `0` out of the string differently from failing to parse it at all.
