### PR TITLE
[pkg] Publish Meteor package from meteor directory to fix #3531

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -159,24 +159,15 @@ module.exports = function (grunt) {
         },
         exec: {
             'meteor-init': {
-                command: [
-                    // Make sure Meteor is installed, per https://meteor.com/install.
-                    // The curl'ed script is safe; takes 2 minutes to read source & check.
-                    'type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }',
-                    // Meteor expects package.js to be in the root directory of
-                    // the checkout, but we already have a package.js for Dojo
-                    'mv package.js package.dojo && cp meteor/package.js .'
-                ].join(';')
-            },
-            'meteor-cleanup': {
-                // remove build files and restore Dojo's package.js
-                command: 'rm -rf ".build.*" versions.json; mv package.dojo package.js'
+                // Make sure Meteor is installed, per https://meteor.com/install.
+                // The curl'ed script is safe; takes 2 minutes to read source & check.
+                command: 'type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }'
             },
             'meteor-test': {
-                command: 'spacejam --mongo-url mongodb:// test-packages ./'
+                command: 'spacejam --mongo-url mongodb:// test-packages ./meteor'
             },
             'meteor-publish': {
-                command: 'meteor publish'
+                command: 'cd meteor && meteor publish'
             },
             'typescript-test': {
                 command: 'node_modules/.bin/tsc --project typing-tests'

--- a/meteor/moment.js
+++ b/meteor/moment.js
@@ -1,0 +1,1 @@
+../moment.js

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -6,7 +6,7 @@ var packageName = 'momentjs:moment';  // https://atmospherejs.com/momentjs/momen
 Package.describe({
   name: packageName,
   summary: 'Moment.js (official): parse, validate, manipulate, and display dates - official Meteor packaging',
-  version: '2.15.2',
+  version: '2.15.3',
   git: 'https://github.com/moment/moment.git'
 });
 
@@ -15,7 +15,7 @@ Package.onUse(function (api) {
   api.export('moment');
   api.addFiles([
     'moment.js',
-    'meteor/export.js'
+    'export.js'
   ]);
 });
 
@@ -23,5 +23,5 @@ Package.onTest(function (api) {
   api.use(packageName);
   api.use('tinytest');
 
-  api.addFiles('meteor/test.js');
+  api.addFiles('test.js');
 });


### PR DESCRIPTION
Fixes issue #3531.

Instead of copying `meteor/package.js` into the root directory and publishing from there, the Grunt script should run `meteor publish` from the `meteor/` directory. This commit implements the changes necessary to make that work.

The most important benefit of this change is that the nearly 200MB of `node_modules` in the root `moment` directory will not accidentally be published along with the Meteor package. This behavior is new in 1.4.2, and was an intentional change, but unfortunately it means `momentjs:moment@2.15.2` is very large, and even unusable for some developers.

I work for Meteor Development Group, and this is a popular package in our developer community, so I hope you'll consider merging this pull request quickly.

If you want to test these changes (in particular the reduction in package size), I've published an identical package called `benjamn:moment`, which you can add to any Meteor app:

``` sh
meteor create test-app
cd test-app
meteor add benjamn:moment
du -chs $(which meteor)/../packages/benjamn_moment
meteor run
```
