### PR TITLE
[bugfix] Make Z and ZZ tokens output Z instead of +00:00, fixes #3117

### DIFF
--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -18,6 +18,9 @@ import { hooks } from '../utils/hooks';
 
 function offset (token, separator) {
     addFormatToken(token, 0, 0, function () {
+        if (this.isUtc()) {
+            return 'Z';
+        }
         var offset = this.utcOffset();
         var sign = '+';
         if (offset < 0) {

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -790,9 +790,9 @@ test('parsing iso with T', function (assert) {
 test('parsing iso Z timezone', function (assert) {
     var i,
     formats = [
-        ['2011-10-08T18:04Z',             '2011-10-08T18:04:00.000+00:00'],
-        ['2011-10-08T18:04:20Z',          '2011-10-08T18:04:20.000+00:00'],
-        ['2011-10-08T18:04:20.111Z',      '2011-10-08T18:04:20.111+00:00']
+        ['2011-10-08T18:04Z',             '2011-10-08T18:04:00.000Z'],
+        ['2011-10-08T18:04:20Z',          '2011-10-08T18:04:20.000Z'],
+        ['2011-10-08T18:04:20.111Z',      '2011-10-08T18:04:20.111Z']
     ];
     for (i = 0; i < formats.length; i++) {
         assert.equal(moment.utc(formats[i][0]).format('YYYY-MM-DDTHH:mm:ss.SSSZ'), formats[i][1], 'moment should be able to parse ISO ' + formats[i][0]);

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -176,15 +176,15 @@ test('inspect', function (assert) {
     );
     testInspect(
         moment.utc('2012-10-09T20:30:40.678'),
-        'moment.utc("2012-10-09T20:30:40.678+00:00")'
+        'moment.utc("2012-10-09T20:30:40.678Z")'
     );
     testInspect(
         moment.utc('+020123-10-09T20:30:40.678'),
-        'moment.utc("+020123-10-09T20:30:40.678+00:00")'
+        'moment.utc("+020123-10-09T20:30:40.678Z")'
     );
     testInspect(
         moment.utc('+020123-10-09T20:30:40.678+01:00'),
-        'moment.utc("+020123-10-09T19:30:40.678+00:00")'
+        'moment.utc("+020123-10-09T19:30:40.678Z")'
     );
     testInspect(
         moment.parseZone('2016-06-11T17:30:40.678+0430'),

--- a/src/test/moment/utc_offset.js
+++ b/src/test/moment/utc_offset.js
@@ -133,7 +133,7 @@ test('update offset after changing any values', function (assert) {
         }
     };
 
-    assert.equal(m.format('ZZ'), '+0000', 'should be at +0000');
+    assert.equal(m.format('ZZ'), 'Z', 'should be at Z');
     assert.equal(m.format('HH:mm'), '00:00', 'should start 12AM at +0000 timezone');
 
     m.__doChange = true;

--- a/src/test/moment/zones.js
+++ b/src/test/moment/zones.js
@@ -124,7 +124,7 @@ test('update offset after changing any values', function (assert) {
         }
     };
 
-    assert.equal(m.format('ZZ'), '+0000', 'should be at +0000');
+    assert.equal(m.format('ZZ'), 'Z', 'should be at Z');
     assert.equal(m.format('HH:mm'), '00:00', 'should start 12AM at +0000 timezone');
 
     m.__doChange = true;
@@ -454,6 +454,9 @@ test('timezone format', function (assert) {
     assert.equal(moment().zone(-90).format('ZZ'), '+0130', '-90 -> +0130');
     assert.equal(moment().zone(-120).format('ZZ'), '+0200', '-120 -> +0200');
 
+    assert.equal(moment().zone(0).format('Z'), 'Z', 'Z token in UTC should return Z');
+    assert.equal(moment().zone(0).format('ZZ'), 'Z', 'ZZ token in UTC should return Z');
+
     assert.equal(moment().zone(+60).format('ZZ'), '-0100', '+60 -> -0100');
     assert.equal(moment().zone(+90).format('ZZ'), '-0130', '+90 -> -0130');
     assert.equal(moment().zone(+120).format('ZZ'), '-0200', '+120 -> -0200');
@@ -467,22 +470,22 @@ test('parse zone without a timezone', function (assert) {
     var m4 = moment.parseZone('2016-02-01T00:00:00+0000'); //Someone might argue this is not necessary, you could even argue that is wrong being here.
     assert.equal(
         m1.format('M D YYYY HH:mm:ss ZZ'),
-        '2 1 2016 00:00:00 +0000',
+        '2 1 2016 00:00:00 Z',
         'Not providing a timezone should keep the time and change the zone to 0'
     );
     assert.equal(
         m2.format('M D YYYY HH:mm:ss ZZ'),
-        '2 1 2016 00:00:00 +0000',
+        '2 1 2016 00:00:00 Z',
         'Not providing a timezone should keep the time and change the zone to 0'
     );
     assert.equal(
         m3.format('M D YYYY HH:mm:ss ZZ'),
-        '2 1 2016 00:00:00 +0000',
+        '2 1 2016 00:00:00 Z',
         'Not providing a timezone should keep the time and change the zone to 0'
     );
     assert.equal(
         m4.format('M D YYYY HH:mm:ss ZZ'),
-        '2 1 2016 00:00:00 +0000',
+        '2 1 2016 00:00:00 Z',
         'Not providing a timezone should keep the time and change the zone to 0'
     );
 });


### PR DESCRIPTION
fixes #3117 

Will need a docs update.

It's non-obvious if this is the right thing, since I don't know if people use `ZZ` to check timezones (it's only numbers before this..). Introducing a new token seems odd, though.

Not sure if breaking, since I did update tests. I guess this is changing behavior...

@maggiepint 