### PR TITLE
[feature] create setTime function

### DIFF
--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -1,4 +1,5 @@
 import { normalizeUnits } from '../units/aliases';
+import { setTime } from '../units/hour';
 
 export function startOf (units) {
     units = normalizeUnits(units);
@@ -16,8 +17,8 @@ export function startOf (units) {
         case 'isoWeek':
         case 'day':
         case 'date':
-            this.hours(0);
-            /* falls through */
+            setTime(this, 0, 0, 0, 0);
+            break;
         case 'hour':
             this.minutes(0);
             /* falls through */

--- a/src/lib/units/hour.js
+++ b/src/lib/units/hour.js
@@ -8,6 +8,7 @@ import { HOUR, MINUTE, SECOND } from './constants';
 import toInt from '../utils/to-int';
 import zeroFill from '../utils/zero-fill';
 import getParsingFlags from '../create/parsing-flags';
+import { hooks } from '../utils/hooks';
 
 // FORMATTING
 
@@ -136,3 +137,10 @@ export function localeMeridiem (hours, minutes, isLower) {
 // a new timezone) makes sense. Adding/subtracting hours does not follow
 // this rule.
 export var getSetHour = makeGetSet('Hours', true);
+
+export function setTime (mom, hours, minutes, seconds, milliseconds) {
+    if (mom.isValid()) {
+        mom._d['set' + (mom._isUTC ? 'UTC' : '') + 'Hours'](hours, minutes, seconds, milliseconds);
+        hooks.updateOffset(mom, true);
+    }
+}


### PR DESCRIPTION
This increases the performance of startOf / endOf by a factor of about 90 for `'day'`.

NB : This is my first PR, i'm not sure what I should do, especially regarding proving my call about this performance gain. I see there is a benchmark folder, but I don't know what to do about it. I have run grunt tests successfully on my computer.