### PR TITLE
[locale] ru: Change first week of year to ISO

### DIFF
--- a/locale/ru.js
+++ b/locale/ru.js
@@ -174,7 +174,7 @@ var ru = moment.defineLocale('ru', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 4  // The week that contains Jan 4st is the first week of the year.
     }
 });
 


### PR DESCRIPTION
In Russia 1st week of the year is a week that contains first thursday of the year