### PR TITLE
[locale] ca: Improved months and datetime formats

### DIFF
--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -5,8 +5,12 @@
 import moment from '../moment';
 
 export default moment.defineLocale('ca', {
-    months : 'gener_febrer_març_abril_maig_juny_juliol_agost_setembre_octubre_novembre_desembre'.split('_'),
-    monthsShort : 'gen._febr._mar._abr._mai._jun._jul._ag._set._oct._nov._des.'.split('_'),
+    months : {
+        standalone: 'gener_febrer_març_abril_maig_juny_juliol_agost_setembre_octubre_novembre_desembre'.split('_'),
+        format: 'de gener_de febrer_de març_d\'abril_de maig_de juny_de juliol_d\'agost_de setembre_d\'octubre_de novembre_de desembre'.split('_'),
+        isFormat: /D[oD]?(\s)+MMMM/
+    },
+    monthsShort : 'gen._febr._març_abr._maig_juny_jul._ag._set._oct._nov._des.'.split('_'),
     monthsParseExact : true,
     weekdays : 'diumenge_dilluns_dimarts_dimecres_dijous_divendres_dissabte'.split('_'),
     weekdaysShort : 'dg._dl._dt._dc._dj._dv._ds.'.split('_'),
@@ -16,9 +20,12 @@ export default moment.defineLocale('ca', {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
         L : 'DD/MM/YYYY',
-        LL : 'D MMMM YYYY',
-        LLL : 'D MMMM YYYY H:mm',
-        LLLL : 'dddd D MMMM YYYY H:mm'
+        LL : '[el] D MMMM [de] YYYY',
+        ll : 'D MMM YYYY',
+        LLL : '[el] D MMMM [de] YYYY [a les] H:mm',
+        lll : 'D MMM YYYY, H:mm',
+        LLLL : '[el] dddd D MMMM [de] YYYY [a les] H:mm',
+        llll : 'ddd D MMM YYYY, H:mm'
     },
     calendar : {
         sameDay : function () {

--- a/src/test/locale/ca.js
+++ b/src/test/locale/ca.js
@@ -3,7 +3,7 @@ import moment from '../../moment';
 localeModule('ca');
 
 test('parse', function (assert) {
-    var tests = 'gener gen._febrer febr._març mar._abril abr._maig mai._juny jun._juliol jul._agost ag._setembre set._octubre oct._novembre nov._desembre des.'.split('_'), i;
+    var tests = 'gener gen._febrer febr._març març_abril abr._maig maig_juny juny_juliol jul._agost ag._setembre set._octubre oct._novembre nov._desembre des.'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -22,7 +22,7 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, Do MMMM YYYY, h:mm:ss a',      'diumenge, 14è febrer 2010, 3:25:50 pm'],
+            ['dddd, Do MMMM YYYY, h:mm:ss a',      'diumenge, 14è de febrer 2010, 3:25:50 pm'],
             ['ddd, hA',                            'dg., 3PM'],
             ['M Mo MM MMMM MMM',                   '2 2n 02 febrer febr.'],
             ['YYYY YY',                            '2010 10'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45è day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 febrer 2010'],
-            ['LLL',                                '14 febrer 2010 15:25'],
-            ['LLLL',                               'diumenge 14 febrer 2010 15:25'],
+            ['LL',                                 'el 14 de febrer de 2010'],
+            ['LLL',                                'el 14 de febrer de 2010 a les 15:25'],
+            ['LLLL',                               'el diumenge 14 de febrer de 2010 a les 15:25'],
             ['l',                                  '14/2/2010'],
             ['ll',                                 '14 febr. 2010'],
-            ['lll',                                '14 febr. 2010 15:25'],
-            ['llll',                               'dg. 14 febr. 2010 15:25']
+            ['lll',                                '14 febr. 2010, 15:25'],
+            ['llll',                               'dg. 14 febr. 2010, 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -91,7 +91,7 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'gener gen._febrer febr._març mar._abril abr._maig mai._juny jun._juliol jul._agost ag._setembre set._octubre oct._novembre nov._desembre des.'.split('_'), i;
+    var expected = 'gener gen._febrer febr._març març_abril abr._maig maig_juny juny_juliol jul._agost ag._setembre set._octubre oct._novembre nov._desembre des.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
@@ -208,3 +208,8 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2a', 'Jan 15 2012 should be week 2');
 });
 
+test('day and month', function (assert) {
+    assert.equal(moment([2012, 1, 15]).format('D MMMM'), '15 de febrer');
+    assert.equal(moment([2012, 9, 15]).format('D MMMM'), '15 d\'octubre');
+    assert.equal(moment([2012, 9, 15]).format('MMMM, D'), 'octubre, 15');
+});


### PR DESCRIPTION
* Changed months abbreviations to the recommended ones
  (https://www.upf.edu/leupf/12ap1/111_3.htm).
* Added articles and 'de' to long-form dates.
* Added commas to short-form dates.

Pinging previous Catalan committers @pereorga and @juanghurtado.