### PR TITLE
Fixed "Argument of type ... is not assignable to string index type" error.

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -67,8 +67,8 @@ declare namespace moment {
     lastWeek?: CalendarSpecVal;
     sameElse?: CalendarSpecVal;
 
-    // any additonal properties might be used with moment.calendarFormat
-    [x: string]: CalendarSpecVal;
+    // any additional properties might be used with moment.calendarFormat
+    [x: string]: CalendarSpecVal | undefined;
   }
 
   type RelativeTimeSpecVal = (


### PR DESCRIPTION
Typescript v2.1.1 compiler is giving me following errors:

> /src/browser/node_modules/moment/moment.d.ts(63,5): error TS2411: Property 'sameDay' of type 'string | ((m?: Moment | undefined, now?: Moment | undefined) => string) | undefined' is not assignable to string index type 'CalendarSpecVal'.
> /src/browser/node_modules/moment/moment.d.ts(64,5): error TS2411: Property 'nextDay' of type 'string | ((m?: Moment | undefined, now?: Moment | undefined) => string) | undefined' is not assignable to string index type 'CalendarSpecVal'.
> /src/browser/node_modules/moment/moment.d.ts(65,5): error TS2411: Property 'lastDay' of type 'string | ((m?: Moment | undefined, now?: Moment | undefined) => string) | undefined' is not assignable to string index type 'CalendarSpecVal'.
> /src/browser/node_modules/moment/moment.d.ts(66,5): error TS2411: Property 'nextWeek' of type 'string | ((m?: Moment | undefined, now?: Moment | undefined) => string) | undefined' is not assignable to string index type 'CalendarSpecVal'.
> /src/browser/node_modules/moment/moment.d.ts(67,5): error TS2411: Property 'lastWeek' of type 'string | ((m?: Moment | undefined, now?: Moment | undefined) => string) | undefined' is not assignable to string index type 'CalendarSpecVal'.
> /src/browser/node_modules/moment/moment.d.ts(68,5): error TS2411: Property 'sameElse' of type 'string | ((m?: Moment | undefined, now?: Moment | undefined) => string) | undefined' is not assignable to string index type 'CalendarSpecVal'.

That's because `sameDay` and other properties have `CalendarSpecVal | undefined` type but string index type is `CalendarSpecVal`.