### PR TITLE
[misc] Clean up usage of `typeof`

### DIFF
--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -1,6 +1,7 @@
 import isArray from '../utils/is-array';
 import isObject from '../utils/is-object';
 import isObjectEmpty from '../utils/is-object-empty';
+import isUndefined from '../utils/is-undefined';
 import isNumber from '../utils/is-number';
 import isDate from '../utils/is-date';
 import map from '../utils/map';
@@ -63,7 +64,7 @@ export function prepareConfig (config) {
 
 function configFromInput(config) {
     var input = config._i;
-    if (input === undefined) {
+    if (isUndefined(input)) {
         config._d = new Date(hooks.now());
     } else if (isDate(input)) {
         config._d = new Date(input.valueOf());
@@ -74,7 +75,7 @@ function configFromInput(config) {
             return parseInt(obj, 10);
         });
         configFromArray(config);
-    } else if (typeof(input) === 'object') {
+    } else if (isObject(input)) {
         configFromObject(config);
     } else if (isNumber(input)) {
         // from milliseconds


### PR DESCRIPTION
`typeof` is an operator not a function. Removing the unneeded parenthesis
makes this clear. Additionally, using `typeof` to check for undefined
values rather than checking equality to `undefined` is safer. Comparing
to `undefined` can be broken if someone assigns to `window.undefined`.