### PR TITLE
[misc] Fix invalid whitespace character causing inability to parse moment.js

### DIFF
--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -18,7 +18,7 @@ export function set (config) {
     // number + (possibly) stuff coming from _dayOfMonthOrdinalParse.
     // TODO: Remove "ordinalParse" fallback in next major release.
     this._dayOfMonthOrdinalParseLenient = new RegExp(
-        (this._dayOfMonthOrdinalParse.source || this._ordinalParse.source) +
+        (this._dayOfMonthOrdinalParse.source || this._ordinalParse.source) +
             '|' + (/\d{1,2}/).source);
 }
 


### PR DESCRIPTION
Please see the attached screenshots from Chrome 56.0.2924.87. 

It appears there is an invalid whitespace character in the source code in `src/lib/locale/set.js`. I removed that character and added a standard space which appears to have fixed the problem. I still ran the tests and confirmed all passed. 

This can be reproduced by adding the following index.html file in the repo at the root of the project and loading it in chrome.

I should note that I put the whitespace replacement into the file referenced above, then ran `grunt release` and confirmed that it did indeed fix the issue.

```
# index.html
<html>
<head>
  <script src="moment.js"></script>
</head>
<body>
</body>
</html>
```

<img width="1440" alt="screen shot 2017-03-20 at 7 52 21 pm" src="https://cloud.githubusercontent.com/assets/1163038/24130593/cdcf228a-0da6-11e7-8fe7-8ea8f33af81d.png">

<img width="655" alt="screen shot 2017-03-20 at 7 52 41 pm" src="https://cloud.githubusercontent.com/assets/1163038/24130597/d103eb16-0da6-11e7-8b74-861eda436680.png">
