### PR TITLE
[build] Remove babel from rollup+babel combo to speed up build

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "qunit": "^0.7.5",
         "qunit-cli": "^0.1.4",
         "rollup": "latest",
-        "rollup-plugin-babel": "latest",
         "spacejam": "latest",
         "typescript": "^1.8.10",
         "coveralls": "^2.11.2",

--- a/tasks/transpile.js
+++ b/tasks/transpile.js
@@ -1,7 +1,7 @@
 module.exports = function (grunt) {
     // var esperanto = require('esperanto');
     var rollup = require('rollup').rollup;
-    var babel = require('rollup-plugin-babel');
+    // var babel = require('rollup-plugin-babel');
     var path = require('path');
     var Promise = require('es6-promise').Promise;
     var TMP_DIR = 'build/tmp';
@@ -49,7 +49,7 @@ module.exports = function (grunt) {
         var rollupOpts = {
             entry: opts.entry,
             plugins: [
-                babel({})
+                // babel({})
             ]
         }, bundleOpts = {
             format: 'umd',


### PR DESCRIPTION
And we're not using it anyway.

With esprima: 8.2s
With rollup only: 13.3s
With rollup+babel: 40s