### PR TITLE
Fixing compilation of moment.d.ts under strict null checks

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -68,7 +68,7 @@ declare namespace moment {
     sameElse?: CalendarSpecVal;
 
     // any additonal properties might be used with moment.calendarFormat
-    [x: string]: CalendarSpecVal;
+    [x: string]: CalendarSpecVal | void;
   }
 
   type RelativeTimeSpecVal = (


### PR DESCRIPTION
There is currently a compilation error when compiling moment.d.ts in TypeScript 2 with strict null checks. 

In the CalendarSpec interface, the 6 properties have type `CalendarSpecVal | undefined` (the undefined comes from them being optional prperties). 
In TypeScript, if there is a string index type, every property in the same interface must be assignable to the string index type. 
And `CalendarSpecVal | undefined` is not assignable to `CalendarSpecVal`. 

This fixes that.