### PR TITLE
Add context for longDateFormat and omit 分 when minutes === 0 in longDateFormat of zh-CN

### DIFF
--- a/src/lib/create/from-string-and-format.js
+++ b/src/lib/create/from-string-and-format.js
@@ -28,7 +28,7 @@ export function configFromStringAndFormat(config) {
         stringLength = string.length,
         totalParsedInputLength = 0;
 
-    tokens = expandFormat(config._f, config._locale).match(formattingTokens) || [];
+    tokens = expandFormat(config._f, config._locale, {input: string}).match(formattingTokens) || [];
 
     for (i = 0; i < tokens.length; i++) {
         token = tokens[i];

--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -67,17 +67,22 @@ export function formatMoment(m, format) {
         return m.localeData().invalidDate();
     }
 
-    format = expandFormat(format, m.localeData());
+    var context = {moment: m};
+    format = expandFormat(format, m.localeData(), context);
     formatFunctions[format] = formatFunctions[format] || makeFormatFunction(format);
 
     return formatFunctions[format](m);
 }
 
-export function expandFormat(format, locale) {
+export function expandFormat(format, locale, context) {
     var i = 5;
 
     function replaceLongDateFormatTokens(input) {
-        return locale.longDateFormat(input) || input;
+        var format = locale.longDateFormat(input) || input;
+        if (typeof format === 'function') {
+            return format(context);
+        }
+        return format;
     }
 
     localFormattingTokens.lastIndex = 0;

--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -16,8 +16,34 @@ export default moment.defineLocale('zh-cn', {
         LTS : 'Ah点m分s秒',
         L : 'YYYY-MM-DD',
         LL : 'YYYY年MMMD日',
-        LLL : 'YYYY年MMMD日Ah点mm分',
-        LLLL : 'YYYY年MMMD日ddddAh点mm分',
+        LLL : function (context) {
+            if (context.input) {
+                if (context.input.indexOf('分') > -1) {
+                    return 'YYYY年MMMD日Ah点mm分';
+                }
+                return 'YYYY年MMMD日Ah点';
+            }
+            if (context.moment) {
+                if (context.moment.minutes() === 0) {
+                    return 'YYYY年MMMD日Ah点';
+                }
+                return 'YYYY年MMMD日Ah点mm分';
+            }
+        },
+        LLLL : function (context) {
+            if (context.input) {
+                if (context.input.indexOf('分') > -1) {
+                    return 'YYYY年MMMD日ddddAh点mm分';
+                }
+                return 'YYYY年MMMD日ddddAh点';
+            }
+            if (context.moment) {
+                if (context.moment.minutes() === 0) {
+                    return 'YYYY年MMMD日ddddAh点';
+                }
+                return 'YYYY年MMMD日ddddAh点mm分';
+            }
+        },
         l : 'YYYY-MM-DD',
         ll : 'YYYY年MMMD日',
         lll : 'YYYY年MMMD日Ah点mm分',

--- a/src/test/helpers/common-locale.js
+++ b/src/test/helpers/common-locale.js
@@ -61,8 +61,12 @@ export function defineCommonLocaleTests(locale, options) {
             // Check each format string to make sure it does not contain any
             // tokens that need to be expanded.
             each(tokens, function (baseToken) {
+                var format = data[baseToken];
+                if (typeof format === 'function') {
+                    format = format.toString();
+                }
                 // strip escaped sequences
-                var format = data[baseToken].replace(/(\[[^\]]*\])/g, '');
+                format = format.replace(/(\[[^\]]*\])/g, '');
                 assert.equal(false, !!~format.indexOf(srchToken),
                         'contains ' + srchToken + ' in ' + baseToken);
             });

--- a/src/test/locale/zh-cn.js
+++ b/src/test/locale/zh-cn.js
@@ -56,6 +56,58 @@ test('format', function (assert) {
     }
 });
 
+test('format when minutes === 0', function (assert) {
+    var a = [
+            ['dddd, MMMM Do YYYY, a h:mm:ss',      '星期日, 二月 14日 2010, 下午 3:00:50'],
+            ['ddd, Ah',                            '周日, 下午3'],
+            ['M Mo MM MMMM MMM',                   '2 2月 02 二月 2月'],
+            ['YYYY YY',                            '2010 10'],
+            ['D Do DD',                            '14 14日 14'],
+            ['d do dddd ddd dd',                   '0 0日 星期日 周日 日'],
+            ['DDD DDDo DDDD',                      '45 45日 045'],
+            ['w wo ww',                            '6 6周 06'],
+            ['h hh',                               '3 03'],
+            ['H HH',                               '15 15'],
+            ['m mm',                               '0 00'],
+            ['s ss',                               '50 50'],
+            ['a A',                                '下午 下午'],
+            ['[这年的第] DDDo',                    '这年的第 45日'],
+            ['LTS',                                '下午3点0分50秒'],
+            ['L',                                  '2010-02-14'],
+            ['LL',                                 '2010年2月14日'],
+            ['LLL',                                '2010年2月14日下午3点'],
+            ['LLLL',                               '2010年2月14日星期日下午3点'],
+            ['l',                                  '2010-02-14'],
+            ['ll',                                 '2010年2月14日'],
+            ['lll',                                '2010年2月14日下午3点00分'],
+            ['llll',                               '2010年2月14日星期日下午3点00分']
+        ],
+        b = moment(new Date(2010, 1, 14, 15, 0, 50, 125)),
+        i;
+
+    for (i = 0; i < a.length; i++) {
+        assert.equal(b.format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
+    }
+});
+
+test('parse', function (assert) {
+    [
+        {
+            format: 'LLL',
+            input: '2010年2月14日下午3点',
+            expected: '2010-02-14 15:00:00'
+        },
+        {
+            format: 'LLL',
+            input: '2010年2月14日下午3点25分',
+            expected: '2010-02-14 15:25:00'
+        }
+    ].forEach(function (testCase) {
+        var parsed = moment(testCase.input, testCase.format).format('YYYY-MM-DD HH:mm:ss');
+        assert.equal(parsed, testCase.expected, testCase.format + ': ' + [parsed, testCase.expected].join(' != '));
+    });
+});
+
 test('format month', function (assert) {
     var expected = '一月 1月_二月 2月_三月 3月_四月 4月_五月 5月_六月 6月_七月 7月_八月 8月_九月 9月_十月 10月_十一月 11月_十二月 12月'.split('_'), i;
 


### PR DESCRIPTION
Just as @jasonkb said in #3608:

> I am especially concerned about the YYYY年MMMD日Ah点mm分 format when there are 0 minutes -- the relatively common case of a timestamp that is on the hour. This comes out as e.g. "2016年11月17日下午4点0分" which is quite awkward -- one would not write it that way, and certainly not speak it that way (the 0分 would be elided). 

This pull request adds context for longDateFormat so that we could return different format based on context. This pull request also omit 分 when minutes === 0 in longDateFormat of zh-CN.

The context object contains 2 fields: context.moment and context.input.
context.moment is the moment instance when we format and context.input is the string input when we parse. 