### PR TITLE
Fix typescript compile error with strictNullChecks enabled

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -68,7 +68,7 @@ declare namespace moment {
     sameElse?: CalendarSpecVal;
 
     // any additonal properties might be used with moment.calendarFormat
-    [x: string]: CalendarSpecVal;
+    [x: string]: CalendarSpecVal | undefined;
   }
 
   type RelativeTimeSpecVal = (


### PR DESCRIPTION
Fixes error compile error with 'strictNullChecks' enabled in typescript by declaring the `[x: string]` accessor as being possibly undefined (see #3599).

 