### PR TITLE
[locale] ru,uk: Improve relative seconds

### DIFF
--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -12,6 +12,7 @@ function plural(word, num) {
 }
 function relativeTimeWithPlural(number, withoutSuffix, key) {
     var format = {
+        'ss': withoutSuffix ? 'секунда_секунды_секунд' : 'секунду_секунды_секунд',
         'mm': withoutSuffix ? 'минута_минуты_минут' : 'минуту_минуты_минут',
         'hh': 'час_часа_часов',
         'dd': 'день_дня_дней',
@@ -124,6 +125,7 @@ export default moment.defineLocale('ru', {
         future : 'через %s',
         past : '%s назад',
         s : 'несколько секунд',
+        ss : relativeTimeWithPlural,
         m : relativeTimeWithPlural,
         mm : relativeTimeWithPlural,
         h : 'час',

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -11,6 +11,7 @@ function plural(word, num) {
 }
 function relativeTimeWithPlural(number, withoutSuffix, key) {
     var format = {
+        'ss': withoutSuffix ? 'секунда_секунди_секунд' : 'секунду_секунди_секунд',
         'mm': withoutSuffix ? 'хвилина_хвилини_хвилин' : 'хвилину_хвилини_хвилин',
         'hh': withoutSuffix ? 'година_години_годин' : 'годину_години_годин',
         'dd': 'день_дні_днів',
@@ -92,6 +93,7 @@ export default moment.defineLocale('uk', {
         future : 'за %s',
         past : '%s тому',
         s : 'декілька секунд',
+        ss : relativeTimeWithPlural,
         m : relativeTimeWithPlural,
         mm : relativeTimeWithPlural,
         h : 'годину',


### PR DESCRIPTION
There is no localization for relative seconds (actually looks like in all languages).
Consider the following example:
```javascript
moment.relativeTimeThreshold('ss', 0)

var t = moment(); t.subtract({seconds: -1}); t.toNow()
// "1 second назад"
var t = moment(); t.subtract({seconds: -2}); t.toNow()
// "2 seconds назад"
var t = moment(); t.subtract({seconds: -3}); t.toNow()
// "5 seconds назад"
```

with this patch (for "ru" and "uk" languages):
```javascript
var t = moment(); t.subtract({seconds: -1}); t.toNow()
// "1 секунду назад"
var t = moment(); t.subtract({seconds: -2}); t.toNow()
// "2 секунды назад"
var t = moment(); t.subtract({seconds: -3}); t.toNow()
// "5 секунд назад"
```

Also this may be used with future work for duration formats. Without plural seconds locales seems inconsistent anyway.