### PR TITLE
Fix TypeScript definition export

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -708,3 +708,4 @@ declare namespace moment {
 }
 
 export = moment;
+export as namespace moment;


### PR DESCRIPTION
This patch fixes TypeScript definition import when not using the module system (i.e. when using /// <reference path="..." />).

Signed-off-by: RandomBK <david@david-li.com>