### PR TITLE
[bugfix] Fixes #3520, parseZone incorrectly handled minutes under 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 nyc_output
 .nyc_output
 .coveralls.yml
+.vscode/

--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -102,7 +102,7 @@ hooks.updateOffset = function () {};
 // a second time. In case it wants us to change the offset again
 // _changeInProgress == true case, then we have to adjust, because
 // there is no such time in the given timezone.
-export function getSetOffset (input, keepLocalTime) {
+export function getSetOffset (input, keepLocalTime, keepMinutes) {
     var offset = this._offset || 0,
         localAdjust;
     if (!this.isValid()) {
@@ -114,7 +114,7 @@ export function getSetOffset (input, keepLocalTime) {
             if (input === null) {
                 return this;
             }
-        } else if (Math.abs(input) < 16) {
+        } else if (Math.abs(input) < 16 && !keepMinutes) {
             input = input * 60;
         }
         if (!this._isUTC && keepLocalTime) {
@@ -172,7 +172,7 @@ export function setOffsetToLocal (keepLocalTime) {
 
 export function setOffsetToParsedOffset () {
     if (this._tzm != null) {
-        this.utcOffset(this._tzm);
+        this.utcOffset(this._tzm, false, true);
     } else if (typeof this._i === 'string') {
         var tZone = offsetFromString(matchOffset, this._i);
         if (tZone != null) {

--- a/src/test/moment/zones.js
+++ b/src/test/moment/zones.js
@@ -486,3 +486,16 @@ test('parse zone without a timezone', function (assert) {
         'Not providing a timezone should keep the time and change the zone to 0'
     );
 });
+
+test('parse zone with a minutes unit abs less than 16 should retain minutes', function (assert) {
+    //ensure when minutes are explicitly parsed, they are retained
+    //instead of converted to hours, even if less than 16
+    var n = moment.parseZone('2013-01-01T00:00:00-00:15');
+    assert.equal(n.utcOffset(), -15);
+    assert.equal(n.zone(), 15);
+    assert.equal(n.hour(), 0);
+    var o = moment.parseZone('2013-01-01T00:00:00+00:15');
+    assert.equal(o.utcOffset(), 15);
+    assert.equal(o.zone(), -15);
+    assert.equal(o.hour(), 0);
+});


### PR DESCRIPTION
Fixes issue in #3520 where explicitly parsed offset in minutes less than abs(16) is converted to hours.