### PR TITLE
Bugfix/fix module reference

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -557,4 +557,6 @@ declare namespace moment {
   export var defaultFormatUtc: string;
 }
 
-export = moment;
+declare module 'moment' {
+  export = moment;
+}

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -1,6 +1,3 @@
-/// <reference path="../moment.d.ts" />
-import moment = require('../moment');
-
 moment().add('hours', 1).fromNow();
 
 var day = new Date(2011, 9, 16);


### PR DESCRIPTION
Found that it was impossible to pull in the moment declaration into Typescript application reliably, and it didn't appear to have the module declaration.  This adds the declaration along with fixing the test script.  Tested under Typescript 1.8 and 2.0.