### PR TITLE
Fix diff and localeData definitions

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -10,6 +10,8 @@ declare function moment(date: Object): moment.Moment;
 declare namespace moment {
   type formatFunction = () => string;
 
+  type MomentComparable = Moment | string | number | Date | number[];
+
   interface MomentDateObject {
     years?: number;
     /* One digit */
@@ -22,11 +24,149 @@ declare namespace moment {
     milliseconds?: number;
   }
 
-  interface MomentLanguageData extends BaseMomentLanguage {
+  interface MomentLanguageData {
     /**
-    * @param formatType should be L, LL, LLL, LLLL.
-    */
-    longDateFormat(formatType: string): string;
+     * Get the full localized month name of a moment object
+     * @param  {Moment} aMoment a moment object
+     * @return {string}         full month name
+     */
+    months(aMoment: Moment): string;
+
+    /**
+     * Get the short localized month name of a moment object
+     * @param  {Moment} aMoment a moment object
+     * @return {string}         short month name
+     */
+    monthsShort(aMoment: Moment): string;
+
+    /**
+     * Parses a month name and returns the month id (0-11)
+     * @param  {string} longOrShortMonthString string of month to parse
+     * @return {number}                        month id (0 to 11) of input
+     */
+    monthsParse(longOrShortMonthString: string): number;
+
+    /**
+     * Gets the full weekday name of a moment object (eg. Monday)
+     * @param  {Moment} aMoment a moment object
+     * @return {string}         full weekday name
+     */
+    weekdays(aMoment: Moment): string;
+
+    /**
+     * Gets the short weekday name of a moment object (eg. Mon)
+     * @param  {Moment} aMoment a moment object
+     * @return {string}         short weekday name
+     */
+    weekdaysShort(aMoment: Moment): string;
+
+    /**
+     * Gets the min weekday name of a moment object (eg. Mo)
+     * @param  {Moment} aMoment a moment object
+     * @return {string}         min weekday name
+     */
+    weekdaysMin(aMoment: Moment): string;
+
+    /**
+     * Parses a weekday name and returns the weekday id (0-6)
+     * @param  {string} longOrShortMonthString string of weekday to parse
+     * @return {number}                        weekday id (0 to 6) of input
+     */
+    weekdaysParse(longOrShortMonthString: string): number;
+
+    /**
+     * Returns the full format of abbreviated date-time formats
+     * @param  {string} dateFormat date-time format such as LT, L, LL and so on
+     * @return {string}            full date format string
+     */
+    longDateFormat(dateFormat: string): string;
+
+    /**
+     * Returns whether a string represents PM
+     * @param  {string}  amPmString date string to check
+     * @return {boolean}            true if string represents PM
+     */
+    isPM(amPmString: string): boolean;
+
+    /**
+     * Returns am/pm string for particular time-of-day in upper/lower case
+     * @param  {number}  hour        hour
+     * @param  {number}  minute      minute
+     * @param  {boolean} isLowercase whether to return in lowercase
+     * @return {string}              'am' or 'pm'
+     */
+    meridiem(hour: number, minute: number, isLowercase: boolean): string;
+
+    /**
+     * Returns a format that would be used for calendar representation.
+     * @param  {string} key     one of 'sameDay', 'nextDay', 'lastDay', 'nextWeek', 'prevWeek', 'sameElse'
+     * @param  {Moment} aMoment a moment object
+     * @return {string}         date format string
+     */
+    calendar(key: string, aMoment: Moment): string;
+
+    /**
+     * Returns relative time string (eg. a year ago)
+     * @param  {number}  number        the relative number
+     * @param  {boolean} withoutSuffix whether to drop the suffix
+     * @param  {string}  key           one of 's', 'm', 'mm', 'h', 'hh', 'd', 'dd', 'M', 'MM', 'y', 'yy'. Single letter when number is 1.
+     * @param  {boolean} isFuture      whether this represents a future date
+     * @return {string}                humanized representation of relative time
+     */
+    relativeTime(number: number, withoutSuffix: boolean, key: string, isFuture: boolean): string;
+
+    /**
+     * Converts relative time string to past or future string depending on difference
+     * @param  {number} diff    positive or negative number
+     * @param  {string} relTime relative time string
+     * @return {string}         humanized representation of relative time
+     */
+    pastFuture(diff: number, relTime: string): string;
+
+    /**
+     * Convert number to ordinal string 1 -> 1st
+     * @param  {number} number the number
+     * @return {string}        ordinal string
+     */
+    ordinal(number: number): string;
+
+    /**
+     * Called before parsing every input string
+     */
+    preparse(str: string): string;
+
+    /**
+     * Called after formatting on every string
+     */
+    postformat(str: string): string;
+
+    /**
+     * Returns week-of-year of a moment object
+     * @param  {Moment} aMoment a moment object
+     * @return {number}         number of the week
+     */
+    week(aMoment: Moment): number;
+
+    /**
+     * Returns a translation of 'Invalid date'
+     * @return {string} translation of 'Invalid date'
+     */
+    invalidDate(): string;
+
+    /**
+     * Returns the first day of the week (0-6, Sunday to Saturday)
+     * @return {number} first day of the week
+     */
+    firstDayOfWeek(): number;
+
+    /**
+     * This and the first day of week are used to determine which is
+     * the first week of the year. dow == 1 and doy == 4 means week starts
+     * Monday and first week that has Thursday is the first week of the
+     * year (but doy is NOT simply Thursday).
+     * @return {number} number between 0-15
+     */
+    firstDayOfYear(): number;
   }
 
   interface Duration {
@@ -384,13 +524,11 @@ declare namespace moment {
     dayOfYear(): number;
     dayOfYear(d: number): Moment;
 
-    from(f: Moment | string | number | Date | number[], suffix?: boolean): string;
-    to(f: Moment | string | number | Date | number[], suffix?: boolean): string;
+    from(f: MomentComparable, suffix?: boolean): string;
+    to(f: MomentComparable, suffix?: boolean): string;
     toNow(withoutPrefix?: boolean): string;
 
-    diff(b: Moment): number;
-    diff(b: Moment, unitOfTime: UnitOfTime): number;
-    diff(b: Moment, unitOfTime: UnitOfTime, precise: boolean): number;
+    diff(b: MomentComparable, unitOfTime?: UnitOfTime, precise?: boolean): number;
 
     toArray(): number[];
     toDate(): Date;
@@ -409,16 +547,16 @@ declare namespace moment {
     isDST(): boolean;
 
     isBefore(): boolean;
-    isBefore(b: Moment | string | number | Date | number[], granularity?: string): boolean;
+    isBefore(b: MomentComparable, granularity?: string): boolean;
 
     isAfter(): boolean;
-    isAfter(b: Moment | string | number | Date | number[], granularity?: string): boolean;
+    isAfter(b: MomentComparable, granularity?: string): boolean;
 
-    isSame(b: Moment | string | number | Date | number[], granularity?: string): boolean;
-    isSameOrAfter(b: Moment | string | number | Date | number[], granularity?: string): boolean;
-    isSameOrBefore(b: Moment | string | number | Date | number[], granularity?: string): boolean;
+    isSame(b: MomentComparable, granularity?: string): boolean;
+    isSameOrAfter(b: MomentComparable, granularity?: string): boolean;
+    isSameOrBefore(b: MomentComparable, granularity?: string): boolean;
 
-    isBetween(a: Moment | string | number | Date | number[], b: Moment | string | number | Date | number[], granularity?: string, inclusivity?: string): boolean;
+    isBetween(a: MomentComparable, b: MomentComparable, granularity?: string, inclusivity?: string): boolean;
 
     // Deprecated as of 2.8.0.
     lang(language: string): Moment;
@@ -433,17 +571,17 @@ declare namespace moment {
 
     localeData(language: string): Moment;
     localeData(reset: boolean): Moment;
-    localeData(): MomentLanguage;
+    localeData(): MomentLanguageData;
 
     defineLocale(language: string, locale: MomentLanguage): MomentLanguage;
     updateLocale(language: string, locale: MomentLanguage): MomentLanguage;
 
     // Deprecated as of 2.7.0.
-    max(date: Moment | string | number | Date | any[]): Moment;
+    max(date: MomentComparable): Moment;
     max(date: string, format: string): Moment;
 
     // Deprecated as of 2.7.0.
-    min(date: Moment | string | number | Date | any[]): Moment;
+    min(date: MomentComparable): Moment;
     min(date: string, format: string): Moment;
 
     get(unit: UnitOfTime): number;

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -185,10 +185,14 @@ moment([2007, 0, 29]).fromNow(true);
 
 var a8 = moment([2007, 0, 29]);
 var b8 = moment([2007, 0, 28]);
-a8.diff(b8) ;
+a8.diff(b8);
 a8.diff(b8, 'days');
 a8.diff(b8, 'years')
 a8.diff(b8, 'years', true);
+a8.diff(new Date());
+a8.diff(new Date().toISOString());
+a8.diff(new Date().getTime());
+a8.diff([2016, 1, 22]);
 
 moment([2007, 0, 29]).toDate();
 moment([2007, 1, 23]).toISOString();
@@ -224,6 +228,29 @@ var localLang = moment();
 localLang.localeData('fr');
 localLang.format('LLLL');
 globalLang.format('LLLL');
+
+var localeData = moment.localeData();
+var aMoment = moment();
+localeData.months(aMoment);
+localeData.monthsShort(aMoment);
+localeData.monthsParse('jan');
+localeData.weekdays(aMoment);
+localeData.weekdaysShort(aMoment);
+localeData.weekdaysMin(aMoment);
+localeData.weekdaysParse('monday');
+localeData.longDateFormat('LL');
+localeData.isPM('03:25 PM');
+localeData.meridiem(2, 5, true);
+localeData.calendar('sameDay', aMoment);
+var relTime = localeData.relativeTime(1, true, 's', true);
+localeData.pastFuture(4, relTime);
+localeData.ordinal(1);
+localeData.preparse('str');
+localeData.postformat('str');
+localeData.week(aMoment);
+localeData.invalidDate();
+localeData.firstDayOfWeek();
+localeData.firstDayOfYear();
 
 moment.duration(100);
 moment.duration(2, 'seconds');


### PR DESCRIPTION
1. Add definitions ([source](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/moment/moment.d.ts)) and tests (own) for `moment.localeData()`
2. Fix definition for `moment().diff()` to allow other input types besides `Moment` (own).
3. Add intermediate type `MomentComparable` for re-use ([source](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/moment/moment.d.ts)).

Note: I haven't looked into all the differences between this definition file and the one on DefinitelyTypes. It would be great to have them converged.
