### PR TITLE
[feature] Enable relative time for multiple seconds, request #2558

### DIFF
--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -1,12 +1,14 @@
 import { createDuration } from './create';
 
 var round = Math.round;
+var secondsThresholdChanged = false;
 var thresholds = {
-    s: 45,  // seconds to minute
-    m: 45,  // minutes to hour
-    h: 22,  // hours to day
-    d: 26,  // days to month
-    M: 11   // months to year
+    ss: 44,         // a few seconds to seconds
+    s : 45,         // seconds to minute
+    m : 45,         // minutes to hour
+    h : 22,         // hours to day
+    d : 26,         // days to month
+    M : 11          // months to year
 };
 
 // helper function for moment.fn.from, moment.fn.fromNow, and moment.duration.fn.humanize
@@ -23,16 +25,17 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
     var months   = round(duration.as('M'));
     var years    = round(duration.as('y'));
 
-    var a = seconds < thresholds.s && ['s', seconds]  ||
-            minutes <= 1           && ['m']           ||
-            minutes < thresholds.m && ['mm', minutes] ||
-            hours   <= 1           && ['h']           ||
-            hours   < thresholds.h && ['hh', hours]   ||
-            days    <= 1           && ['d']           ||
-            days    < thresholds.d && ['dd', days]    ||
-            months  <= 1           && ['M']           ||
-            months  < thresholds.M && ['MM', months]  ||
-            years   <= 1           && ['y']           || ['yy', years];
+    var a = seconds <= thresholds.ss && ['s', seconds]  ||
+            seconds < thresholds.s   && ['ss', seconds] ||
+            minutes <= 1             && ['m']           ||
+            minutes < thresholds.m   && ['mm', minutes] ||
+            hours   <= 1             && ['h']           ||
+            hours   < thresholds.h   && ['hh', hours]   ||
+            days    <= 1             && ['d']           ||
+            days    < thresholds.d   && ['dd', days]    ||
+            months  <= 1             && ['M']           ||
+            months  < thresholds.M   && ['MM', months]  ||
+            years   <= 1             && ['y']           || ['yy', years];
 
     a[2] = withoutSuffix;
     a[3] = +posNegDuration > 0;
@@ -59,6 +62,11 @@ export function getSetRelativeTimeThreshold (threshold, limit) {
     }
     if (limit === undefined) {
         return thresholds[threshold];
+    }
+    if (threshold === 's' && !secondsThresholdChanged) {
+        thresholds.ss = limit - 1;
+    } else if (threshold === 'ss') {
+        secondsThresholdChanged = true;
     }
     thresholds[threshold] = limit;
     return true;

--- a/src/lib/locale/relative.js
+++ b/src/lib/locale/relative.js
@@ -2,6 +2,7 @@ export var defaultRelativeTime = {
     future : 'in %s',
     past   : '%s ago',
     s  : 'a few seconds',
+    ss : '%d seconds',
     m  : 'a minute',
     mm : '%d minutes',
     h  : 'an hour',

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -102,6 +102,17 @@ test('custom thresholds', function (assert) {
 
     moment.relativeTimeThreshold('s', 45);
 
+    // A few seconds to seconds threshold
+    moment.relativeTimeThreshold('ss', 3);
+
+    a = moment();
+    a.subtract(3, 'seconds');
+    assert.equal(a.fromNow(), 'a few seconds ago', 'Below custom a few seconds to seconds threshold');
+    a.subtract(1, 'seconds');
+    assert.equal(a.fromNow(), '4 seconds ago', 'Above custom a few seconds to seconds threshold');
+
+    moment.relativeTimeThreshold('ss', 44);
+
     // Minutes to hours threshold
     moment.relativeTimeThreshold('m', 55);
     a = moment();
@@ -190,14 +201,14 @@ test('custom rounding', function (assert) {
     moment.relativeTimeRounding(roundingDefault);
 });
 
-test('retrive rounding settings', function (assert) {
+test('retrieve rounding settings', function (assert) {
     moment.relativeTimeRounding(Math.round);
     var roundingFunction = moment.relativeTimeRounding();
 
     assert.equal(roundingFunction, Math.round, 'Can retrieve rounding setting');
 });
 
-test('retrive threshold settings', function (assert) {
+test('retrieve threshold settings', function (assert) {
     moment.relativeTimeThreshold('m', 45);
     var minuteThreshold = moment.relativeTimeThreshold('m');
 


### PR DESCRIPTION
This PR adds an optional threshold (`ss`) for `a few seconds` to `%d seconds`. It is built so that it will never display `%d seconds` UNLESS the user manually sets the `ss` threshold. Setting the `ss` threshold once will separate the default value (which is the value in the `s` threshold minus 1).

As mentioned in #2558, there is no translation for: `%d seconds`. I could add this for each locale using the `seconds` word that is already present in each locale for the `s` threshold (e.g. `a few **seconds**`), but I don't know if this would work for all locales. So then this would require a review from a native speaker for each locale. Probably not gonna happen.

#2182: I hope by not actively using this `ss` threshold by default (afaik this is backwards compatible), this PR still has a chance.

Let me know what you think :)