### PR TITLE
[misc] Add coveralls testing to travis build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -171,6 +171,9 @@ module.exports = function (grunt) {
             },
             'typescript-test': {
                 command: 'npm run typescript-test'
+            },
+            'coveralls': {
+                command: 'npm run coveralls'
             }
         }
 
@@ -199,7 +202,7 @@ module.exports = function (grunt) {
     grunt.registerTask('test:meteor', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-cleanup']);
 
     // travis build task
-    grunt.registerTask('build:travis', ['default']);
+    grunt.registerTask('build:travis', ['default', 'exec:coveralls']);
     grunt.registerTask('meteor-publish', ['exec:meteor-init', 'exec:meteor-publish', 'exec:meteor-cleanup']);
 
     // Task to be run when releasing a new version

--- a/tasks/qtest.js
+++ b/tasks/qtest.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
         testrunner.options.log.tests = false;
         testrunner.options.log.summary = false;
         testrunner.options.log.testing = false;
-        testrunner.options.maxBlockDuration = 120000;
+        testrunner.options.maxBlockDuration = 600000;
 
         var tests;
 


### PR DESCRIPTION
I think this will just work. Check out my own Travis Builds and Coveralls here:
https://travis-ci.org/marwahaha/moment/builds
[![Coverage Status](https://coveralls.io/repos/github/marwahaha/moment/badge.svg?branch=add-coveralls)](https://coveralls.io/github/marwahaha/moment?branch=add-coveralls)

Builds are significantly longer (takes ~4 minutes instead of ~3), but the coverage is probably worth it. I sort of prefer long builds to flaky/less-useful builds. (This is why I decided to test twice --- once with `default` and once with coveralls)

this is moment develop's, but it might be out of date
[![Coverage Status](https://coveralls.io/repos/github/moment/moment/badge.svg?branch=develop)](https://coveralls.io/github/moment/moment?branch=develop)


fixes #2509
