### PR TITLE
moment.d.ts: Exporting moment as default export

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -709,4 +709,4 @@ declare namespace moment {
   export var defaultFormatUtc: string;
 }
 
-export = moment;
+export default moment;


### PR DESCRIPTION
Default exporting moment as default export instead of export = moment in the typings file.
I don't know the implications for people using older typescript versions. But now as typescript 2.x has been stable for quite a while, I suppose this should be the way to do it.

(As requested in #2608, #3476, #3616)