### PR TITLE
[misc] TS: Make typescript definitions work with 1.x

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -68,7 +68,7 @@ declare namespace moment {
     sameElse?: CalendarSpecVal;
 
     // any additional properties might be used with moment.calendarFormat
-    [x: string]: CalendarSpecVal | undefined;
+    [x: string]: CalendarSpecVal | void; // undefined
   }
 
   type RelativeTimeSpecVal = (
@@ -248,12 +248,12 @@ declare namespace moment {
     overflow: number;
     charsLeftOver: number;
     nullInput: boolean;
-    invalidMonth: string | null;
+    invalidMonth: string | void; // null
     invalidFormat: boolean;
     userInvalidated: boolean;
     iso: boolean;
     parsedDateParts: any[];
-    meridiem: string | null;
+    meridiem: string | void; // null
   }
 
   interface MomentParsingFlagsOpt {
@@ -389,8 +389,8 @@ declare namespace moment {
     to: MomentInput;
   }
 
-  type MomentInput = Moment | Date | string | number | (number | string)[] | MomentInputObject | null | undefined;
-  type DurationInputArg1 = Duration | number | string | FromTo | DurationInputObject | null | undefined;
+  type MomentInput = Moment | Date | string | number | (number | string)[] | MomentInputObject | void; // null | undefined
+  type DurationInputArg1 = Duration | number | string | FromTo | DurationInputObject | void; // null | undefined
   type DurationInputArg2 = unitOfTime.DurationConstructor;
   type LocaleSpecifier = string | Moment | Duration | string[];
 
@@ -632,7 +632,7 @@ declare namespace moment {
 
   export function locale(language?: string): string;
   export function locale(language?: string[]): string;
-  export function locale(language?: string, definition?: LocaleSpecification | null | undefined): string;
+  export function locale(language?: string, definition?: LocaleSpecification | void): string; // null | undefined
 
   export function localeData(key?: string | string[]): Locale;
 
@@ -684,8 +684,8 @@ declare namespace moment {
    */
   export function now(): number;
 
-  export function defineLocale(language: string, localeSpec: LocaleSpecification | null): Locale;
-  export function updateLocale(language: string, localeSpec: LocaleSpecification | null): Locale;
+  export function defineLocale(language: string, localeSpec: LocaleSpecification | void): Locale; // null
+  export function updateLocale(language: string, localeSpec: LocaleSpecification | void): Locale; // null
 
   export function locales(): string[];
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "qunit-cli": "^0.1.4",
         "rollup": "latest",
         "spacejam": "latest",
-        "typescript": "^2.0.8",
+        "typescript": "^1.8.10",
         "coveralls": "^2.11.2",
         "nyc": "^2.1.4"
     },

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -22,7 +22,8 @@ var array = [2010, 1, 14, 15, 25, 50, 125];
 var day11 = moment(Date.UTC.apply({}, array));
 var day12 = moment.unix(1318781876);
 
-moment(null);
+// TODO: reenable in 2.0
+// moment(null);
 moment(undefined);
 moment({ years: 2010, months: 3, days: 5, hours: 15, minutes: 10, seconds: 3, milliseconds: 123 });
 moment("20140101", "YYYYMMDD", true);
@@ -225,7 +226,8 @@ localLang.localeData();
 localLang.format('LLLL');
 globalLang.format('LLLL');
 
-moment.duration(null);
+// TODO: reenable in 2.0
+// moment.duration(null);
 moment.duration(undefined);
 moment.duration(100);
 moment.duration(2, 'seconds');
@@ -259,9 +261,10 @@ moment.locale();
 moment.locale('en');
 moment.locale(['en', 'fr']);
 
-moment.defineLocale('en', null);
-moment.updateLocale('en', null);
-moment.locale('en', null);
+// TODO: Reenable in 2.0
+// moment.defineLocale('en', null);
+// moment.updateLocale('en', null);
+// moment.locale('en', null);
 
 // Defining a custom language:
 moment.locale('en', {

--- a/typing-tests/tsconfig.json
+++ b/typing-tests/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "noEmit": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true
+    "noImplicitAny": true
   },
   "files": [
     "../moment.d.ts",


### PR DESCRIPTION
This fixes the definitions file from breaking changes introduced in #3490. Now the file is somewhat compatible with 2.0 with the use of `void` instead of `undefined`, but unfortunately `null` arguments are not supported with 2.x and `strictNullChecks`, because `null` keyword is not available in 1.x.

The typescript definitions will be updated for 2.0 (proper `null` support) with the release of moment 3.x. **NOTE** Any requests to fix the definitions before that will be denied.

**NOTE2**: For the eager 2.0 ts users -- the definition file includes in comments whether the `void` corresponds to null, undefined, or both. So one can simply write a script to generate a proper 2.0 definition. The scope of this generator is *not* part of the moment team's efforts, so PRs won't be accepted.