### PR TITLE
Add a UMD global declaration to 'moment.d.ts'.

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -706,3 +706,4 @@ declare namespace moment {
 }
 
 export = moment;
+export as namespace moment;


### PR DESCRIPTION
This is a TS 2.0-specific construct that allows TypeScript users to consume moment as a global.

It looks like the current `.d.ts` file avoids 2.0+ features, but just throwing this out there because I found [this Stack Overflow question](http://stackoverflow.com/questions/41336330/typescript-how-can-i-make-an-existing-namespace-global).

CC @RyanCavanaugh.