### PR TITLE
[misc] Don't enumerate momentProperties with 'in'

### DIFF
--- a/src/lib/moment/constructor.js
+++ b/src/lib/moment/constructor.js
@@ -42,7 +42,7 @@ export function copyConfig(to, from) {
     }
 
     if (momentProperties.length > 0) {
-        for (i in momentProperties) {
+        for (i = 0; i < momentProperties.length; i++) {
             prop = momentProperties[i];
             val = from[prop];
             if (!isUndefined(val)) {


### PR DESCRIPTION
Because of the way many polyfill libraries modify Array.prototype (without Object.defineProperty), enumerating momentProperties with for...in is unsafe.

This is a near zero-cost change that makes this enumeration safe.