### PR TITLE
Fix localeData months call on Greek

### DIFF
--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -11,7 +11,7 @@ export default moment.defineLocale('el', {
     months : function (momentToFormat, format) {
         if (!momentToFormat) {
             return this._monthsNominativeEl;
-        } else if (/D/.test(format.substring(0, format.indexOf('MMMM')))) { // if there is a day number before 'MMMM'
+        } else if (typeof format === 'string' && /D/.test(format.substring(0, format.indexOf('MMMM')))) { // if there is a day number before 'MMMM'
             return this._monthsGenitiveEl[momentToFormat.month()];
         } else {
             return this._monthsNominativeEl[momentToFormat.month()];

--- a/src/test/locale/el.js
+++ b/src/test/locale/el.js
@@ -258,3 +258,8 @@ test('weeks year starting sunday format', function (assert) {
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2η', 'Jan 15 2012 should be week 2');
 });
 
+test('localeData months calls', function (assert) {
+    var jan = moment('2012-01-01');
+    assert.equal(moment.localeData().months(jan),           'Ιανουάριος', 'should return the nominative month name');
+    assert.equal(moment.localeData().months(jan, 'D MMMM'), 'Ιανουαρίου', 'should return the genitive month name');
+});


### PR DESCRIPTION
Bug when calling months from locale data on Greek:
```js
moment.locale('el');
moment.localeData().months(moment());
Uncaught TypeError: Cannot read property 'substring' of undefined
    at Locale.months (global.js:6522)
    at <anonymous>:1:21
```
Original author @mehiel