### PR TITLE
[bugfix] Implement lazy-loading of child locales with missing prents

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -11,6 +11,7 @@ import { baseConfig } from './base-config';
 
 // internal storage for locale config files
 var locales = {};
+var localeFamilies = {};
 var globalLocale;
 
 function normalizeLocale(key) {
@@ -97,15 +98,29 @@ export function defineLocale (name, config) {
             if (locales[config.parentLocale] != null) {
                 parentConfig = locales[config.parentLocale]._config;
             } else {
-                // treat as if there is no base config
-                deprecateSimple('parentLocaleUndefined',
-                        'specified parentLocale is not defined yet. See http://momentjs.com/guides/#/warnings/parent-locale/');
+                if (!localeFamilies[config.parentLocale]) {
+                    localeFamilies[config.parentLocale] = [];
+                }
+                localeFamilies[config.parentLocale].push({
+                    name: name,
+                    config: config
+                });
+                return null;
             }
         }
         locales[name] = new Locale(mergeConfigs(parentConfig, config));
 
+        if (localeFamilies[name]) {
+            localeFamilies[name].forEach(function (x) {
+                defineLocale(x.name, x.config);
+            });
+        }
+
         // backwards compat for now: also set the locale
+        // make sure we set the locale AFTER all child locales have been
+        // created, so we won't end up with the child locale set.
         getSetGlobalLocale(name);
+
 
         return locales[name];
     } else {

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -163,3 +163,20 @@ test('months', function (assert) {
     });
     assert.ok(moment.utc('2015-01-01', 'YYYY-MM-DD').format('MMMM'), 'First', 'months uses child');
 });
+
+test('define child locale before parent', function (assert) {
+    moment.defineLocale('months-x', null);
+    moment.defineLocale('base-months-x', null);
+
+    moment.defineLocale('months-x', {
+        parentLocale: 'base-months-x',
+        months : 'First_Second_Third_Fourth_Fifth_Sixth_Seventh_Eighth_Ninth_Tenth_Eleventh_Twelveth '.split('_')
+    });
+    assert.equal(moment.locale(), 'en', 'failed to set a locale requiring missing parent');
+    moment.defineLocale('base-months-x', {
+        months : 'One_Two_Three_Four_Five_Six_Seven_Eight_Nine_Ten_Eleven_Twelve'.split('_')
+    });
+    assert.equal(moment.locale(), 'base-months-x', 'defineLocale should also set the locale (regardless of child locales)');
+
+    assert.equal(moment().locale('months-x').month(0).format('MMMM'), 'First', 'loading child before parent locale works');
+});


### PR DESCRIPTION
This is a minimalistic redo of #3336 without the crazy test scaffolding.

@skfd what do you think.

I'd wait and see if users are happy, there are a few ways to improve it, but if that works I'm happy to leave it.
