### PR TITLE
[build] Drop 0.10 environment from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "0.12"
-  - "0.10"
 sudo: false
 
 env:


### PR DESCRIPTION
https://github.com/moment/moment/pull/3545#issuecomment-258198233

Node 0.10 is dead. Long live Node!