### PR TITLE
Boost performance by using predefined array

### DIFF
--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -68,7 +68,7 @@ addParseToken(['MMM', 'MMMM'], function (input, array, config, token) {
 // LOCALES
 
 var MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s)+MMMM?/;
-export var defaultLocaleMonths = 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_');
+export var defaultLocaleMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 export function localeMonths (m, format) {
     if (!m) {
         return isArray(this._months) ? this._months :
@@ -78,7 +78,7 @@ export function localeMonths (m, format) {
         this._months[(this._months.isFormat || MONTHS_IN_FORMAT).test(format) ? 'format' : 'standalone'][m.month()];
 }
 
-export var defaultLocaleMonthsShort = 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_');
+export var defaultLocaleMonthsShort = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 export function localeMonthsShort (m, format) {
     if (!m) {
         return isArray(this._monthsShort) ? this._monthsShort :


### PR DESCRIPTION


## Issue
JSPerf shows that using `.split` to create the month array is **96%** slower than using a predefined array of months.

[https://jsperf.com/split-versus-array-for-month-names](https://jsperf.com/split-versus-array-for-month-names)

![screen shot 2017-03-26 at 22 24 16](https://cloud.githubusercontent.com/assets/7824734/24335372/84f10458-1273-11e7-8be4-d8584e301051.png)

## Solution

Use predefined month array.