### PR TITLE
Option to express difference as multiple units.

### DIFF
--- a/src/lib/moment/diff.js
+++ b/src/lib/moment/diff.js
@@ -19,6 +19,10 @@ export function diff (input, units, asFloat) {
 
     zoneDelta = (that.utcOffset() - this.utcOffset()) * 6e4;
 
+    if (units === 'all') {
+        return allUnitsDiff(this,that);
+    }
+
     units = normalizeUnits(units);
 
     if (units === 'year' || units === 'month' || units === 'quarter') {
@@ -59,4 +63,32 @@ function monthDiff (a, b) {
 
     //check for negative zero, return zero if negative zero
     return -(wholeMonthDiff + adjust) || 0;
+}
+
+function allUnitsDiff(after,before) {
+    var totalMonths = absFloor(monthDiff(after,before)),
+        years, months, days, hours,
+        minutes, seconds, milliseconds,
+        nd;
+
+    years   = absFloor(totalMonths / 12);
+    months  = totalMonths - (years * 12);
+    //reduce difference between dates by totalMonths (years & months)
+    nd = before.clone().add(totalMonths, 'months');
+    days    = (after - nd) / 864e5; // days / ms in a day
+    //extract previous unit and convert decimal
+    hours   = (days % 1) * 24;
+    minutes = (hours % 1) * 60;
+    seconds = (minutes % 1) * 60;
+    milliseconds = (seconds % 1) * 1000;
+
+    return {
+        years:   absFloor(years),
+        months:  absFloor(months),
+        days:    absFloor(days),
+        hours:   absFloor(hours),
+        minutes: absFloor(minutes),
+        seconds: absFloor(seconds),
+        milliseconds: Math.round(milliseconds)
+    };
 }

--- a/src/lib/moment/diff.js
+++ b/src/lib/moment/diff.js
@@ -69,15 +69,16 @@ function allUnitsDiff(after,before) {
     var totalMonths = absFloor(monthDiff(after,before)),
         years, months, days, hours,
         minutes, seconds, milliseconds,
-        nd;
+        diff, nd;
 
     years   = absFloor(totalMonths / 12);
     months  = totalMonths - (years * 12);
     //reduce difference between dates by totalMonths (years & months)
     nd = before.clone().add(totalMonths, 'months');
-    days    = (after - nd) / 864e5; // days / ms in a day
+    diff = after - nd;
+    days = diff / 864e5; // days / ms in a day
     //extract previous unit and convert decimal
-    hours   = (days % 1) * 24;
+    hours   = diff / 36e5 - absFloor(days) * 24;
     minutes = (hours % 1) * 60;
     seconds = (minutes % 1) * 60;
     milliseconds = (seconds % 1) * 1000;

--- a/src/test/moment/diff.js
+++ b/src/test/moment/diff.js
@@ -113,6 +113,11 @@ test('diff all key', function (assert) {
         {years: -15, months: -1, days: -29, hours: -5, minutes: -5, seconds: -5, milliseconds: -550},
         'Negative values when base moment is the earlier date'
     );
+    assert.deepEqual(
+        moment([2015,2,9]).diff([2015,1,10],'all'),
+        {years: 0, months: 0, days: 26, hours: 23, minutes: 0, seconds: 0, milliseconds: 0},
+        'Daylight savings effects result until next month begins'
+    );
 });
 
 test('diff across DST', function (assert) {

--- a/src/test/moment/diff.js
+++ b/src/test/moment/diff.js
@@ -102,6 +102,19 @@ test('diff month', function (assert) {
     assert.equal(moment([2011, 0, 31]).diff([2011, 2, 1], 'months'), -1, 'month diff');
 });
 
+test('diff all key', function (assert) {
+    assert.deepEqual(
+        moment([2015,8,8,5,5,5,550]).diff([2000,6,10],'all'),
+        {years: 15, months: 1, days: 29, hours: 5, minutes: 5, seconds: 5, milliseconds: 550},
+        'Correct value for each unit'
+    );
+    assert.deepEqual(
+        moment([2000,6,10]).diff([2015,8,8,5,5,5,550],'all'),
+        {years: -15, months: -1, days: -29, hours: -5, minutes: -5, seconds: -5, milliseconds: -550},
+        'Negative values when base moment is the earlier date'
+    );
+});
+
 test('diff across DST', function (assert) {
     var dst = dstForYear(2012), a, b, daysInMonth;
     if (!dst) {

--- a/src/test/moment/diff.js
+++ b/src/test/moment/diff.js
@@ -113,11 +113,6 @@ test('diff all key', function (assert) {
         {years: -15, months: -1, days: -29, hours: -5, minutes: -5, seconds: -5, milliseconds: -550},
         'Negative values when base moment is the earlier date'
     );
-    assert.deepEqual(
-        moment([2015,2,9]).diff([2015,1,10],'all'),
-        {years: 0, months: 0, days: 26, hours: 23, minutes: 0, seconds: 0, milliseconds: 0},
-        'Daylight savings effects result until next month begins'
-    );
 });
 
 test('diff across DST', function (assert) {
@@ -175,6 +170,11 @@ test('diff across DST', function (assert) {
             'year diff across DST, lower bound');
     assert.ok(b.diff(a, 'year', true) < 1.05 / (2 * 28 * 12),
             'year diff across DST, upper bound');
+
+    assert.deepEqual(
+        b.diff(a,'all'),
+        {years: 0, months: 0, days: 0, hours: (12 + dst.diff), minutes: 0, seconds: 0, milliseconds: 0},
+        'Daylight savings effects result until next month begins');
 });
 
 test('diff overflow', function (assert) {


### PR DESCRIPTION
Adds the option for diff to return an object containing the result over multiple units. For example:
```javascript
moment([2015,8,8,5,5,5,550]).diff([2000,6,10],'all');
//returns {years: 15, months: 1, days: 29, hours: 5, minutes: 5, seconds: 5, milliseconds: 550}
```
Currently using 'all' as the key. Not sure if there'd be a better term. 