### PR TITLE
[misc] Change ordinalParse to dayOfMonthOrdinalParse in locales

### DIFF
--- a/src/lib/locale/base-config.js
+++ b/src/lib/locale/base-config.js
@@ -1,7 +1,7 @@
 import { defaultCalendar } from './calendar';
 import { defaultLongDateFormat } from './formats';
 import { defaultInvalidDate } from './invalid';
-import { defaultOrdinal, defaultOrdinalParse } from './ordinal';
+import { defaultOrdinal, defaultDayOfMonthOrdinalParse } from './ordinal';
 import { defaultRelativeTime } from './relative';
 
 // months
@@ -28,7 +28,7 @@ export var baseConfig = {
     longDateFormat: defaultLongDateFormat,
     invalidDate: defaultInvalidDate,
     ordinal: defaultOrdinal,
-    ordinalParse: defaultOrdinalParse,
+    dayOfMonthOrdinalParse: defaultDayOfMonthOrdinalParse,
     relativeTime: defaultRelativeTime,
 
     months: defaultLocaleMonths,

--- a/src/lib/locale/en.js
+++ b/src/lib/locale/en.js
@@ -3,7 +3,7 @@ import { getSetGlobalLocale } from './locales';
 import toInt from '../utils/to-int';
 
 getSetGlobalLocale('en', {
-    ordinalParse: /\d{1,2}(th|st|nd|rd)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(th|st|nd|rd)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (toInt(number % 100 / 10) === 1) ? 'th' :

--- a/src/lib/locale/ordinal.js
+++ b/src/lib/locale/ordinal.js
@@ -1,5 +1,5 @@
 export var defaultOrdinal = '%d';
-export var defaultOrdinalParse = /\d{1,2}/;
+export var defaultDayOfMonthOrdinalParse = /\d{1,2}/;
 
 export function ordinal (number) {
     return this._ordinal.replace('%d', number);

--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -15,8 +15,9 @@ export function set (config) {
     }
     this._config = config;
     // Lenient ordinal parsing accepts just a number in addition to
-    // number + (possibly) stuff coming from _ordinalParseLenient.
-    this._ordinalParseLenient = new RegExp(this._ordinalParse.source + '|' + (/\d{1,2}/).source);
+    // number + (possibly) stuff coming from _dayOfMonthOrdinalParse.
+    this._dayOfMonthOrdinalParseLenient = new RegExp(
+        this._dayOfMonthOrdinalParse.source + '|' + (/\d{1,2}/).source);
 }
 
 export function mergeConfigs(parentConfig, childConfig) {

--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -16,8 +16,10 @@ export function set (config) {
     this._config = config;
     // Lenient ordinal parsing accepts just a number in addition to
     // number + (possibly) stuff coming from _dayOfMonthOrdinalParse.
+    // TODO: Remove "ordinalParse" fallback in next major release.
     this._dayOfMonthOrdinalParseLenient = new RegExp(
-        this._dayOfMonthOrdinalParse.source + '|' + (/\d{1,2}/).source);
+        (this._dayOfMonthOrdinalParse.source || this._ordinalParse.source) +
+            '|' + (/\d{1,2}/).source);
 }
 
 export function mergeConfigs(parentConfig, childConfig) {

--- a/src/lib/units/day-of-month.js
+++ b/src/lib/units/day-of-month.js
@@ -23,7 +23,10 @@ addUnitPriority('date', 9);
 addRegexToken('D',  match1to2);
 addRegexToken('DD', match1to2, match2);
 addRegexToken('Do', function (isStrict, locale) {
-    return isStrict ? locale._dayOfMonthOrdinalParse : locale._dayOfMonthOrdinalParseLenient;
+    // TODO: Remove "ordinalParse" fallback in next major release.
+    return isStrict ?
+      (locale._dayOfMonthOrdinalParse || locale._ordinalParse) :
+      locale._dayOfMonthOrdinalParseLenient;
 });
 
 addParseToken(['D', 'DD'], DATE);

--- a/src/lib/units/day-of-month.js
+++ b/src/lib/units/day-of-month.js
@@ -23,7 +23,7 @@ addUnitPriority('date', 9);
 addRegexToken('D',  match1to2);
 addRegexToken('DD', match1to2, match2);
 addRegexToken('Do', function (isStrict, locale) {
-    return isStrict ? locale._ordinalParse : locale._ordinalParseLenient;
+    return isStrict ? locale._dayOfMonthOrdinalParse : locale._dayOfMonthOrdinalParseLenient;
 });
 
 addParseToken(['D', 'DD'], DATE);

--- a/src/locale/af.js
+++ b/src/locale/af.js
@@ -52,7 +52,7 @@ export default moment.defineLocale('af', {
         y : '\'n jaar',
         yy : '%d jaar'
     },
-    ordinalParse: /\d{1,2}(ste|de)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(ste|de)/,
     ordinal : function (number) {
         return number + ((number === 1 || number === 8 || number >= 20) ? 'ste' : 'de'); // Thanks to Joris Röling : https://github.com/jjupiter
     },

--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -78,7 +78,7 @@ export default moment.defineLocale('az', {
             return 'axşam';
         }
     },
-    ordinalParse: /\d{1,2}-(ıncı|inci|nci|üncü|ncı|uncu)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(ıncı|inci|nci|üncü|ncı|uncu)/,
     ordinal : function (number) {
         if (number === 0) {  // special case for zero
             return number + '-ıncı';

--- a/src/locale/be.js
+++ b/src/locale/be.js
@@ -102,7 +102,7 @@ export default moment.defineLocale('be', {
             return 'вечара';
         }
     },
-    ordinalParse: /\d{1,2}-(і|ы|га)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(і|ы|га)/,
     ordinal: function (number, period) {
         switch (period) {
             case 'M':

--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -53,7 +53,7 @@ export default moment.defineLocale('bg', {
         y : 'година',
         yy : '%d години'
     },
-    ordinalParse: /\d{1,2}-(ев|ен|ти|ви|ри|ми)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(ев|ен|ти|ви|ри|ми)/,
     ordinal : function (number) {
         var lastDigit = number % 10,
             last2Digits = number % 100;

--- a/src/locale/br.js
+++ b/src/locale/br.js
@@ -86,7 +86,7 @@ export default moment.defineLocale('br', {
         y : 'ur bloaz',
         yy : specialMutationForYears
     },
-    ordinalParse: /\d{1,2}(añ|vet)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(añ|vet)/,
     ordinal : function (number) {
         var output = (number === 1) ? 'añ' : 'vet';
         return number + output;

--- a/src/locale/bs.js
+++ b/src/locale/bs.js
@@ -124,7 +124,7 @@ export default moment.defineLocale('bs', {
         y      : 'godinu',
         yy     : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -53,7 +53,7 @@ export default moment.defineLocale('ca', {
         y : 'un any',
         yy : '%d anys'
     },
-    ordinalParse: /\d{1,2}(r|n|t|è|a)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(r|n|t|è|a)/,
     ordinal : function (number, period) {
         var output = (number === 1) ? 'r' :
             (number === 2) ? 'n' :

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -153,7 +153,7 @@ export default moment.defineLocale('cs', {
         y : translate,
         yy : translate
     },
-    ordinalParse : /\d{1,2}\./,
+    dayOfMonthOrdinalParse : /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/cv.js
+++ b/src/locale/cv.js
@@ -44,7 +44,7 @@ export default moment.defineLocale('cv', {
         y : 'пӗр ҫул',
         yy : '%d ҫул'
     },
-    ordinalParse: /\d{1,2}-мӗш/,
+    dayOfMonthOrdinalParse: /\d{1,2}-мӗш/,
     ordinal : '%d-мӗш',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/cy.js
+++ b/src/locale/cy.js
@@ -44,7 +44,7 @@ export default moment.defineLocale('cy', {
         y: 'blwyddyn',
         yy: '%d flynedd'
     },
-    ordinalParse: /\d{1,2}(fed|ain|af|il|ydd|ed|eg)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(fed|ain|af|il|ydd|ed|eg)/,
     // traditional ordinal numbers above 31 are not commonly used in colloquial Welsh
     ordinal: function (number) {
         var b = number,

--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('da', {
         y : 'et år',
         yy : '%d år'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -60,7 +60,7 @@ export default moment.defineLocale('de-at', {
         y : processRelativeTime,
         yy : processRelativeTime
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -59,7 +59,7 @@ export default moment.defineLocale('de', {
         y : processRelativeTime,
         yy : processRelativeTime
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -76,7 +76,7 @@ export default moment.defineLocale('el', {
         y : 'ένας χρόνος',
         yy : '%d χρόνια'
     },
-    ordinalParse: /\d{1,2}η/,
+    dayOfMonthOrdinalParse: /\d{1,2}η/,
     ordinal: '%dη',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/en-au.js
+++ b/src/locale/en-au.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('en-au', {
         y : 'a year',
         yy : '%d years'
     },
-    ordinalParse: /\d{1,2}(st|nd|rd|th)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(st|nd|rd|th)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'th' :

--- a/src/locale/en-ca.js
+++ b/src/locale/en-ca.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('en-ca', {
         y : 'a year',
         yy : '%d years'
     },
-    ordinalParse: /\d{1,2}(st|nd|rd|th)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(st|nd|rd|th)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'th' :

--- a/src/locale/en-gb.js
+++ b/src/locale/en-gb.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('en-gb', {
         y : 'a year',
         yy : '%d years'
     },
-    ordinalParse: /\d{1,2}(st|nd|rd|th)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(st|nd|rd|th)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'th' :

--- a/src/locale/en-ie.js
+++ b/src/locale/en-ie.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('en-ie', {
         y : 'a year',
         yy : '%d years'
     },
-    ordinalParse: /\d{1,2}(st|nd|rd|th)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(st|nd|rd|th)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'th' :

--- a/src/locale/en-nz.js
+++ b/src/locale/en-nz.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('en-nz', {
         y : 'a year',
         yy : '%d years'
     },
-    ordinalParse: /\d{1,2}(st|nd|rd|th)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(st|nd|rd|th)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'th' :

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -54,7 +54,7 @@ export default moment.defineLocale('eo', {
         y : 'jaro',
         yy : '%d jaroj'
     },
-    ordinalParse: /\d{1,2}a/,
+    dayOfMonthOrdinalParse: /\d{1,2}a/,
     ordinal : '%da',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/es-do.js
+++ b/src/locale/es-do.js
@@ -61,7 +61,7 @@ export default moment.defineLocale('es-do', {
         y : 'un año',
         yy : '%d años'
     },
-    ordinalParse : /\d{1,2}º/,
+    dayOfMonthOrdinalParse : /\d{1,2}º/,
     ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -62,7 +62,7 @@ export default moment.defineLocale('es', {
         y : 'un año',
         yy : '%d años'
     },
-    ordinalParse : /\d{1,2}º/,
+    dayOfMonthOrdinalParse : /\d{1,2}º/,
     ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/et.js
+++ b/src/locale/et.js
@@ -61,7 +61,7 @@ export default moment.defineLocale('et', {
         y      : processRelativeTime,
         yy     : processRelativeTime
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/eu.js
+++ b/src/locale/eu.js
@@ -47,7 +47,7 @@ export default moment.defineLocale('eu', {
         y : 'urte bat',
         yy : '%d urte'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/fa.js
+++ b/src/locale/fa.js
@@ -87,7 +87,7 @@ export default moment.defineLocale('fa', {
             return symbolMap[match];
         }).replace(/,/g, '،');
     },
-    ordinalParse: /\d{1,2}م/,
+    dayOfMonthOrdinalParse: /\d{1,2}م/,
     ordinal : '%dم',
     week : {
         dow : 6, // Saturday is the first day of the week.

--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -88,7 +88,7 @@ export default moment.defineLocale('fi', {
         y : translate,
         yy : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/fo.js
+++ b/src/locale/fo.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('fo', {
         y : 'eitt ár',
         yy : '%d ár'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -43,7 +43,7 @@ export default moment.defineLocale('fr-ca', {
         y : 'un an',
         yy : '%d ans'
     },
-    ordinalParse: /\d{1,2}(er|e)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(er|e)/,
     ordinal : function (number) {
         return number + (number === 1 ? 'er' : 'e');
     }

--- a/src/locale/fr-ch.js
+++ b/src/locale/fr-ch.js
@@ -43,7 +43,7 @@ export default moment.defineLocale('fr-ch', {
         y : 'un an',
         yy : '%d ans'
     },
-    ordinalParse: /\d{1,2}(er|e)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(er|e)/,
     ordinal : function (number) {
         return number + (number === 1 ? 'er' : 'e');
     },

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -43,7 +43,7 @@ export default moment.defineLocale('fr', {
         y : 'un an',
         yy : '%d ans'
     },
-    ordinalParse: /\d{1,2}(er|)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(er|)/,
     ordinal : function (number) {
         return number + (number === 1 ? 'er' : '');
     },

--- a/src/locale/fy.js
+++ b/src/locale/fy.js
@@ -52,7 +52,7 @@ export default moment.defineLocale('fy', {
         y : 'ien jier',
         yy : '%d jierren'
     },
-    ordinalParse: /\d{1,2}(ste|de)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(ste|de)/,
     ordinal : function (number) {
         return number + ((number === 1 || number === 8 || number >= 20) ? 'ste' : 'de');
     },

--- a/src/locale/gd.js
+++ b/src/locale/gd.js
@@ -54,7 +54,7 @@ export default moment.defineLocale('gd', {
         y : 'bliadhna',
         yy : '%d bliadhna'
     },
-    ordinalParse : /\d{1,2}(d|na|mh)/,
+    dayOfMonthOrdinalParse : /\d{1,2}(d|na|mh)/,
     ordinal : function (number) {
         var output = number === 1 ? 'd' : number % 10 === 2 ? 'na' : 'mh';
         return number + output;

--- a/src/locale/gl.js
+++ b/src/locale/gl.js
@@ -58,7 +58,7 @@ export default moment.defineLocale('gl', {
         y : 'un ano',
         yy : '%d anos'
     },
-    ordinalParse : /\d{1,2}º/,
+    dayOfMonthOrdinalParse : /\d{1,2}º/,
     ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -126,7 +126,7 @@ export default moment.defineLocale('hr', {
         y      : 'godinu',
         yy     : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/hu.js
+++ b/src/locale/hu.js
@@ -90,7 +90,7 @@ export default moment.defineLocale('hu', {
         y : translate,
         yy : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/hy-am.js
+++ b/src/locale/hy-am.js
@@ -63,7 +63,7 @@ export default moment.defineLocale('hy-am', {
             return 'երեկոյան';
         }
     },
-    ordinalParse: /\d{1,2}|\d{1,2}-(ին|րդ)/,
+    dayOfMonthOrdinalParse: /\d{1,2}|\d{1,2}-(ին|րդ)/,
     ordinal: function (number, period) {
         switch (period) {
             case 'DDD':

--- a/src/locale/is.js
+++ b/src/locale/is.js
@@ -108,7 +108,7 @@ export default moment.defineLocale('is', {
         y : translate,
         yy : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -51,7 +51,7 @@ export default moment.defineLocale('it', {
         y : 'un anno',
         yy : '%d anni'
     },
-    ordinalParse : /\d{1,2}º/,
+    dayOfMonthOrdinalParse : /\d{1,2}º/,
     ordinal: '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('ja', {
         lastWeek : '[前週]dddd LT',
         sameElse : 'L'
     },
-    ordinalParse : /\d{1,2}日/,
+    dayOfMonthOrdinalParse : /\d{1,2}日/,
     ordinal : function (number, period) {
         switch (period) {
             case 'd':

--- a/src/locale/ka.js
+++ b/src/locale/ka.js
@@ -59,7 +59,7 @@ export default moment.defineLocale('ka', {
         y : 'წელი',
         yy : '%d წელი'
     },
-    ordinalParse: /0|1-ლი|მე-\d{1,2}|\d{1,2}-ე/,
+    dayOfMonthOrdinalParse: /0|1-ლი|მე-\d{1,2}|\d{1,2}-ე/,
     ordinal : function (number) {
         if (number === 0) {
             return number;

--- a/src/locale/kk.js
+++ b/src/locale/kk.js
@@ -64,7 +64,7 @@ export default moment.defineLocale('kk', {
         y : 'бір жыл',
         yy : '%d жыл'
     },
-    ordinalParse: /\d{1,2}-(ші|шы)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(ші|шы)/,
     ordinal : function (number) {
         var a = number % 10,
             b = number >= 100 ? 100 : null;

--- a/src/locale/kn.js
+++ b/src/locale/kn.js
@@ -105,7 +105,7 @@ export default moment.defineLocale('kn', {
             return 'ರಾತ್ರಿ';
         }
     },
-    ordinalParse: /\d{1,2}(ನೇ)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(ನೇ)/,
     ordinal : function (number) {
         return number + 'ನೇ';
     },

--- a/src/locale/ko.js
+++ b/src/locale/ko.js
@@ -47,7 +47,7 @@ export default moment.defineLocale('ko', {
         y : '일 년',
         yy : '%d년'
     },
-    ordinalParse : /\d{1,2}일/,
+    dayOfMonthOrdinalParse : /\d{1,2}일/,
     ordinal : '%d일',
     meridiemParse : /오전|오후/,
     isPM : function (token) {

--- a/src/locale/ky.js
+++ b/src/locale/ky.js
@@ -65,7 +65,7 @@ export default moment.defineLocale('ky', {
         y : 'бир жыл',
         yy : '%d жыл'
     },
-    ordinalParse: /\d{1,2}-(чи|чы|чү|чу)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(чи|чы|чү|чу)/,
     ordinal : function (number) {
         var a = number % 10,
             b = number >= 100 ? 100 : null;

--- a/src/locale/lb.js
+++ b/src/locale/lb.js
@@ -118,7 +118,7 @@ export default moment.defineLocale('lb', {
         y : processRelativeTime,
         yy : '%d Joer'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal: '%d.',
     week: {
         dow: 1, // Monday is the first day of the week.

--- a/src/locale/lo.js
+++ b/src/locale/lo.js
@@ -53,7 +53,7 @@ export default moment.defineLocale('lo', {
         y : '1 ປີ',
         yy : '%d ປີ'
     },
-    ordinalParse: /(ທີ່)\d{1,2}/,
+    dayOfMonthOrdinalParse: /(ທີ່)\d{1,2}/,
     ordinal : function (number) {
         return 'ທີ່' + number;
     }

--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -96,7 +96,7 @@ export default moment.defineLocale('lt', {
         y : translateSingular,
         yy : translate
     },
-    ordinalParse: /\d{1,2}-oji/,
+    dayOfMonthOrdinalParse: /\d{1,2}-oji/,
     ordinal : function (number) {
         return number + '-oji';
     },

--- a/src/locale/lv.js
+++ b/src/locale/lv.js
@@ -78,7 +78,7 @@ export default moment.defineLocale('lv', {
         y : relativeTimeWithSingular,
         yy : relativeTimeWithPlural
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/me.js
+++ b/src/locale/me.js
@@ -92,7 +92,7 @@ export default moment.defineLocale('me', {
         y      : 'godinu',
         yy     : translator.translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/mi.js
+++ b/src/locale/mi.js
@@ -45,7 +45,7 @@ export default moment.defineLocale('mi', {
         y: 'he tau',
         yy: '%d tau'
     },
-    ordinalParse: /\d{1,2}º/,
+    dayOfMonthOrdinalParse: /\d{1,2}º/,
     ordinal: '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/mk.js
+++ b/src/locale/mk.js
@@ -53,7 +53,7 @@ export default moment.defineLocale('mk', {
         y : 'година',
         yy : '%d години'
     },
-    ordinalParse: /\d{1,2}-(ев|ен|ти|ви|ри|ми)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(ев|ен|ти|ви|ри|ми)/,
     ordinal : function (number) {
         var lastDigit = number % 10,
             last2Digits = number % 100;

--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -44,7 +44,7 @@ export default moment.defineLocale('nb', {
         y : 'ett år',
         yy : '%d år'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/nl-be.js
+++ b/src/locale/nl-be.js
@@ -65,7 +65,7 @@ export default moment.defineLocale('nl-be', {
         y : 'één jaar',
         yy : '%d jaar'
     },
-    ordinalParse: /\d{1,2}(ste|de)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(ste|de)/,
     ordinal : function (number) {
         return number + ((number === 1 || number === 8 || number >= 20) ? 'ste' : 'de');
     },

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -65,7 +65,7 @@ export default moment.defineLocale('nl', {
         y : 'één jaar',
         yy : '%d jaar'
     },
-    ordinalParse: /\d{1,2}(ste|de)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(ste|de)/,
     ordinal : function (number) {
         return number + ((number === 1 || number === 8 || number >= 20) ? 'ste' : 'de');
     },

--- a/src/locale/nn.js
+++ b/src/locale/nn.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('nn', {
         y : 'eit år',
         yy : '%d år'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/pl.js
+++ b/src/locale/pl.js
@@ -86,7 +86,7 @@ export default moment.defineLocale('pl', {
         y : 'rok',
         yy : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -46,7 +46,7 @@ export default moment.defineLocale('pt-br', {
         y : 'um ano',
         yy : '%d anos'
     },
-    ordinalParse: /\d{1,2}º/,
+    dayOfMonthOrdinalParse: /\d{1,2}º/,
     ordinal : '%dº'
 });
 

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -46,7 +46,7 @@ export default moment.defineLocale('pt', {
         y : 'um ano',
         yy : '%d anos'
     },
-    ordinalParse: /\d{1,2}º/,
+    dayOfMonthOrdinalParse: /\d{1,2}º/,
     ordinal : '%dº',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -150,7 +150,7 @@ export default moment.defineLocale('ru', {
             return 'вечера';
         }
     },
-    ordinalParse: /\d{1,2}-(й|го|я)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(й|го|я)/,
     ordinal: function (number, period) {
         switch (period) {
             case 'M':

--- a/src/locale/se.js
+++ b/src/locale/se.js
@@ -42,7 +42,7 @@ export default moment.defineLocale('se', {
         y : 'okta jahki',
         yy : '%d jagit'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/si.js
+++ b/src/locale/si.js
@@ -43,7 +43,7 @@ export default moment.defineLocale('si', {
         y : 'වසර',
         yy : 'වසර %d'
     },
-    ordinalParse: /\d{1,2} වැනි/,
+    dayOfMonthOrdinalParse: /\d{1,2} වැනි/,
     ordinal : function (number) {
         return number + ' වැනි';
     },

--- a/src/locale/sk.js
+++ b/src/locale/sk.js
@@ -131,7 +131,7 @@ export default moment.defineLocale('sk', {
         y : translate,
         yy : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -143,7 +143,7 @@ export default moment.defineLocale('sl', {
         y      : processRelativeTime,
         yy     : processRelativeTime
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/sq.js
+++ b/src/locale/sq.js
@@ -51,7 +51,7 @@ export default moment.defineLocale('sq', {
         y : 'një vit',
         yy : '%d vite'
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/sr-cyrl.js
+++ b/src/locale/sr-cyrl.js
@@ -91,7 +91,7 @@ export default moment.defineLocale('sr-cyrl', {
         y      : 'годину',
         yy     : translator.translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -91,7 +91,7 @@ export default moment.defineLocale('sr', {
         y      : 'godinu',
         yy     : translator.translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/ss.js
+++ b/src/locale/ss.js
@@ -70,7 +70,7 @@ export default moment.defineLocale('ss', {
             return hour + 12;
         }
     },
-    ordinalParse: /\d{1,2}/,
+    dayOfMonthOrdinalParse: /\d{1,2}/,
     ordinal : '%d',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -43,7 +43,7 @@ export default moment.defineLocale('sv', {
         y : 'ett år',
         yy : '%d år'
     },
-    ordinalParse: /\d{1,2}(e|a)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(e|a)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'e' :

--- a/src/locale/ta.js
+++ b/src/locale/ta.js
@@ -65,7 +65,7 @@ export default moment.defineLocale('ta', {
         y : 'ஒரு வருடம்',
         yy : '%d ஆண்டுகள்'
     },
-    ordinalParse: /\d{1,2}வது/,
+    dayOfMonthOrdinalParse: /\d{1,2}வது/,
     ordinal : function (number) {
         return number + 'வது';
     },

--- a/src/locale/te.js
+++ b/src/locale/te.js
@@ -42,7 +42,7 @@ export default moment.defineLocale('te', {
         y : 'ఒక సంవత్సరం',
         yy : '%d సంవత్సరాలు'
     },
-    ordinalParse : /\d{1,2}వ/,
+    dayOfMonthOrdinalParse : /\d{1,2}వ/,
     ordinal : '%dవ',
     meridiemParse: /రాత్రి|ఉదయం|మధ్యాహ్నం|సాయంత్రం/,
     meridiemHour : function (hour, meridiem) {

--- a/src/locale/tet.js
+++ b/src/locale/tet.js
@@ -42,7 +42,7 @@ export default moment.defineLocale('tet', {
         y : 'tinan ida',
         yy : 'tinan %d'
     },
-    ordinalParse: /\d{1,2}(st|nd|rd|th)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(st|nd|rd|th)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'th' :

--- a/src/locale/tl-ph.js
+++ b/src/locale/tl-ph.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('tl-ph', {
         y : 'isang taon',
         yy : '%d taon'
     },
-    ordinalParse: /\d{1,2}/,
+    dayOfMonthOrdinalParse: /\d{1,2}/,
     ordinal : function (number) {
         return number;
     },

--- a/src/locale/tlh.js
+++ b/src/locale/tlh.js
@@ -101,7 +101,7 @@ export default moment.defineLocale('tlh', {
         y : 'wa’ DIS',
         yy : translate
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -63,7 +63,7 @@ export default moment.defineLocale('tr', {
         y : 'bir yıl',
         yy : '%d yıl'
     },
-    ordinalParse: /\d{1,2}'(inci|nci|üncü|ncı|uncu|ıncı)/,
+    dayOfMonthOrdinalParse: /\d{1,2}'(inci|nci|üncü|ncı|uncu|ıncı)/,
     ordinal : function (number) {
         if (number === 0) {  // special case for zero
             return number + '\'ıncı';

--- a/src/locale/tzl.js
+++ b/src/locale/tzl.js
@@ -55,7 +55,7 @@ export default moment.defineLocale('tzl', {
         y : processRelativeTime,
         yy : processRelativeTime
     },
-    ordinalParse: /\d{1,2}\./,
+    dayOfMonthOrdinalParse: /\d{1,2}\./,
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -114,7 +114,7 @@ export default moment.defineLocale('uk', {
             return 'вечора';
         }
     },
-    ordinalParse: /\d{1,2}-(й|го)/,
+    dayOfMonthOrdinalParse: /\d{1,2}-(й|го)/,
     ordinal: function (number, period) {
         switch (period) {
             case 'M':

--- a/src/locale/vi.js
+++ b/src/locale/vi.js
@@ -58,7 +58,7 @@ export default moment.defineLocale('vi', {
         y : 'một năm',
         yy : '%d năm'
     },
-    ordinalParse: /\d{1,2}/,
+    dayOfMonthOrdinalParse: /\d{1,2}/,
     ordinal : function (number) {
         return number;
     },

--- a/src/locale/x-pseudo.js
+++ b/src/locale/x-pseudo.js
@@ -42,7 +42,7 @@ export default moment.defineLocale('x-pseudo', {
         y : 'á ~ýéár',
         yy : '%d ý~éárs'
     },
-    ordinalParse: /\d{1,2}(th|st|nd|rd)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(th|st|nd|rd)/,
     ordinal : function (number) {
         var b = number % 10,
             output = (~~(number % 100 / 10) === 1) ? 'th' :

--- a/src/locale/yo.js
+++ b/src/locale/yo.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('yo', {
         y : 'ọdún kan',
         yy : 'ọdún %d'
     },
-    ordinalParse : /ọjọ́\s\d{1,2}/,
+    dayOfMonthOrdinalParse : /ọjọ́\s\d{1,2}/,
     ordinal : 'ọjọ́ %d',
     week : {
         dow : 1, // Monday is the first day of the week.

--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -62,7 +62,7 @@ export default moment.defineLocale('zh-cn', {
         lastWeek : '[上]ddddLT',
         sameElse : 'L'
     },
-    ordinalParse: /\d{1,2}(日|月|周)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(日|月|周)/,
     ordinal : function (number, period) {
         switch (period) {
             case 'd':

--- a/src/locale/zh-hk.js
+++ b/src/locale/zh-hk.js
@@ -61,7 +61,7 @@ export default moment.defineLocale('zh-hk', {
         lastWeek : '[上]ddddLT',
         sameElse : 'L'
     },
-    ordinalParse: /\d{1,2}(日|月|週)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(日|月|週)/,
     ordinal : function (number, period) {
         switch (period) {
             case 'd' :

--- a/src/locale/zh-tw.js
+++ b/src/locale/zh-tw.js
@@ -60,7 +60,7 @@ export default moment.defineLocale('zh-tw', {
         lastWeek : '[上]ddddLT',
         sameElse : 'L'
     },
-    ordinalParse: /\d{1,2}(日|月|週)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(日|月|週)/,
     ordinal : function (number, period) {
         switch (period) {
             case 'd' :

--- a/src/test/helpers/common-locale.js
+++ b/src/test/helpers/common-locale.js
@@ -5,39 +5,39 @@ import moment from '../../moment';
 import defaults from '../../lib/utils/defaults';
 
 export function defineCommonLocaleTests(locale, options) {
-    test('lenient ordinal parsing', function (assert) {
+    test('lenient day of month ordinal parsing', function (assert) {
         var i, ordinalStr, testMoment;
         for (i = 1; i <= 31; ++i) {
             ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
             testMoment = moment(ordinalStr, 'YYYY MM Do');
             assert.equal(testMoment.year(), 2014,
-                    'lenient ordinal parsing ' + i + ' year check');
+                    'lenient day of month ordinal parsing ' + i + ' year check');
             assert.equal(testMoment.month(), 0,
-                    'lenient ordinal parsing ' + i + ' month check');
+                    'lenient day of month ordinal parsing ' + i + ' month check');
             assert.equal(testMoment.date(), i,
-                    'lenient ordinal parsing ' + i + ' date check');
+                    'lenient day of month ordinal parsing ' + i + ' date check');
         }
     });
 
-    test('lenient ordinal parsing of number', function (assert) {
+    test('lenient day of month ordinal parsing of number', function (assert) {
         var i, testMoment;
         for (i = 1; i <= 31; ++i) {
             testMoment = moment('2014 01 ' + i, 'YYYY MM Do');
             assert.equal(testMoment.year(), 2014,
-                    'lenient ordinal parsing of number ' + i + ' year check');
+                    'lenient day of month ordinal parsing of number ' + i + ' year check');
             assert.equal(testMoment.month(), 0,
-                    'lenient ordinal parsing of number ' + i + ' month check');
+                    'lenient day of month ordinal parsing of number ' + i + ' month check');
             assert.equal(testMoment.date(), i,
-                    'lenient ordinal parsing of number ' + i + ' date check');
+                    'lenient day of month ordinal parsing of number ' + i + ' date check');
         }
     });
 
-    test('strict ordinal parsing', function (assert) {
+    test('strict day of month ordinal parsing', function (assert) {
         var i, ordinalStr, testMoment;
         for (i = 1; i <= 31; ++i) {
             ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
             testMoment = moment(ordinalStr, 'YYYY MM Do', true);
-            assert.ok(testMoment.isValid(), 'strict ordinal parsing ' + i);
+            assert.ok(testMoment.isValid(), 'strict day of month ordinal parsing ' + i);
         }
     });
 

--- a/src/test/locale/pa-in.js
+++ b/src/test/locale/pa-in.js
@@ -284,38 +284,38 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0, 15]).format('w ww wo'), '੩ ੦੩ ੩', 'Jan 15 2012 should be week 3');
 });
 
-test('lenient ordinal parsing', function (assert) {
+test('lenient day of month ordinal parsing', function (assert) {
     var i, ordinalStr, testMoment;
     for (i = 1; i <= 31; ++i) {
         ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
         testMoment = moment(ordinalStr, 'YYYY MM Do');
         assert.equal(testMoment.year(), 2014,
-                'lenient ordinal parsing ' + i + ' year check');
+                'lenient day of month ordinal parsing ' + i + ' year check');
         assert.equal(testMoment.month(), 0,
-                'lenient ordinal parsing ' + i + ' month check');
+                'lenient day of month ordinal parsing ' + i + ' month check');
         assert.equal(testMoment.date(), i,
-                'lenient ordinal parsing ' + i + ' date check');
+                'lenient day of month ordinal parsing ' + i + ' date check');
     }
 });
 
-test('lenient ordinal parsing of number', function (assert) {
+test('lenient day of month ordinal parsing of number', function (assert) {
     var i, testMoment;
     for (i = 1; i <= 31; ++i) {
         testMoment = moment('2014 01 ' + i, 'YYYY MM Do');
         assert.equal(testMoment.year(), 2014,
-                'lenient ordinal parsing of number ' + i + ' year check');
+                'lenient day of month ordinal parsing of number ' + i + ' year check');
         assert.equal(testMoment.month(), 0,
-                'lenient ordinal parsing of number ' + i + ' month check');
+                'lenient day of month ordinal parsing of number ' + i + ' month check');
         assert.equal(testMoment.date(), i,
-                'lenient ordinal parsing of number ' + i + ' date check');
+                'lenient day of month ordinal parsing of number ' + i + ' date check');
     }
 });
 
-test('strict ordinal parsing', function (assert) {
+test('strict day of month ordinal parsing', function (assert) {
     var i, ordinalStr, testMoment;
     for (i = 1; i <= 31; ++i) {
         ordinalStr = moment([2014, 0, i]).format('YYYY MM Do');
         testMoment = moment(ordinalStr, 'YYYY MM Do', true);
-        assert.ok(testMoment.isValid(), 'strict ordinal parsing ' + i);
+        assert.ok(testMoment.isValid(), 'strict day of month ordinal parsing ' + i);
     }
 });

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -133,21 +133,21 @@ test('ordinal', function (assert) {
 
 test('ordinal parse', function (assert) {
     moment.defineLocale('base-ordinal-parse-1', {
-        ordinalParse : /\d{1,2}x/
+        dayOfMonthOrdinalParse : /\d{1,2}x/
     });
     moment.defineLocale('child-ordinal-parse-1', {
         parentLocale: 'base-ordinal-parse-1',
-        ordinalParse : /\d{1,2}y/
+        dayOfMonthOrdinalParse : /\d{1,2}y/
     });
 
     assert.ok(moment.utc('2015-01-1y', 'YYYY-MM-Do', true).isValid(), 'ordinal parse uses child');
 
     moment.defineLocale('base-ordinal-parse-2', {
-        ordinalParse : /\d{1,2}x/
+        dayOfMonthOrdinalParse : /\d{1,2}x/
     });
     moment.defineLocale('child-ordinal-parse-2', {
         parentLocale: 'base-ordinal-parse-2',
-        ordinalParse : /\d{1,2}/
+        dayOfMonthOrdinalParse : /\d{1,2}/
     });
 
     assert.ok(moment.utc('2015-01-1', 'YYYY-MM-Do', true).isValid(), 'ordinal parse uses child (default)');

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -134,20 +134,20 @@ test('ordinal', function (assert) {
 test('ordinal parse', function (assert) {
     moment.defineLocale('ordinal-parse-1', null);
     moment.defineLocale('ordinal-parse-1', {
-        ordinalParse : /\d{1,2}x/
+        dayOfMonthOrdinalParse : /\d{1,2}x/
     });
     moment.updateLocale('ordinal-parse-1', {
-        ordinalParse : /\d{1,2}y/
+        dayOfMonthOrdinalParse : /\d{1,2}y/
     });
 
     assert.ok(moment.utc('2015-01-1y', 'YYYY-MM-Do', true).isValid(), 'ordinal parse uses child');
 
     moment.defineLocale('ordinal-parse-2', null);
     moment.defineLocale('ordinal-parse-2', {
-        ordinalParse : /\d{1,2}x/
+        dayOfMonthOrdinalParse : /\d{1,2}x/
     });
     moment.updateLocale('ordinal-parse-2', {
-        ordinalParse : /\d{1,2}/
+        dayOfMonthOrdinalParse : /\d{1,2}/
     });
 
     assert.ok(moment.utc('2015-01-1', 'YYYY-MM-Do', true).isValid(), 'ordinal parse uses child (default)');


### PR DESCRIPTION
`ordinalParse` was poorly named, because, contrary to `ordinal` short which is responsible to display ordinals for many units, the former cares only about day of month parsing.

Ran `grunt`.