### PR TITLE
[locale] eo: Fix grammatical errors

### DIFF
--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -9,16 +9,16 @@ import moment from '../moment';
 export default moment.defineLocale('eo', {
     months : 'januaro_februaro_marto_aprilo_majo_junio_julio_aŭgusto_septembro_oktobro_novembro_decembro'.split('_'),
     monthsShort : 'jan_feb_mar_apr_maj_jun_jul_aŭg_sep_okt_nov_dec'.split('_'),
-    weekdays : 'Dimanĉo_Lundo_Mardo_Merkredo_Ĵaŭdo_Vendredo_Sabato'.split('_'),
-    weekdaysShort : 'Dim_Lun_Mard_Merk_Ĵaŭ_Ven_Sab'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Ĵa_Ve_Sa'.split('_'),
+    weekdays : 'dimanĉo_lundo_mardo_merkredo_ĵaŭdo_vendredo_sabato'.split('_'),
+    weekdaysShort : 'dim_lun_mard_merk_ĵaŭ_ven_sab'.split('_'),
+    weekdaysMin : 'di_lu_ma_me_ĵa_ve_sa'.split('_'),
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',
         L : 'YYYY-MM-DD',
-        LL : 'D[-an de] MMMM, YYYY',
-        LLL : 'D[-an de] MMMM, YYYY HH:mm',
-        LLLL : 'dddd, [la] D[-an de] MMMM, YYYY HH:mm'
+        LL : 'D[-a de] MMMM, YYYY',
+        LLL : 'D[-a de] MMMM, YYYY HH:mm',
+        LLLL : 'dddd, [la] D[-a de] MMMM, YYYY HH:mm'
     },
     meridiemParse: /[ap]\.t\.m/i,
     isPM: function (input) {
@@ -40,7 +40,7 @@ export default moment.defineLocale('eo', {
         sameElse : 'L'
     },
     relativeTime : {
-        future : 'je %s',
+        future : 'post %s',
         past : 'antaŭ %s',
         s : 'sekundoj',
         m : 'minuto',

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -1,8 +1,8 @@
 //! moment.js locale configuration
 //! locale : Esperanto [eo]
 //! author : Colin Dean : https://github.com/colindean
-//! komento: Mi estas malcerta se mi korekte traktis akuzativojn en tiu traduko.
-//!          Se ne, bonvolu korekti kaj avizi min por ke mi povas lerni!
+//! author : Mia Nordentoft Imperatori : https://github.com/miestasmia
+//! comment : miestasmia corrected the translation by colindean
 
 import moment from '../moment';
 

--- a/src/test/locale/eo.js
+++ b/src/test/locale/eo.js
@@ -22,12 +22,12 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Dimanĉo, februaro 14a 2010, 3:25:50 p.t.m.'],
-            ['ddd, hA',                            'Dim, 3P.T.M.'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'dimanĉo, februaro 14a 2010, 3:25:50 p.t.m.'],
+            ['ddd, hA',                            'dim, 3P.T.M.'],
             ['M Mo MM MMMM MMM',                   '2 2a 02 februaro feb'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14a 14'],
-            ['d do dddd ddd dd',                   '0 0a Dimanĉo Dim Di'],
+            ['d do dddd ddd dd',                   '0 0a dimanĉo dim di'],
             ['DDD DDDo DDDD',                      '45 45a 045'],
             ['w wo ww',                            '7 7a 07'],
             ['h hh',                               '3 03'],
@@ -38,13 +38,13 @@ test('format', function (assert) {
             ['[la] DDDo [tago] [de] [la] [jaro]',  'la 45a tago de la jaro'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '2010-02-14'],
-            ['LL',                                 '14-an de februaro, 2010'],
-            ['LLL',                                '14-an de februaro, 2010 15:25'],
-            ['LLLL',                               'Dimanĉo, la 14-an de februaro, 2010 15:25'],
+            ['LL',                                 '14-a de februaro, 2010'],
+            ['LLL',                                '14-a de februaro, 2010 15:25'],
+            ['LLLL',                               'dimanĉo, la 14-a de februaro, 2010 15:25'],
             ['l',                                  '2010-2-14'],
-            ['ll',                                 '14-an de feb, 2010'],
-            ['lll',                                '14-an de feb, 2010 15:25'],
-            ['llll',                               'Dim, la 14-an de feb, 2010 15:25']
+            ['ll',                                 '14-a de feb, 2010'],
+            ['lll',                                '14-a de feb, 2010 15:25'],
+            ['llll',                               'dim, la 14-a de feb, 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -98,7 +98,7 @@ test('format month', function (assert) {
 });
 
 test('format week', function (assert) {
-    var expected = 'Dimanĉo Dim Di_Lundo Lun Lu_Mardo Mard Ma_Merkredo Merk Me_Ĵaŭdo Ĵaŭ Ĵa_Vendredo Ven Ve_Sabato Sab Sa'.split('_'), i;
+    var expected = 'dimanĉo dim di_lundo lun lu_mardo mard ma_merkredo merk me_ĵaŭdo ĵaŭ ĵa_vendredo ven ve_sabato sab sa'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }
@@ -137,7 +137,7 @@ test('from', function (assert) {
 });
 
 test('suffix', function (assert) {
-    assert.equal(moment(30000).from(0), 'je sekundoj',  'je prefix');
+    assert.equal(moment(30000).from(0), 'post sekundoj',  'post prefix');
     assert.equal(moment(0).from(30000), 'antaŭ sekundoj', 'antaŭ prefix');
 });
 
@@ -146,8 +146,8 @@ test('now from now', function (assert) {
 });
 
 test('fromNow', function (assert) {
-    assert.equal(moment().add({s: 30}).fromNow(), 'je sekundoj', 'je sekundoj');
-    assert.equal(moment().add({d: 5}).fromNow(), 'je 5 tagoj', 'je 5 tagoj');
+    assert.equal(moment().add({s: 30}).fromNow(), 'post sekundoj', 'post sekundoj');
+    assert.equal(moment().add({d: 5}).fromNow(), 'post 5 tagoj', 'post 5 tagoj');
 });
 
 test('calendar day', function (assert) {


### PR DESCRIPTION
The Esperanto locale has various different issues regarding use of the accusative (technically n-finaĵo, but this has no English equivalent), capitalization and use of hyphens in dates. The original author [mentions this in a comment, as well](https://github.com/moment/moment/blob/4b3fc58ddc777ec7d65fd3a85bd0ae64632e3dfe/src/locale/eo.js#L4). This PR fixes that.

@colindean Can you please verify these changes? Otherwise I can get another speaker to do so.