### PR TITLE
[bugfix] Remove RTL scraping from preparse, fixes #3487

### DIFF
--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -98,7 +98,7 @@ export default moment.defineLocale('ar-ly', {
         yy : pluralize('y')
     },
     preparse: function (string) {
-        return string.replace(/\u200f/g, '').replace(/،/g, ',');
+        return string.replace(/،/g, ',');
     },
     postformat: function (string) {
         return string.replace(/\d/g, function (match) {

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -111,7 +111,7 @@ export default moment.defineLocale('ar', {
         yy : pluralize('y')
     },
     preparse: function (string) {
-        return string.replace(/\u200f/g, '').replace(/[١٢٣٤٥٦٧٨٩٠]/g, function (match) {
+        return string.replace(/[١٢٣٤٥٦٧٨٩٠]/g, function (match) {
             return numberMap[match];
         }).replace(/،/g, ',');
     },
@@ -125,4 +125,3 @@ export default moment.defineLocale('ar', {
         doy : 12  // The week that contains Jan 1st is the first week of the year.
     }
 });
-

--- a/src/test/locale/ar-ly.js
+++ b/src/test/locale/ar-ly.js
@@ -240,3 +240,11 @@ test('no leading zeros in long date formats', function (assert) {
         }
     }
 });
+
+// locale-specific
+test('ar-ly strict mode parsing works', function (assert) {
+    const m = moment().locale('ar-ly');
+    const formattedDate = m.format('l');
+    assert.equal(moment.utc(formattedDate, 'l', 'ar-ly', false).isValid(), true, 'Non-strict parsing works');
+    assert.equal(moment.utc(formattedDate, 'l', 'ar-ly', true).isValid(), true,'Strict parsing must work');
+});

--- a/src/test/locale/ar-ly.js
+++ b/src/test/locale/ar-ly.js
@@ -243,8 +243,9 @@ test('no leading zeros in long date formats', function (assert) {
 
 // locale-specific
 test('ar-ly strict mode parsing works', function (assert) {
-    const m = moment().locale('ar-ly');
-    const formattedDate = m.format('l');
+    var m, formattedDate;
+    m = moment().locale('ar-ly');
+    formattedDate = m.format('l');
     assert.equal(moment.utc(formattedDate, 'l', 'ar-ly', false).isValid(), true, 'Non-strict parsing works');
     assert.equal(moment.utc(formattedDate, 'l', 'ar-ly', true).isValid(), true,'Strict parsing must work');
 });

--- a/src/test/locale/ar.js
+++ b/src/test/locale/ar.js
@@ -240,3 +240,11 @@ test('no leading zeros in long date formats', function (assert) {
         }
     }
 });
+
+// locale-specific
+test('ar strict mode parsing works', function (assert) {
+    const m = moment().locale('ar');
+    const formattedDate = m.format('l');
+    assert.equal(moment.utc(formattedDate, 'l', 'ar', false).isValid(), true, 'Non-strict parsing works');
+    assert.equal(moment.utc(formattedDate, 'l', 'ar', true).isValid(), true,'Strict parsing must work');
+});

--- a/src/test/locale/ar.js
+++ b/src/test/locale/ar.js
@@ -243,8 +243,9 @@ test('no leading zeros in long date formats', function (assert) {
 
 // locale-specific
 test('ar strict mode parsing works', function (assert) {
-    const m = moment().locale('ar');
-    const formattedDate = m.format('l');
+    var m, formattedDate;
+    m = moment().locale('ar');
+    formattedDate = m.format('l');
     assert.equal(moment.utc(formattedDate, 'l', 'ar', false).isValid(), true, 'Non-strict parsing works');
     assert.equal(moment.utc(formattedDate, 'l', 'ar', true).isValid(), true,'Strict parsing must work');
 });


### PR DESCRIPTION
fixes #3487 

The preparse line was introduced here
https://github.com/moment/moment/pull/2268/files

But since the tests implemented in #2268 still pass, I think it's safe to remove the line. I don't know of other implications...