### PR TITLE
Fix accidental reference to global "value" variable

### DIFF
--- a/src/lib/utils/is-number.js
+++ b/src/lib/utils/is-number.js
@@ -1,3 +1,3 @@
 export default function isNumber(input) {
-    return typeof value === 'number' || Object.prototype.toString.call(input) === '[object Number]';
+    return typeof input === 'number' || Object.prototype.toString.call(input) === '[object Number]';
 }


### PR DESCRIPTION
Hi,

We just encountered a bug today where moment was incorrectly parsing year and month fields. The bug was introduced while upgrading to moment v2.16.0.

We eventually tracked it down to another library (modular-scale) which was setting a global variable called `value` to a number. The isNumber function in moment is then mistakenly referencing this global value instead of the input value it gets passed. This pull request fixes the problem.

All the best,
David