### PR TITLE
Add MomentStatic type [workaround]

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -705,4 +705,10 @@ declare namespace moment {
   export var defaultFormatUtc: string;
 }
 
+type _tmptype = typeof moment;
+
+declare namespace moment {
+  type MomentStatic = _tmptype;
+}
+
 export = moment;


### PR DESCRIPTION
This is useful when you want to pass around the imported moment module.

In my case I needed to add this workaround to assign `moment` (required with browserify from node_modules) to the window object