### PR TITLE
Updated typings to allow for isoWeeks

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -217,6 +217,7 @@ declare namespace moment {
               "quarter" | "quarters" | "Q" |
               "month" | "months" | "M" |
               "week" | "weeks" | "w" |
+              "isoWeek" | "isoWeeks" | "W" |
               "date" | "dates" | "d" |
               "day" | "days" |
               "hour" | "hours" | "h" |


### PR DESCRIPTION
TypeScript does not allow for the "isoWeek" unit of time and causes an error when trying to compile

[StartOf Documentation](http://momentjs.com/docs/#/manipulating/start-of/)

Before this change simply trying to use 

`let date = moment().year(2016).dayOfYear(271).startOf('isoWeek').toDate() `
 
Would cause TypeScript to throw this error 

`Argument of type '"isoWeek"' is not assignable to parameter of type '"s" | "year" | "years" | "y" | "quarter" | "quarters" | "Q" | "month" | "months" | "M" | "week" |...'.`