### PR TITLE
[misc] Avoid boolean type check

### DIFF
--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -84,7 +84,7 @@ function configFromInput(config) {
 export function createLocalOrUTC (input, format, locale, strict, isUTC) {
     var c = {};
 
-    if (typeof(locale) === 'boolean') {
+    if (locale === true || locale === false) {
         strict = locale;
         locale = undefined;
     }


### PR DESCRIPTION
In #3559 @ichernev stated that he would prefer two strict comparisons
(to `true` and `false`) over checking the type.

This pull request actualizes that preference.