### PR TITLE
Fix localeData.months call throwing exception on Greek

### DIFF
--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -11,7 +11,7 @@ export default moment.defineLocale('el', {
     months : function (momentToFormat, format) {
         if (!momentToFormat) {
             return this._monthsNominativeEl;
-        } else if (/D/.test(format.substring(0, format.indexOf('MMMM')))) { // if there is a day number before 'MMMM'
+        } else if (typeof format === 'string' && /D/.test(format.substring(0, format.indexOf('MMMM')))) { // if there is a day number before 'MMMM'
             return this._monthsGenitiveEl[momentToFormat.month()];
         } else {
             return this._monthsNominativeEl[momentToFormat.month()];

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -137,6 +137,7 @@ test('library localeData', function (assert) {
     assert.equal(moment.localeData().months(jan), 'January', 'no arguments returns global');
     assert.equal(moment.localeData('zh-cn').months(jan), '一月', 'a string returns the locale based on key');
     assert.equal(moment.localeData(moment().locale('es')).months(jan), 'enero', 'if you pass in a moment it uses the moment\'s locale');
+    assert.equal(moment.localeData(moment().locale('el')).months(jan), 'Ιανουάριος', 'should return the localized month name like other languages');
 });
 
 test('library deprecations', function (assert) {


### PR DESCRIPTION
Bug when calling `months` from locale data on Greek:

```js
moment.locale('el');
moment.localeData.months(moment());
Uncaught TypeError: Cannot read property 'substring' of undefined
    at Locale.months (global.js:6522)
    at <anonymous>:1:21
```

Original author @mehiel 