### PR TITLE
[misc] TS: add export moment as namespace to enable consumption outside ES6

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -710,3 +710,4 @@ declare namespace moment {
 }
 
 export = moment;
+export as namespace moment;


### PR DESCRIPTION
### Fix:
[x] add export as namespace moment; into moment.d.ts to allow for consuming the moment declarations without ES6 modules
