### PR TITLE
[misc] typescrpt: Fixes #3702, add week in duration input spec

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -348,6 +348,10 @@ declare namespace moment {
     quarters?: number;
     quarter?: number;
     Q?: number;
+
+    weeks?: number;
+    week?: number;
+    w?: number;
   }
 
   interface MomentSetObject extends MomentInputObject {

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -240,6 +240,15 @@ moment.duration({
     months: 2,
     years: 2
 });
+moment.duration({
+    s: 2,
+    m: 2,
+    h: 2,
+    d: 2,
+    w: 2,
+    M: 2,
+    y: 2,
+});
 moment.duration(1, "minutes").humanize();
 moment.duration(500).milliseconds();
 moment.duration(500).asMilliseconds();


### PR DESCRIPTION
Fixes #3702 

This bug was shadowed by a weird Typing bug:

When you initialize the moment.duration object, `DurationInputArg1` could be a `Duration` object. Since the `Duration` object has a `weeks` attribute (more precisely, a method), the type `weeks` is allowed within the constructor. This should not happen (i.e. Duration objects should only be allowed if they are full Duration objects).