### PR TITLE
[feature] RFC2822 parsing

### DIFF
--- a/src/lib/create/from-string-and-format.js
+++ b/src/lib/create/from-string-and-format.js
@@ -1,4 +1,4 @@
-import { configFromISO } from './from-string';
+import { configFromISO, configFromRFC2822 } from './from-string';
 import { configFromArray } from './from-array';
 import { getParseRegexForToken }   from '../parse/regex';
 import { addTimeToArrayFromToken } from '../parse/token';
@@ -11,6 +11,9 @@ import getParsingFlags from './parsing-flags';
 // constant that refers to the ISO standard
 hooks.ISO_8601 = function () {};
 
+// constant that refers to the RFC 2822 form
+hooks.RFC_2822 = function () {};
+
 // date from string and format string
 export function configFromStringAndFormat(config) {
     // TODO: Move this to another part of the creation flow to prevent circular deps
@@ -18,7 +21,10 @@ export function configFromStringAndFormat(config) {
         configFromISO(config);
         return;
     }
-
+    if (config._f === hooks.RFC_2822) {
+        configFromRFC2822(config);
+        return;
+    }
     config._a = [];
     getParsingFlags(config).empty = true;
 

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -164,7 +164,6 @@ export function configFromRFC2822(config) {
         //  NB: Needs an instance of moment, created from the date element of the input string.
         /* */
         if (match[1]) { // day of week given
-//            console.log('[' + match[1].substr(0,3) + ']', moment(match[2], dateFormat).format('ddd'));
             var momentDate = new Date(match[2]);
             var momentDay = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][momentDate.getDay()];
 

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -145,8 +145,8 @@ export function configFromRFC2822(config) {
                     timezoneIndex = military.indexOf(match[5][1].toUpperCase()) - 12;
                     timezone = ((timezoneIndex < 0) ? ' -' : ' +') +
                         (('' + timezoneIndex).replace(/^-?/, '0')).match(/..$/)[0] + '00';
+                    timezone += '00';
                 }
-                timezone += '00';
                 break;
             case 4: // Zone
                 timezone = timezones[match[5]];

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -125,7 +125,6 @@ export function configFromRFC2822(config) {
         dateFormat = 'D MMM ' + ((match[2].length > 10) ? 'YYYY ' : 'YY ');
         timeFormat = 'HH:mm' + (match[4] ? ':ss' : '');
 
-
         // TODO: Replace the vanilla JS Date object with an indepentent day-of-week check.
         if (match[1]) { // day of week given
             var momentDate = new Date(match[2]);
@@ -137,7 +136,6 @@ export function configFromRFC2822(config) {
                 return;
             }
         }
-        getParsingFlags(config).rfc2822 = true;
 
         switch (match[5].length) {
             case 2: // military
@@ -161,6 +159,7 @@ export function configFromRFC2822(config) {
         tzFormat = ' ZZ';
         config._f = dayFormat + dateFormat + timeFormat + tzFormat;
         configFromStringAndFormat(config);
+        getParsingFlags(config).rfc2822 = true;
     } else {
         config._isValid = false;
     }

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -160,9 +160,7 @@ export function configFromRFC2822(config) {
         dateFormat = 'D MMM ' + ((match[2].length > 10) ? 'YYYY ' : 'YY ');
         timeFormat = 'HH:mm' + (match[4] ? ':ss' : '');
 
-        // TODO Confirm the given day-of-week is consistent with the day-of-month-year
-        //  NB: Needs an instance of moment, created from the date element of the input string.
-        /* */
+        // TODO: Replace the vanilla JS Date object with an indepentent day-of-week check.
         if (match[1]) { // day of week given
             var momentDate = new Date(match[2]);
             var momentDay = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][momentDate.getDay()];
@@ -172,7 +170,6 @@ export function configFromRFC2822(config) {
                 return;
             }
         }
-        /* */
         getParsingFlags(config).rfc2822 = true;
 
         switch (match[5].length) {

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -165,7 +165,7 @@ export function configFromRFC2822(config) {
         if (match[1]) { // day of week given
             var momentDate = new Date(match[2]);
             var momentDay = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][momentDate.getDay()];
-            
+
             if (match[1].substr(0,3) !== momentDay) {
                 getParsingFlags(config).weekdayMismatch = true;
                 config._isValid = false;

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -1,6 +1,5 @@
 import { configFromStringAndFormat } from './from-string-and-format';
 import { hooks } from '../utils/hooks';
-import moment from '../moment';     // Needed for RFC2822 validation of weekday
 import { deprecate } from '../utils/deprecate';
 import getParsingFlags from './parsing-flags';
 

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -176,19 +176,17 @@ export function configFromString(config) {
     }
 
     configFromISO(config);
-    if (config._isValid === true) {
-        return;
-    } else {
+    if (config._isValid === false) {
         delete config._isValid;
-        getParsingFlags(config).iso = false;
+    } else {
+        return;
     }
 
     configFromRFC2822(config);
-    if (config._isValid === true) {
-        return;
-    } else {
-        getParsingFlags(config).rfc2822 = false;
+    if (config._isValid === false) {
         delete config._isValid;
+    } else {
+        return;
     }
 
     // Final attempt, use Input Fallback

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -94,7 +94,7 @@ export function configFromISO(config) {
 }
 
 // RFC 2822 regex: For details see https://tools.ietf.org/html/rfc2822#section-3.3
-var basicRfcRegex = /^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d?\d\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:\d\d)?\d\d\s)(\d\d:\d\d)(\:\d\d)?(\s(?:UT|GMT|[ECMP][SD]T|[A-IK-Z]|[+-]\d{4}))$/;
+var basicRfcRegex = /^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d?\d\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:\d\d)?\d\d\s)(\d\d:\d\d)(\:\d\d)?(\s(?:UT|GMT|[ECMP][SD]T|[A-IK-Z]|[a-ik-z]|[+-]\d{4}))$/;
 
 // date and time from ref 2822 format
 export function configFromRFC2822(config) {
@@ -142,7 +142,7 @@ export function configFromRFC2822(config) {
                 if (timezoneIndex === 0) {
                     timezone = ' +0000';
                 } else {
-                    timezoneIndex = military.indexOf(match[5][1]) - 12;
+                    timezoneIndex = military.indexOf((match[5][1]).toUpperCase()) - 12;
                     timezone = ((timezoneIndex < 0) ? ' -' : ' +') +
                         (('' + timezoneIndex).replace(/^-?/, '0')).match(/..$/)[0] + '00';
                 }

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -163,7 +163,6 @@ export function configFromRFC2822(config) {
 
         // TODO Confirm the given day-of-week is consistent with the day-of-month-year
         //  NB: Needs an instance of moment, created from the date element of the input string.
-        /* */
         if (match[1]) { // day of week given
             console.log('[' + match[1].substr(0,3) + ']', moment(match[2], dateFormat).format('ddd'));
             var momentDay = moment(match[2], dateFormat).format('ddd');
@@ -173,7 +172,6 @@ export function configFromRFC2822(config) {
                 return;
             }
         }
-        /* */
        
         getParsingFlags(config).rfc2822 = true;
 

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -160,17 +160,15 @@ export function configFromRFC2822(config) {
         dateFormat = 'D MMM ' + ((match[2].length > 10) ? 'YYYY ' : 'YY ');
         timeFormat = 'HH:mm' + (match[4] ? ':ss' : '');
 
-        // TODO Confirm the given day-of-week is consistent with the day-of-month-year
-        //  NB: Needs an instance of moment, created from the date element of the input string.
-        /*
-        if (match[1]) {
+        if (match[1]) { // day of week given
             console.log('[' + match[1].substr(0,3) + ']', moment(match[2], dateFormat).format('ddd'));
-            if (match[1].substr(0,3) !== this(match[2], dateFormat).format('ddd')) {
+            var momentDay = moment(match[2], dateFormat).format('ddd');
+
+            if (match[1].substr(0,3) !== momentDay) {
                 config._isValid = false;
                 return;
             }
         }
-        */
         getParsingFlags(config).rfc2822 = true;
 
         switch (match[5].length) {

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -182,7 +182,7 @@ export function configFromString(config) {
         delete config._isValid;
         getParsingFlags(config).iso = false;
     }
-    
+
     configFromRFC2822(config);
     if (config._isValid === true) {
         return;
@@ -190,7 +190,7 @@ export function configFromString(config) {
         getParsingFlags(config).rfc2822 = false;
         delete config._isValid;
     }
-    
+
     // Final attempt, use Input Fallback
     hooks.createFromInputFallback(config);
 }

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -135,7 +135,7 @@ var basicRfcRegex = /^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d?\d\s(?:Jan|Feb|M
 export function configFromRFC2822(config) {
     var string, match, dayFormat,
         dateFormat, timeFormat, tzFormat;
-    var rfc2822Timezones = {
+    var timezones = {
         ' GMT': ' +0000',
         ' EDT': ' -0400',
         ' EST': ' -0500',
@@ -146,8 +146,8 @@ export function configFromRFC2822(config) {
         ' PDT': ' -0700',
         ' PST': ' -0800'
     };
-    var rfc2822Military = 'YXWVUTSRQPONZABCDEFGHIKLM';
-    var rfc2822Timezone, rfc2822Index;
+    var Military = 'YXWVUTSRQPONZABCDEFGHIKLM';
+    var timezone, timezoneIndex;
 
     string = config._i
         .replace(/\([^\)]*\)|[\n\t]/g, ' ') // Remove comments and folding whitespace
@@ -175,22 +175,22 @@ export function configFromRFC2822(config) {
 
         switch (match[5].length) {
             case 2: // Military
-                if (rfc2822Index === 0) {
-                    rfc2822Timezone = ' +0000';
+                if (timezoneIndex === 0) {
+                    timezone = ' +0000';
                 } else {
-                    rfc2822Index = rfc2822Military.indexOf(match[5][1]) - 12;
-                    rfc2822Timezone = ((rfc2822Index < 0) ? ' -' : ' +') +
-                        (('' + rfc2822Index).replace(/^-?/, '0')).match(/..$/)[0] + '00';
+                    timezoneIndex = Military.indexOf(match[5][1]) - 12;
+                    timezone = ((timezoneIndex < 0) ? ' -' : ' +') +
+                        (('' + timezoneIndex).replace(/^-?/, '0')).match(/..$/)[0] + '00';
                 }
-                rfc2822Timezone += '00';
+                timezone += '00';
                 break;
             case 4: // Zone
-                rfc2822Timezone = rfc2822Timezones[match[5]];
+                timezone = timezones[match[5]];
                 break;
             default: // UT or +/-9999
-                rfc2822Timezone = rfc2822Timezones[' GMT'];
+                timezone = timezones[' GMT'];
         }
-        match[5] = rfc2822Timezone;
+        match[5] = timezone;
         config._i = match.splice(1).join('');
         tzFormat = ' ZZ';
         config._f = dayFormat + dateFormat + timeFormat + tzFormat;

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -94,7 +94,7 @@ export function configFromISO(config) {
 }
 
 // RFC 2822 regex: For details see https://tools.ietf.org/html/rfc2822#section-3.3
-var basicRfcRegex = /^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d?\d\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:\d\d)?\d\d\s)(\d\d:\d\d)(\:\d\d)?(\s(?:UT|GMT|[ECMP][SD]T|[A-IK-Z]|[a-ik-z]|[+-]\d{4}))$/;
+var basicRfcRegex = /^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d?\d\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:\d\d)?\d\d\s)(\d\d:\d\d)(\:\d\d)?(\s(?:UT|GMT|[ECMP][SD]T|[A-IK-Za-ik-z]|[+-]\d{4}))$/;
 
 // date and time from ref 2822 format
 export function configFromRFC2822(config) {
@@ -142,7 +142,7 @@ export function configFromRFC2822(config) {
                 if (timezoneIndex === 0) {
                     timezone = ' +0000';
                 } else {
-                    timezoneIndex = military.indexOf((match[5][1]).toUpperCase()) - 12;
+                    timezoneIndex = military.indexOf(match[5][1].toUpperCase()) - 12;
                     timezone = ((timezoneIndex < 0) ? ' -' : ' +') +
                         (('' + timezoneIndex).replace(/^-?/, '0')).match(/..$/)[0] + '00';
                 }

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -122,12 +122,14 @@ export function configFromISO(config) {
 /*
     var detailedRfcRegex = /^
         ((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?
-        ((?:0?[1-9]|[1-2]?\d|3[01])\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:[2-9]\d|19)?\d\d\s)
-        ((?:[01]\d|2[0-3]):[0-5]\d)(\:(?:60|[0-5]\d))?
-        (\s(?:UT|GMT|(?:[ECMP][SD]T)|[A-IK-Z]|(?:[+-](?:[0-8]\d\d|9\d[0-5])\d)))
+        ((?:0?[1-9]|[1-2]?\d|3[01])\s
+            (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:(?:19|[2-9]\d)?\d\d\s))
+        ((?:(?:2[0-3]|[0-1]\d)):[0-5]\d)
+        (\:(?:60|[0-5]\d))?
+        (\s(?:UT|GMT|[ECMP][SD]T|[A-IK-Z]|(?:[+-](?:1[012]|0\d)[03]0)))
     $/;
 */
-var basicRfcRegex = /^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d?\d\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:\d\d)?\d\d\s)(\d\d:\d\d)(\:\d\d)?(\s(?:UT|GMT|([ECMP][SD]T)|[A-IK-Z]|(?:[+-]\d{4})))$/;
+var basicRfcRegex = /^((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d?\d\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(?:\d\d)?\d\d\s)(\d\d:\d\d)(\:\d\d)?(\s(?:UT|GMT|[ECMP][SD]T|[A-IK-Z]|[+-]\d{4}))$/;
 
 // date and time from ref 2822 format
 export function configFromRFC2822(config) {

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -1,5 +1,6 @@
 import { configFromStringAndFormat } from './from-string-and-format';
 import { hooks } from '../utils/hooks';
+import moment from '../moment';     // Needed for RFC2822 validation of weekday
 import { deprecate } from '../utils/deprecate';
 import getParsingFlags from './parsing-flags';
 
@@ -160,6 +161,9 @@ export function configFromRFC2822(config) {
         dateFormat = 'D MMM ' + ((match[2].length > 10) ? 'YYYY ' : 'YY ');
         timeFormat = 'HH:mm' + (match[4] ? ':ss' : '');
 
+        // TODO Confirm the given day-of-week is consistent with the day-of-month-year
+        //  NB: Needs an instance of moment, created from the date element of the input string.
+        /* */
         if (match[1]) { // day of week given
             console.log('[' + match[1].substr(0,3) + ']', moment(match[2], dateFormat).format('ddd'));
             var momentDay = moment(match[2], dateFormat).format('ddd');
@@ -169,6 +173,8 @@ export function configFromRFC2822(config) {
                 return;
             }
         }
+        /* */
+       
         getParsingFlags(config).rfc2822 = true;
 
         switch (match[5].length) {

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -160,12 +160,14 @@ export function configFromRFC2822(config) {
         dateFormat = 'D MMM ' + ((match[2].length > 10) ? 'YYYY ' : 'YY ');
         timeFormat = 'HH:mm' + (match[4] ? ':ss' : '');
 
+
         // TODO: Replace the vanilla JS Date object with an indepentent day-of-week check.
         if (match[1]) { // day of week given
             var momentDate = new Date(match[2]);
             var momentDay = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][momentDate.getDay()];
-
+            
             if (match[1].substr(0,3) !== momentDay) {
+                getParsingFlags(config).weekdayMismatch = true;
                 config._isValid = false;
                 return;
             }

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -160,6 +160,7 @@ export function configFromRFC2822(config) {
         dateFormat = 'D MMM ' + ((match[2].length > 10) ? 'YYYY ' : 'YY ');
         timeFormat = 'HH:mm' + (match[4] ? ':ss' : '');
 
+
         // TODO: Replace the vanilla JS Date object with an indepentent day-of-week check.
         if (match[1]) { // day of week given
             var momentDate = new Date(match[2]);

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -145,7 +145,6 @@ export function configFromRFC2822(config) {
                     timezoneIndex = military.indexOf(match[5][1].toUpperCase()) - 12;
                     timezone = ((timezoneIndex < 0) ? ' -' : ' +') +
                         (('' + timezoneIndex).replace(/^-?/, '0')).match(/..$/)[0] + '00';
-                    timezone += '00';
                 }
                 break;
             case 4: // Zone

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -160,7 +160,6 @@ export function configFromRFC2822(config) {
         dateFormat = 'D MMM ' + ((match[2].length > 10) ? 'YYYY ' : 'YY ');
         timeFormat = 'HH:mm' + (match[4] ? ':ss' : '');
 
-
         // TODO: Replace the vanilla JS Date object with an indepentent day-of-week check.
         if (match[1]) { // day of week given
             var momentDate = new Date(match[2]);

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -163,6 +163,7 @@ export function configFromRFC2822(config) {
 
         // TODO Confirm the given day-of-week is consistent with the day-of-month-year
         //  NB: Needs an instance of moment, created from the date element of the input string.
+        /*
         if (match[1]) { // day of week given
             console.log('[' + match[1].substr(0,3) + ']', moment(match[2], dateFormat).format('ddd'));
             var momentDay = moment(match[2], dateFormat).format('ddd');
@@ -172,7 +173,7 @@ export function configFromRFC2822(config) {
                 return;
             }
         }
-       
+        */
         getParsingFlags(config).rfc2822 = true;
 
         switch (match[5].length) {

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -162,17 +162,18 @@ export function configFromRFC2822(config) {
 
         // TODO Confirm the given day-of-week is consistent with the day-of-month-year
         //  NB: Needs an instance of moment, created from the date element of the input string.
-        /*
+        /* */
         if (match[1]) { // day of week given
-            console.log('[' + match[1].substr(0,3) + ']', moment(match[2], dateFormat).format('ddd'));
-            var momentDay = moment(match[2], dateFormat).format('ddd');
+//            console.log('[' + match[1].substr(0,3) + ']', moment(match[2], dateFormat).format('ddd'));
+            var momentDate = new Date(match[2]);
+            var momentDay = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][momentDate.getDay()];
 
             if (match[1].substr(0,3) !== momentDay) {
                 config._isValid = false;
                 return;
             }
         }
-        */
+        /* */
         getParsingFlags(config).rfc2822 = true;
 
         switch (match[5].length) {

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -177,7 +177,7 @@ export function configFromString(config) {
 
     configFromISO(config);
     if (config._isValid === true) {
-        return
+        return;
     } else {
         delete config._isValid;
         getParsingFlags(config).iso = false;
@@ -185,7 +185,7 @@ export function configFromString(config) {
     
     configFromRFC2822(config);
     if (config._isValid === true) {
-        return
+        return;
     } else {
         getParsingFlags(config).rfc2822 = false;
         delete config._isValid;

--- a/src/lib/create/parsing-flags.js
+++ b/src/lib/create/parsing-flags.js
@@ -13,7 +13,8 @@ function defaultParsingFlags() {
         iso             : false,
         parsedDateParts : [],
         meridiem        : null,
-        rfc2822			: false
+        rfc2822			: false,
+        weekdayMismatch : false
     };
 }
 

--- a/src/lib/create/parsing-flags.js
+++ b/src/lib/create/parsing-flags.js
@@ -13,7 +13,7 @@ function defaultParsingFlags() {
         iso             : false,
         parsedDateParts : [],
         meridiem        : null,
-        rfc2822			: false,
+        rfc2822         : false,
         weekdayMismatch : false
     };
 }

--- a/src/lib/create/parsing-flags.js
+++ b/src/lib/create/parsing-flags.js
@@ -12,7 +12,8 @@ function defaultParsingFlags() {
         userInvalidated : false,
         iso             : false,
         parsedDateParts : [],
-        meridiem        : null
+        meridiem        : null,
+        rfc2822			: false
     };
 }
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -428,9 +428,20 @@ test('cloning carrying over utc mode', function (assert) {
 test('parsing rfc 2822', function (assert) {
     assert.ok(moment('2011-10-08T18:04:20', moment.ISO_8601, true).isValid(),
         'CONTROL-WORKS complete ISO date and time');
-
+    /*
     assert.ok(moment('Tue, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'clean RFC2822 datetime with all options');
+    assert.ok(moment('Tue 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
+        'clean RFC2822 datetime without comma');
+    assert.ok(moment('Tue, 01 Nov 2016 01:23 GMT', moment.RFC_2822, true).isValid(),
+        'clean RFC2822 datetime without seconds');
+    assert.ok(moment('Tue, 01 Nov 16 01:23:45 GMT', moment.RFC_2822, true).isValid(),
+        'clean RFC2822 datetime without century');
+    assert.ok(moment('01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
+        'clean RFC2822 datetime without day');
+    assert.ok(moment('Tue, 1 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
+        'clean RFC2822 datetime with single-digit day-of-month');
+    */
 });
 
 test('non rfc 2822 strings', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -425,10 +425,7 @@ test('cloning carrying over utc mode', function (assert) {
     assert.equal(moment(moment.utc())._isUTC, true, 'An implicit cloned utc moment should have _isUTC == true');
 });
 
-test('parsing rfc 2822', function (assert) {
-    assert.ok(moment('2011-10-08T18:04:20', moment.ISO_8601, true).isValid(),
-        'CONTROL-WORKS complete ISO date and time');
-    /*
+test('parsing RFC 2822', function (assert) {
     assert.ok(moment('Tue, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'clean RFC2822 datetime with all options');
     assert.ok(moment('Tue 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
@@ -441,12 +438,19 @@ test('parsing rfc 2822', function (assert) {
         'clean RFC2822 datetime without day');
     assert.ok(moment('Tue, 1 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'clean RFC2822 datetime with single-digit day-of-month');
-    */
+    assert.ok(moment(`(Init Comment) Tue,
+ 1 Nov              2016 (Split
+ Comment)  01:23:45 +0000 (GMT)`, moment.RFC_2822, true).isValid(),
+        'RFC2822 datetime with CFWSs');
 });
 
-test('non rfc 2822 strings', function (assert) {
+test('non RFC 2822 strings', function (assert) {
     assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with all options but invalid day delimiter');
+    /*
+    assert.ok(!moment('Mon, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
+        'RFC2822 datetime with mismatching Day (week v date)');
+    */
 });
 
 test('parsing iso', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -445,10 +445,8 @@ test('parsing RFC 2822', function (assert) {
 test('non RFC 2822 strings', function (assert) {
     assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with all options but invalid day delimiter');
-    /*
     assert.ok(!moment('Mon, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with mismatching Day (week v date)');
-    */
 });
 
 test('parsing iso', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -438,7 +438,7 @@ test('parsing RFC 2822', function (assert) {
     var testCase;
 
     for (testCase in testCases) {
-        var testResult = moment(testCases[testCase], moment.RFC_2822, true)
+        var testResult = moment(testCases[testCase], moment.RFC_2822, true);
         assert.ok(testResult.isValid(), testResult);
     }
 });
@@ -451,7 +451,7 @@ test('non RFC 2822 strings', function (assert) {
     var testCase;
 
     for (testCase in testCases) {
-        var testResult = moment(testCases[testCase], moment.RFC_2822, true)
+        var testResult = moment(testCases[testCase], moment.RFC_2822, true);
         assert.ok(!testResult.isValid(), testResult);
     }
 });

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -445,8 +445,10 @@ test('parsing RFC 2822', function (assert) {
 test('non RFC 2822 strings', function (assert) {
     assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with all options but invalid day delimiter');
+    /* */
     assert.ok(!moment('Mon, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with mismatching Day (week v date)');
+    /* */
 });
 
 test('parsing iso', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -427,11 +427,11 @@ test('cloning carrying over utc mode', function (assert) {
 
 test('parsing RFC 2822', function (assert) {
     var testCases = {
-        'clean RFC2822 datetime with all options': 'Tue, 01 Nov 2016 01:23:45 GMT',
+        'clean RFC2822 datetime with all options': 'Tue, 01 Nov 2016 01:23:45 UT',
         'clean RFC2822 datetime without comma': 'Tue 01 Nov 2016 01:23:45 GMT',
-        'clean RFC2822 datetime without seconds': 'Tue, 01 Nov 2016 01:23 GMT',
-        'clean RFC2822 datetime without century': 'Tue, 01 Nov 16 01:23:45 GMT',
-        'clean RFC2822 datetime without day': '01 Nov 2016 01:23:45 GMT',
+        'clean RFC2822 datetime without seconds': 'Tue, 01 Nov 2016 01:23 +0000',
+        'clean RFC2822 datetime without century': 'Tue, 01 Nov 16 01:23:45 Z',
+        'clean RFC2822 datetime without day': '01 Nov 2016 01:23:45 z',
         'clean RFC2822 datetime with single-digit day-of-month': 'Tue, 1 Nov 2016 01:23:45 GMT',
         'RFC2822 datetime with CFWSs': '(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  01:23:45 +0000 (GMT)'
     };

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -428,12 +428,12 @@ test('cloning carrying over utc mode', function (assert) {
 test('parsing RFC 2822', function (assert) {
     var testCases = {
         'clean RFC2822 datetime with all options': 'Tue, 01 Nov 2016 01:23:45 UT',
-        'clean RFC2822 datetime without comma': 'Tue 01 Nov 2016 01:23:45 GMT',
-        'clean RFC2822 datetime without seconds': 'Tue, 01 Nov 2016 01:23 +0000',
-        'clean RFC2822 datetime without century': 'Tue, 01 Nov 16 01:23:45 Z',
-        'clean RFC2822 datetime without day': '01 Nov 2016 01:23:45 z',
-        'clean RFC2822 datetime with single-digit day-of-month': 'Tue, 1 Nov 2016 01:23:45 GMT',
-        'RFC2822 datetime with CFWSs': '(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  01:23:45 +0000 (GMT)'
+        'clean RFC2822 datetime without comma': 'Tue 01 Nov 2016 02:23:45 GMT',
+        'clean RFC2822 datetime without seconds': 'Tue, 01 Nov 2016 03:23 +0000',
+        'clean RFC2822 datetime without century': 'Tue, 01 Nov 16 04:23:45 Z',
+        'clean RFC2822 datetime without day': '01 Nov 2016 05:23:45 z',
+        'clean RFC2822 datetime with single-digit day-of-month': 'Tue, 1 Nov 2016 06:23:45 GMT',
+        'RFC2822 datetime with CFWSs': '(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  07:23:45 +0000 (GMT)'
     };
     var testCase;
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -440,6 +440,7 @@ test('parsing RFC 2822', function (assert) {
     for (testCase in testCases) {
         var testResult = moment(testCases[testCase], moment.RFC_2822, true);
         assert.ok(testResult.isValid(), testResult);
+        assert.ok(testResult.parsingFlags().rfc2822(), testResult + ' - rfc2822 parsingFlag');
     }
 });
 
@@ -453,6 +454,7 @@ test('non RFC 2822 strings', function (assert) {
     for (testCase in testCases) {
         var testResult = moment(testCases[testCase], moment.RFC_2822, true);
         assert.ok(!testResult.isValid(), testResult);
+        assert.ok(!testResult.parsingFlags().rfc2822(), testResult + ' - rfc2822 parsingFlag');
     }
 });
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -440,7 +440,7 @@ test('parsing RFC 2822', function (assert) {
     for (testCase in testCases) {
         var testResult = moment(testCases[testCase], moment.RFC_2822, true);
         assert.ok(testResult.isValid(), testResult);
-        assert.ok(testResult.parsingFlags().rfc2822(), testResult + ' - rfc2822 parsingFlag');
+        assert.ok(testResult.parsingFlags().rfc2822, testResult + ' - rfc2822 parsingFlag');
     }
 });
 
@@ -454,7 +454,7 @@ test('non RFC 2822 strings', function (assert) {
     for (testCase in testCases) {
         var testResult = moment(testCases[testCase], moment.RFC_2822, true);
         assert.ok(!testResult.isValid(), testResult);
-        assert.ok(!testResult.parsingFlags().rfc2822(), testResult + ' - rfc2822 parsingFlag');
+        assert.ok(!testResult.parsingFlags().rfc2822, testResult + ' - rfc2822 parsingFlag');
     }
 });
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -425,6 +425,19 @@ test('cloning carrying over utc mode', function (assert) {
     assert.equal(moment(moment.utc())._isUTC, true, 'An implicit cloned utc moment should have _isUTC == true');
 });
 
+test('parsing rfc 2822', function (assert) {
+    assert.ok(moment('2011-10-08T18:04:20', moment.ISO_8601, true).isValid(),
+        'CONTROL-WORKS complete ISO date and time');
+
+    assert.ok(moment('Tue, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
+        'clean RFC2822 datetime with all options');
+});
+
+test('non rfc 2822 strings', function (assert) {
+    assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
+        'RFC2822 datetime with all options but invalid day delimiter');
+});
+
 test('parsing iso', function (assert) {
     var offset = moment([2011, 9, 8]).utcOffset(),
     pad = function (input) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -445,10 +445,10 @@ test('parsing RFC 2822', function (assert) {
 test('non RFC 2822 strings', function (assert) {
     assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with all options but invalid day delimiter');
-    /* */
+    /* TODO Confirm the given day-of-week is consistent with the day-of-month-year
     assert.ok(!moment('Mon, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with mismatching Day (week v date)');
-    /* */
+    */
 });
 
 test('parsing iso', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -445,13 +445,8 @@ test('parsing RFC 2822', function (assert) {
 test('non RFC 2822 strings', function (assert) {
     assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with all options but invalid day delimiter');
-    /* TODO Confirm the given day-of-week is consistent with the day-of-month-year
-     * 
-     */
     assert.ok(!moment('Mon, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with mismatching Day (week v date)');
-    /*
-    */
 });
 
 test('parsing iso', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -446,8 +446,11 @@ test('non RFC 2822 strings', function (assert) {
     assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with all options but invalid day delimiter');
     /* TODO Confirm the given day-of-week is consistent with the day-of-month-year
+     * 
+     */
     assert.ok(!moment('Mon, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with mismatching Day (week v date)');
+    /*
     */
 });
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -426,27 +426,34 @@ test('cloning carrying over utc mode', function (assert) {
 });
 
 test('parsing RFC 2822', function (assert) {
-    assert.ok(moment('Tue, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
-        'clean RFC2822 datetime with all options');
-    assert.ok(moment('Tue 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
-        'clean RFC2822 datetime without comma');
-    assert.ok(moment('Tue, 01 Nov 2016 01:23 GMT', moment.RFC_2822, true).isValid(),
-        'clean RFC2822 datetime without seconds');
-    assert.ok(moment('Tue, 01 Nov 16 01:23:45 GMT', moment.RFC_2822, true).isValid(),
-        'clean RFC2822 datetime without century');
-    assert.ok(moment('01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
-        'clean RFC2822 datetime without day');
-    assert.ok(moment('Tue, 1 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
-        'clean RFC2822 datetime with single-digit day-of-month');
-    assert.ok(moment('(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  01:23:45 +0000 (GMT)', moment.RFC_2822, true).isValid(),
-        'RFC2822 datetime with CFWSs');
+    var testCases = {
+        'clean RFC2822 datetime with all options': 'Tue, 01 Nov 2016 01:23:45 GMT',
+        'clean RFC2822 datetime without comma': 'Tue 01 Nov 2016 01:23:45 GMT',
+        'clean RFC2822 datetime without seconds': 'Tue, 01 Nov 2016 01:23 GMT',
+        'clean RFC2822 datetime without century': 'Tue, 01 Nov 16 01:23:45 GMT',
+        'clean RFC2822 datetime without day': '01 Nov 2016 01:23:45 GMT',
+        'clean RFC2822 datetime with single-digit day-of-month': 'Tue, 1 Nov 2016 01:23:45 GMT',
+        'RFC2822 datetime with CFWSs': '(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  01:23:45 +0000 (GMT)'
+    };
+    var testCase;
+
+    for (testCase in testCases) {
+        var testResult = moment(testCases[testCase], moment.RFC_2822, true)
+        assert.ok(testResult.isValid(), testResult);
+    }
 });
 
 test('non RFC 2822 strings', function (assert) {
-    assert.ok(!moment('Tue. 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
-        'RFC2822 datetime with all options but invalid day delimiter');
-    assert.ok(!moment('Mon, 01 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
-        'RFC2822 datetime with mismatching Day (week v date)');
+    var testCases = {
+        'RFC2822 datetime with all options but invalid day delimiter': 'Tue. 01 Nov 2016 01:23:45 GMT',
+        'RFC2822 datetime with mismatching Day (week v date)': 'Mon, 01 Nov 2016 01:23:45 GMT'
+    };
+    var testCase;
+
+    for (testCase in testCases) {
+        var testResult = moment(testCases[testCase], moment.RFC_2822, true)
+        assert.ok(!testResult.isValid(), testResult);
+    }
 });
 
 test('parsing iso', function (assert) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -438,9 +438,7 @@ test('parsing RFC 2822', function (assert) {
         'clean RFC2822 datetime without day');
     assert.ok(moment('Tue, 1 Nov 2016 01:23:45 GMT', moment.RFC_2822, true).isValid(),
         'clean RFC2822 datetime with single-digit day-of-month');
-    assert.ok(moment(`(Init Comment) Tue,
- 1 Nov              2016 (Split
- Comment)  01:23:45 +0000 (GMT)`, moment.RFC_2822, true).isValid(),
+    assert.ok(moment('(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  01:23:45 +0000 (GMT)', moment.RFC_2822, true).isValid(),
         'RFC2822 datetime with CFWSs');
 });
 

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -139,7 +139,6 @@ test('custom thresholds', function (assert) {
     moment.relativeTimeThreshold('M', 11);
 });
 
-/* TGJG Disabled
 test('custom rounding', function (assert) {
     var roundingDefault = moment.relativeTimeRounding();
 
@@ -190,7 +189,6 @@ test('custom rounding', function (assert) {
     moment.relativeTimeThreshold('M', 11);
     moment.relativeTimeRounding(roundingDefault);
 });
-*/
 
 test('retrive rounding settings', function (assert) {
     moment.relativeTimeRounding(Math.round);

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -139,6 +139,7 @@ test('custom thresholds', function (assert) {
     moment.relativeTimeThreshold('M', 11);
 });
 
+/* TGJG Disabled
 test('custom rounding', function (assert) {
     var roundingDefault = moment.relativeTimeRounding();
 
@@ -189,6 +190,7 @@ test('custom rounding', function (assert) {
     moment.relativeTimeThreshold('M', 11);
     moment.relativeTimeRounding(roundingDefault);
 });
+*/
 
 test('retrive rounding settings', function (assert) {
     moment.relativeTimeRounding(Math.round);


### PR DESCRIPTION
I have corrected the issue with the failing test but I still have a test I am unable to perform with out some advice. The test case 'RFC2822 datetime with mismatching Day (week v date)' confirms the day is consistent when given as both a day of week and day of month. This is a stipulation of the RFC so needs to be correct but I cannot achieve this without using a JS Date object, unless the core team have an alternative solution.

**Work in Progress - Do not Merge, Advice required. Issue #2530**