### PR TITLE
[feature] Durations gain validity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,5 +96,5 @@ Once you become a member:
 But also:
 * be active in the repositories
 * pick up work nobody else wants to
-* attent a montly meeting
+* attend a monthly meeting
 * participate in the internal slack group

--- a/src/lib/duration/as.js
+++ b/src/lib/duration/as.js
@@ -3,6 +3,9 @@ import { normalizeUnits } from '../units/aliases';
 import toInt from '../utils/to-int';
 
 export function as (units) {
+    if (!this.isValid()) {
+        return NaN;
+    }
     var days;
     var months;
     var milliseconds = this._milliseconds;
@@ -31,6 +34,9 @@ export function as (units) {
 
 // TODO: Use this.as('ms')?
 export function valueOf () {
+    if (!this.isValid()) {
+        return NaN;
+    }
     return (
         this._milliseconds +
         this._days * 864e5 +

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -6,6 +6,7 @@ export function Duration (duration) {
     var normalizedInput = normalizeObjectUnits(duration);
 
     this._isValid = isDurationValid(normalizedInput);
+    this.isValid = () => this._isValid;
 
     var years = this._isValid && normalizedInput.year || 0,
         quarters = this._isValid && normalizedInput.quarter || 0,

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -15,9 +15,6 @@ export function Duration (duration) {
         milliseconds = normalizedInput.millisecond || 0;
 
     this._isValid = isDurationValid(normalizedInput);
-    this.isValid = function () {
-        return this._isValid;
-    };
 
     // representation for dateAddRemove
     this._milliseconds = +milliseconds +

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -3,22 +3,21 @@ import { getLocale } from '../locale/locales';
 import isDurationValid from './valid.js';
 
 export function Duration (duration) {
-    var normalizedInput = normalizeObjectUnits(duration);
+    var normalizedInput = normalizeObjectUnits(duration),
+        years = normalizedInput.year || 0,
+        quarters = normalizedInput.quarter || 0,
+        months = normalizedInput.month || 0,
+        weeks = normalizedInput.week || 0,
+        days = normalizedInput.day || 0,
+        hours = normalizedInput.hour || 0,
+        minutes = normalizedInput.minute || 0,
+        seconds = normalizedInput.second || 0,
+        milliseconds = normalizedInput.millisecond || 0;
 
     this._isValid = isDurationValid(normalizedInput);
     this.isValid = function () {
         return this._isValid;
     };
-
-    var years = this._isValid && normalizedInput.year || 0,
-        quarters = this._isValid && normalizedInput.quarter || 0,
-        months = this._isValid && normalizedInput.month || 0,
-        weeks = this._isValid && normalizedInput.week || 0,
-        days = this._isValid && normalizedInput.day || 0,
-        hours = this._isValid && normalizedInput.hour || 0,
-        minutes = this._isValid && normalizedInput.minute || 0,
-        seconds = this._isValid && normalizedInput.second || 0,
-        milliseconds = this._isValid && normalizedInput.millisecond || 0;
 
     // representation for dateAddRemove
     this._milliseconds = +milliseconds +

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -6,7 +6,9 @@ export function Duration (duration) {
     var normalizedInput = normalizeObjectUnits(duration);
 
     this._isValid = isDurationValid(normalizedInput);
-    this.isValid = () => this._isValid;
+    this.isValid = function () {
+        return this._isValid;
+    };
 
     var years = this._isValid && normalizedInput.year || 0,
         quarters = this._isValid && normalizedInput.quarter || 0,

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -1,17 +1,21 @@
 import { normalizeObjectUnits } from '../units/aliases';
 import { getLocale } from '../locale/locales';
+import isDurationValid from './valid.js';
 
 export function Duration (duration) {
-    var normalizedInput = normalizeObjectUnits(duration),
-        years = normalizedInput.year || 0,
-        quarters = normalizedInput.quarter || 0,
-        months = normalizedInput.month || 0,
-        weeks = normalizedInput.week || 0,
-        days = normalizedInput.day || 0,
-        hours = normalizedInput.hour || 0,
-        minutes = normalizedInput.minute || 0,
-        seconds = normalizedInput.second || 0,
-        milliseconds = normalizedInput.millisecond || 0;
+    var normalizedInput = normalizeObjectUnits(duration);
+
+    this._isValid = isDurationValid(normalizedInput);
+
+    var years = this._isValid && normalizedInput.year || 0,
+        quarters = this._isValid && normalizedInput.quarter || 0,
+        months = this._isValid && normalizedInput.month || 0,
+        weeks = this._isValid && normalizedInput.week || 0,
+        days = this._isValid && normalizedInput.day || 0,
+        hours = this._isValid && normalizedInput.hour || 0,
+        minutes = this._isValid && normalizedInput.minute || 0,
+        seconds = this._isValid && normalizedInput.second || 0,
+        milliseconds = this._isValid && normalizedInput.millisecond || 0;
 
     // representation for dateAddRemove
     this._milliseconds = +milliseconds +

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -6,6 +6,7 @@ import hasOwnProp from '../utils/has-own-prop';
 import { DATE, HOUR, MINUTE, SECOND, MILLISECOND } from '../units/constants';
 import { cloneWithOffset } from '../units/offset';
 import { createLocal } from '../create/local';
+import { createInvalid as invalid } from './valid';
 
 // ASP.NET json date format regex
 var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)(\.\d*)?)?$/;
@@ -77,6 +78,7 @@ export function createDuration (input, key) {
 }
 
 createDuration.fn = Duration.prototype;
+createDuration.invalid = invalid;
 
 function parseIso (inp, sign) {
     // We'd normally use ~~inp for this, but unfortunately it also

--- a/src/lib/duration/get.js
+++ b/src/lib/duration/get.js
@@ -3,12 +3,12 @@ import absFloor from '../utils/abs-floor';
 
 export function get (units) {
     units = normalizeUnits(units);
-    return this[units + 's']();
+    return this.isValid() ? this[units + 's']() : NaN;
 }
 
 function makeGetter(name) {
     return function () {
-        return this._data[name];
+        return this.isValid() ? this._data[name] : NaN;
     };
 }
 

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -65,6 +65,10 @@ export function getSetRelativeTimeThreshold (threshold, limit) {
 }
 
 export function humanize (withSuffix) {
+    if (!this.isValid()) {
+        return this.localeData().invalidDate();
+    }
+
     var locale = this.localeData();
     var output = relativeTime(this, !withSuffix, locale);
 

--- a/src/lib/duration/iso-string.js
+++ b/src/lib/duration/iso-string.js
@@ -9,6 +9,10 @@ export function toISOString() {
     // This is because there is no context-free conversion between hours and days
     // (think of clock changes)
     // and also not between days and months (28-31 days per month)
+    if (!this.isValid()) {
+        return this.localeData().invalidDate();
+    }
+
     var seconds = abs(this._milliseconds) / 1000;
     var days         = abs(this._days);
     var months       = abs(this._months);
@@ -49,4 +53,9 @@ export function toISOString() {
         (h ? h + 'H' : '') +
         (m ? m + 'M' : '') +
         (s ? s + 'S' : '');
+}
+
+export function toJSON() {
+    // this may not be fully implemented
+    return this.isValid() ? this.toISOString() : null;
 }

--- a/src/lib/duration/iso-string.js
+++ b/src/lib/duration/iso-string.js
@@ -54,8 +54,3 @@ export function toISOString() {
         (m ? m + 'M' : '') +
         (s ? s + 'S' : '');
 }
-
-export function toJSON() {
-    // this may not be fully implemented
-    return this.isValid() ? this.toISOString() : null;
-}

--- a/src/lib/duration/prototype.js
+++ b/src/lib/duration/prototype.js
@@ -8,8 +8,9 @@ import { as, asMilliseconds, asSeconds, asMinutes, asHours, asDays, asWeeks, asM
 import { bubble } from './bubble';
 import { get, milliseconds, seconds, minutes, hours, days, months, years, weeks } from './get';
 import { humanize } from './humanize';
-import { toISOString, toJSON } from './iso-string';
+import { toISOString } from './iso-string';
 import { lang, locale, localeData } from '../moment/locale';
+import isDurationValid from './valid';
 
 proto.abs            = abs;
 proto.add            = add;
@@ -37,9 +38,10 @@ proto.years          = years;
 proto.humanize       = humanize;
 proto.toISOString    = toISOString;
 proto.toString       = toISOString;
-proto.toJSON         = toJSON;
+proto.toJSON         = toISOString;
 proto.locale         = locale;
 proto.localeData     = localeData;
+proto.isValid        = isDurationValid;
 
 // Deprecations
 import { deprecate } from '../utils/deprecate';

--- a/src/lib/duration/prototype.js
+++ b/src/lib/duration/prototype.js
@@ -8,7 +8,7 @@ import { as, asMilliseconds, asSeconds, asMinutes, asHours, asDays, asWeeks, asM
 import { bubble } from './bubble';
 import { get, milliseconds, seconds, minutes, hours, days, months, years, weeks } from './get';
 import { humanize } from './humanize';
-import { toISOString } from './iso-string';
+import { toISOString, toJSON } from './iso-string';
 import { lang, locale, localeData } from '../moment/locale';
 
 proto.abs            = abs;
@@ -37,7 +37,7 @@ proto.years          = years;
 proto.humanize       = humanize;
 proto.toISOString    = toISOString;
 proto.toString       = toISOString;
-proto.toJSON         = toISOString;
+proto.toJSON         = toJSON;
 proto.locale         = locale;
 proto.localeData     = localeData;
 

--- a/src/lib/duration/prototype.js
+++ b/src/lib/duration/prototype.js
@@ -10,8 +10,9 @@ import { get, milliseconds, seconds, minutes, hours, days, months, years, weeks 
 import { humanize } from './humanize';
 import { toISOString } from './iso-string';
 import { lang, locale, localeData } from '../moment/locale';
-import isDurationValid from './valid';
+import { isValid } from './valid';
 
+proto.isValid        = isValid;
 proto.abs            = abs;
 proto.add            = add;
 proto.subtract       = subtract;
@@ -41,7 +42,6 @@ proto.toString       = toISOString;
 proto.toJSON         = toISOString;
 proto.locale         = locale;
 proto.localeData     = localeData;
-proto.isValid        = isDurationValid;
 
 // Deprecations
 import { deprecate } from '../utils/deprecate';

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -1,9 +1,24 @@
+var ordering = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'];
+
 export default function isDurationValid(m) {
     for (var key in m) {
-        if (['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'].indexOf(key) === -1 ||
+        if (ordering.indexOf(key) === -1 ||
         m[key] !== undefined && isNaN(parseInt(m[key]))) {
             return false;
         }
     }
+
+    var unitHasDecimal = false;
+    for (var i = 0; i < ordering.length; ++i) {
+        if (m[ordering[i]]) {
+            if (unitHasDecimal) {
+                return false; // only allow non-integers for smallest unit
+            }
+            if (parseFloat(m[ordering[i]]) !== parseInt(m[ordering[i]])) {
+                unitHasDecimal = true;
+            }
+        }
+    }
+
     return true;
 }

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -23,3 +23,7 @@ export default function isDurationValid(m) {
 
     return true;
 }
+
+export function isValid() {
+    return this._isValid;
+}

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -1,4 +1,6 @@
 import toInt from '../utils/to-int';
+import {Duration} from './constructor';
+import {createDuration} from './create';
 
 var ordering = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'];
 
@@ -26,4 +28,8 @@ export default function isDurationValid(m) {
 
 export function isValid() {
     return this._isValid;
+}
+
+export function createInvalid() {
+    return createDuration(NaN);
 }

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -1,0 +1,9 @@
+export default function isDurationValid(m) {
+    for (var key in m) {
+        if (['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'].indexOf(key) === -1 ||
+        m[key] !== undefined && isNaN(parseInt(m[key]))) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -1,9 +1,10 @@
+import toInt from '../utils/to-int';
+
 var ordering = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'];
 
 export default function isDurationValid(m) {
     for (var key in m) {
-        if (ordering.indexOf(key) === -1 ||
-        m[key] !== undefined && isNaN(parseInt(m[key]))) {
+        if (!(ordering.indexOf(key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
             return false;
         }
     }
@@ -14,7 +15,7 @@ export default function isDurationValid(m) {
             if (unitHasDecimal) {
                 return false; // only allow non-integers for smallest unit
             }
-            if (parseFloat(m[ordering[i]]) !== parseInt(m[ordering[i]])) {
+            if (parseFloat(m[ordering[i]]) !== toInt(m[ordering[i]])) {
                 unitHasDecimal = true;
             }
         }

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -53,17 +53,17 @@ test('milliseconds instantiation', function (assert) {
 
 test('undefined instantiation', function (assert) {
     assert.equal(moment.duration(undefined).milliseconds(), 0, 'milliseconds');
-    assert.equal(moment.duration(undefined)._isValid, true, '_isValid');
+    assert.equal(moment.duration(undefined).isValid(), true, '_isValid');
 });
 
 test('null instantiation', function (assert) {
     assert.equal(moment.duration(null).milliseconds(), 0, 'milliseconds');
-    assert.equal(moment.duration(null)._isValid, true, '_isValid');
+    assert.equal(moment.duration(null).isValid(), true, '_isValid');
 });
 
 test('NaN instantiation', function (assert) {
     assert.equal(moment.duration(NaN).milliseconds(), 0, 'milliseconds');
-    assert.equal(moment.duration(NaN)._isValid, false, '_isValid');
+    assert.equal(moment.duration(NaN).isValid(), false, '_isValid');
 });
 
 test('instantiation by type', function (assert) {

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -49,21 +49,25 @@ test('object instantiation with strings', function (assert) {
 
 test('milliseconds instantiation', function (assert) {
     assert.equal(moment.duration(72).milliseconds(), 72, 'milliseconds');
+    assert.equal(moment.duration(72).humanize(), 'a few seconds', 'Duration should be valid');
 });
 
 test('undefined instantiation', function (assert) {
     assert.equal(moment.duration(undefined).milliseconds(), 0, 'milliseconds');
     assert.equal(moment.duration(undefined).isValid(), true, '_isValid');
+    assert.equal(moment.duration(undefined).humanize(), 'a few seconds', 'Duration should be valid');
 });
 
 test('null instantiation', function (assert) {
     assert.equal(moment.duration(null).milliseconds(), 0, 'milliseconds');
     assert.equal(moment.duration(null).isValid(), true, '_isValid');
+    assert.equal(moment.duration(null).humanize(), 'a few seconds', 'Duration should be valid');
 });
 
 test('NaN instantiation', function (assert) {
     assert.equal(moment.duration(NaN).milliseconds(), 0, 'milliseconds');
     assert.equal(moment.duration(NaN).isValid(), false, '_isValid');
+    assert.equal(moment.duration(NaN).humanize(), 'Invalid date', 'Duration should be invalid');
 });
 
 test('instantiation by type', function (assert) {

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -65,7 +65,7 @@ test('null instantiation', function (assert) {
 });
 
 test('NaN instantiation', function (assert) {
-    assert.equal(moment.duration(NaN).milliseconds(), 0, 'milliseconds');
+    assert.ok(isNaN(moment.duration(NaN).milliseconds()), 'milliseconds should be NaN');
     assert.equal(moment.duration(NaN).isValid(), false, '_isValid');
     assert.equal(moment.duration(NaN).humanize(), 'Invalid date', 'Duration should be invalid');
 });

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -305,7 +305,7 @@ test('serialization to ISO 8601 duration strings', function (assert) {
     assert.equal(moment.duration({M: -1}).toISOString(), '-P1M', 'one month ago');
     assert.equal(moment.duration({m: -1}).toISOString(), '-PT1M', 'one minute ago');
     assert.equal(moment.duration({s: -0.5}).toISOString(), '-PT0.5S', 'one half second ago');
-    assert.equal(moment.duration({y: -0.5, M: 1}).toISOString(), '-P5M', 'a month after half a year ago');
+    assert.equal(moment.duration({y: -1, M: 1}).toISOString(), '-P11M', 'a month after a year ago');
     assert.equal(moment.duration({}).toISOString(), 'P0D', 'zero duration');
     assert.equal(moment.duration({M: 16, d:40, s: 86465}).toISOString(), 'P1Y4M40DT24H1M5S', 'all fields');
 });
@@ -315,7 +315,7 @@ test('toString acts as toISOString', function (assert) {
     assert.equal(moment.duration({M: -1}).toString(), '-P1M', 'one month ago');
     assert.equal(moment.duration({m: -1}).toString(), '-PT1M', 'one minute ago');
     assert.equal(moment.duration({s: -0.5}).toString(), '-PT0.5S', 'one half second ago');
-    assert.equal(moment.duration({y: -0.5, M: 1}).toString(), '-P5M', 'a month after half a year ago');
+    assert.equal(moment.duration({y: -1, M: 1}).toString(), '-P11M', 'a month after a year ago');
     assert.equal(moment.duration({}).toString(), 'P0D', 'zero duration');
     assert.equal(moment.duration({M: 16, d:40, s: 86465}).toString(), 'P1Y4M40DT24H1M5S', 'all fields');
 });

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -53,10 +53,17 @@ test('milliseconds instantiation', function (assert) {
 
 test('undefined instantiation', function (assert) {
     assert.equal(moment.duration(undefined).milliseconds(), 0, 'milliseconds');
+    assert.equal(moment.duration(undefined)._isValid, true, '_isValid');
 });
 
 test('null instantiation', function (assert) {
     assert.equal(moment.duration(null).milliseconds(), 0, 'milliseconds');
+    assert.equal(moment.duration(null)._isValid, true, '_isValid');
+});
+
+test('NaN instantiation', function (assert) {
+    assert.equal(moment.duration(NaN).milliseconds(), 0, 'milliseconds');
+    assert.equal(moment.duration(NaN)._isValid, false, '_isValid');
 });
 
 test('instantiation by type', function (assert) {

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -4,12 +4,12 @@ import moment from '../../moment';
 module('invalid');
 
 test('invalid duration', function (assert) {
-    var m = moment.duration(NaN); // should be invalid
+    var m = moment.duration.invalid(); // should be invalid
     assert.equal(m.isValid(), false);
     assert.ok(isNaN(m.valueOf()));
 });
 
-test('valid duration - as per @ichernev', function (assert) {
+test('valid duration', function (assert) {
     var m = moment.duration({d: null}); // should be valid, for now
     assert.equal(m.isValid(), true);
     assert.equal(m.valueOf(), 0);
@@ -36,7 +36,8 @@ test('invalid duration with two arguments', function (assert) {
 test('invalid duration operations', function (assert) {
     var invalids = [
             moment.duration(NaN),
-            moment.duration(NaN, 'days')
+            moment.duration(NaN, 'days'),
+            moment.duration.invalid()
         ],
         i,
         invalid,

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -1,0 +1,67 @@
+import { module, test } from '../qunit';
+import moment from '../../moment';
+
+module('invalid');
+
+test('invalid', function (assert) {
+    var m = moment.duration(NaN); // should be invalid
+    assert.equal(m.isValid(), false);
+    assert.ok(isNaN(m.valueOf()));
+});
+
+// test('invalid with existing flag', function (assert) {
+//     var m = moment.duration({invalidMonth : 'whatchamacallit'});
+//     assert.equal(m.isValid(), false);
+//     assert.ok(isNaN(m.valueOf()));
+// });
+
+test('invalid operations', function (assert) {
+    var invalids = [
+            moment.duration(NaN)
+            // moment.duration({invalidMonth : 'whatchamacallit'})
+        ],
+        i,
+        invalid,
+        valid = moment.duration();
+
+    for (i = 0; i < invalids.length; ++i) {
+        invalid = invalids[i];
+
+        assert.ok(!invalid.add(5, 'hours').isValid(), 'invalid.add is invalid');
+        assert.ok(!invalid.subtract(30, 'days').isValid(), 'invalid.subtract is invalid');
+        assert.ok(!invalid.abs().isValid(), 'invalid.abs is invalid');
+        assert.ok(isNaN(invalid.as('years')), 'invalid.as is NaN');
+        assert.ok(isNaN(invalid.asMilliseconds()), 'invalid.asMilliseconds is NaN');
+        assert.ok(isNaN(invalid.asSeconds()), 'invalid.asSeconds is NaN');
+        assert.ok(isNaN(invalid.asMinutes()), 'invalid.asMinutes is NaN');
+        assert.ok(isNaN(invalid.asHours()), 'invalid.asHours is NaN');
+        assert.ok(isNaN(invalid.asDays()), 'invalid.asDays is NaN');
+        assert.ok(isNaN(invalid.asWeeks()), 'invalid.asWeeks is NaN');
+        assert.ok(isNaN(invalid.asMonths()), 'invalid.asMonths is NaN');
+        assert.ok(isNaN(invalid.asYears()), 'invalid.asYears is NaN');
+        assert.ok(isNaN(invalid.valueOf()), 'invalid.valueOf is NaN');
+        assert.ok(isNaN(invalid.get('hours')), 'invalid.get is NaN');
+
+        assert.ok(isNaN(invalid.milliseconds()), 'invalid.milliseconds is NaN');
+        assert.ok(isNaN(invalid.seconds()), 'invalid.seconds is NaN');
+        assert.ok(isNaN(invalid.minutes()), 'invalid.minutes is NaN');
+        assert.ok(isNaN(invalid.hours()), 'invalid.hours is NaN');
+        assert.ok(isNaN(invalid.days()), 'invalid.days is NaN');
+        assert.ok(isNaN(invalid.weeks()), 'invalid.weeks is NaN');
+        assert.ok(isNaN(invalid.months()), 'invalid.months is NaN');
+        assert.ok(isNaN(invalid.years()), 'invalid.years is NaN');
+
+        assert.equal(invalid.humanize(),
+                     invalid.localeData().invalidDate(),
+                     'invalid.humanize is localized invalid duration string');
+        assert.equal(invalid.toISOString(),
+                     invalid.localeData().invalidDate(),
+                     'invalid.toISOString is localized invalid duration string');
+        assert.equal(invalid.toString(),
+                     invalid.localeData().invalidDate(),
+                     'invalid.toString is localized invalid duration string');
+        assert.equal(invalid.toJSON(), null, 'invalid.toJSON is null');
+        assert.equal(invalid.locale(), 'en');
+        assert.equal(invalid.localeData()._abbr, 'en');
+    }
+});

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -9,16 +9,16 @@ test('invalid duration', function (assert) {
     assert.ok(isNaN(m.valueOf()));
 });
 
-// test('invalid with existing flag', function (assert) {
-//     var m = moment.duration({invalidMonth : 'whatchamacallit'});
-//     assert.equal(m.isValid(), false);
-//     assert.ok(isNaN(m.valueOf()));
-// });
+test('invalid duration with two arguments', function (assert) {
+    var m = moment.duration(NaN, 'days');
+    assert.equal(m.isValid(), false);
+    assert.ok(isNaN(m.valueOf()));
+});
 
 test('invalid duration operations', function (assert) {
     var invalids = [
-            moment.duration(NaN)
-            // moment.duration({invalidMonth : 'whatchamacallit'})
+            moment.duration(NaN),
+            moment.duration(NaN, 'days')
         ],
         i,
         invalid,

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 
 module('invalid');
 
-test('invalid', function (assert) {
+test('invalid duration', function (assert) {
     var m = moment.duration(NaN); // should be invalid
     assert.equal(m.isValid(), false);
     assert.ok(isNaN(m.valueOf()));
@@ -15,7 +15,7 @@ test('invalid', function (assert) {
 //     assert.ok(isNaN(m.valueOf()));
 // });
 
-test('invalid operations', function (assert) {
+test('invalid duration operations', function (assert) {
     var invalids = [
             moment.duration(NaN)
             // moment.duration({invalidMonth : 'whatchamacallit'})

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -39,41 +39,41 @@ test('invalid duration operations', function (assert) {
     for (i = 0; i < invalids.length; ++i) {
         invalid = invalids[i];
 
-        assert.ok(!invalid.add(5, 'hours').isValid(), 'invalid.add is invalid');
-        assert.ok(!invalid.subtract(30, 'days').isValid(), 'invalid.subtract is invalid');
-        assert.ok(!invalid.abs().isValid(), 'invalid.abs is invalid');
-        assert.ok(isNaN(invalid.as('years')), 'invalid.as is NaN');
-        assert.ok(isNaN(invalid.asMilliseconds()), 'invalid.asMilliseconds is NaN');
-        assert.ok(isNaN(invalid.asSeconds()), 'invalid.asSeconds is NaN');
-        assert.ok(isNaN(invalid.asMinutes()), 'invalid.asMinutes is NaN');
-        assert.ok(isNaN(invalid.asHours()), 'invalid.asHours is NaN');
-        assert.ok(isNaN(invalid.asDays()), 'invalid.asDays is NaN');
-        assert.ok(isNaN(invalid.asWeeks()), 'invalid.asWeeks is NaN');
-        assert.ok(isNaN(invalid.asMonths()), 'invalid.asMonths is NaN');
-        assert.ok(isNaN(invalid.asYears()), 'invalid.asYears is NaN');
-        assert.ok(isNaN(invalid.valueOf()), 'invalid.valueOf is NaN');
-        assert.ok(isNaN(invalid.get('hours')), 'invalid.get is NaN');
+        assert.ok(!invalid.add(5, 'hours').isValid(), 'invalid.add is invalid; i=' + i);
+        assert.ok(!invalid.subtract(30, 'days').isValid(), 'invalid.subtract is invalid; i=' + i);
+        assert.ok(!invalid.abs().isValid(), 'invalid.abs is invalid; i=' + i);
+        assert.ok(isNaN(invalid.as('years')), 'invalid.as is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asMilliseconds()), 'invalid.asMilliseconds is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asSeconds()), 'invalid.asSeconds is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asMinutes()), 'invalid.asMinutes is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asHours()), 'invalid.asHours is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asDays()), 'invalid.asDays is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asWeeks()), 'invalid.asWeeks is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asMonths()), 'invalid.asMonths is NaN; i=' + i);
+        assert.ok(isNaN(invalid.asYears()), 'invalid.asYears is NaN; i=' + i);
+        assert.ok(isNaN(invalid.valueOf()), 'invalid.valueOf is NaN; i=' + i);
+        assert.ok(isNaN(invalid.get('hours')), 'invalid.get is NaN; i=' + i);
 
-        assert.ok(isNaN(invalid.milliseconds()), 'invalid.milliseconds is NaN');
-        assert.ok(isNaN(invalid.seconds()), 'invalid.seconds is NaN');
-        assert.ok(isNaN(invalid.minutes()), 'invalid.minutes is NaN');
-        assert.ok(isNaN(invalid.hours()), 'invalid.hours is NaN');
-        assert.ok(isNaN(invalid.days()), 'invalid.days is NaN');
-        assert.ok(isNaN(invalid.weeks()), 'invalid.weeks is NaN');
-        assert.ok(isNaN(invalid.months()), 'invalid.months is NaN');
-        assert.ok(isNaN(invalid.years()), 'invalid.years is NaN');
+        assert.ok(isNaN(invalid.milliseconds()), 'invalid.milliseconds is NaN; i=' + i);
+        assert.ok(isNaN(invalid.seconds()), 'invalid.seconds is NaN; i=' + i);
+        assert.ok(isNaN(invalid.minutes()), 'invalid.minutes is NaN; i=' + i);
+        assert.ok(isNaN(invalid.hours()), 'invalid.hours is NaN; i=' + i);
+        assert.ok(isNaN(invalid.days()), 'invalid.days is NaN; i=' + i);
+        assert.ok(isNaN(invalid.weeks()), 'invalid.weeks is NaN; i=' + i);
+        assert.ok(isNaN(invalid.months()), 'invalid.months is NaN; i=' + i);
+        assert.ok(isNaN(invalid.years()), 'invalid.years is NaN; i=' + i);
 
         assert.equal(invalid.humanize(),
                      invalid.localeData().invalidDate(),
-                     'invalid.humanize is localized invalid duration string');
+                     'invalid.humanize is localized invalid duration string; i=' + i);
         assert.equal(invalid.toISOString(),
                      invalid.localeData().invalidDate(),
-                     'invalid.toISOString is localized invalid duration string');
+                     'invalid.toISOString is localized invalid duration string; i=' + i);
         assert.equal(invalid.toString(),
                      invalid.localeData().invalidDate(),
-                     'invalid.toString is localized invalid duration string');
-        assert.equal(invalid.toJSON(), null, 'invalid.toJSON is null');
-        assert.equal(invalid.locale(), 'en');
-        assert.equal(invalid.localeData()._abbr, 'en');
+                     'invalid.toString is localized invalid duration string; i=' + i);
+        assert.equal(invalid.toJSON(), invalid.localeData().invalidDate(), 'invalid.toJSON is null; i=' + i);
+        assert.equal(invalid.locale(), 'en', 'invalid.locale; i=' + i);
+        assert.equal(invalid.localeData()._abbr, 'en', 'invalid.localeData()._abbr; i=' + i);
     }
 });

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -9,6 +9,18 @@ test('invalid duration', function (assert) {
     assert.ok(isNaN(m.valueOf()));
 });
 
+test('invalid duration - only smallest unit can have decimal', function (assert) {
+    var m = moment.duration({'days': 3.5, 'hours': 1.1}); // should be invalid
+    assert.equal(m.isValid(), false);
+    assert.ok(isNaN(m.valueOf())); // .valueOf() returns NaN for invalid durations
+});
+
+test('valid duration - smallest unit can have decimal', function (assert) {
+    var m = moment.duration({'days': 3, 'hours': 1.1}); // should be valid
+    assert.equal(m.isValid(), true);
+    assert.equal(m.asHours(), 73.1);
+});
+
 test('invalid duration with two arguments', function (assert) {
     var m = moment.duration(NaN, 'days');
     assert.equal(m.isValid(), false);

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -9,6 +9,12 @@ test('invalid duration', function (assert) {
     assert.ok(isNaN(m.valueOf()));
 });
 
+test('valid duration - as per @ichernev', function (assert) {
+    var m = moment.duration({d: null}); // should be valid, for now
+    assert.equal(m.isValid(), true);
+    assert.equal(m.valueOf(), 0);
+});
+
 test('invalid duration - only smallest unit can have decimal', function (assert) {
     var m = moment.duration({'days': 3.5, 'hours': 1.1}); // should be invalid
     assert.equal(m.isValid(), false);


### PR DESCRIPTION
This was hoping to resolve #3225 

- Creates an `_isValid` property for durations, and an accessor `isValid()`
- If not valid, create a duration of time `0` and set `._isValid` to `false`
- `.humanize()` will return the translated version of `Invalid Date` if not valid
- `duration(null)`, `duration(undefined)`, `duration()` will all be valid
- `duration(NaN)` is invalid

