### PR TITLE
[misc] typescript: Add boolean to LocaleSelector variants

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -392,7 +392,7 @@ declare namespace moment {
   type MomentInput = Moment | Date | string | number | (number | string)[] | MomentInputObject | void; // null | undefined
   type DurationInputArg1 = Duration | number | string | FromTo | DurationInputObject | void; // null | undefined
   type DurationInputArg2 = unitOfTime.DurationConstructor;
-  type LocaleSpecifier = string | Moment | Duration | string[];
+  type LocaleSpecifier = string | Moment | Duration | string[] | boolean;
 
   interface MomentCreationData {
     input: string;


### PR DESCRIPTION
According to the docs (http://momentjs.com/docs/#/i18n/instance-locale/) calling `.locale(false)` would reset the instance's locale to the global one, but the existing typings don't allow passing `false` to this function. This PR fixes this issue.