### PR TITLE
[misc] perf: Use Object.keys for empty object check

### DIFF
--- a/benchmarks/isObjectEmpty.js
+++ b/benchmarks/isObjectEmpty.js
@@ -1,0 +1,67 @@
+var Benchmark = require('benchmark'),
+    moment = require("./../moment.js");
+
+var isObjectEmpty_getOwnPropertyNames = function(obj) {
+    if (Object.getOwnPropertyNames) {
+        return (Object.getOwnPropertyNames(obj).length === 0);
+    } else {
+        var k;
+        for (k in obj) {
+            if (obj.hasOwnProperty(k)) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+var isObjectEmpty_keys = function(obj) {
+    if (Object.keys) {
+        return (Object.keys(obj).length === 0);
+    } else {
+        var k;
+        for (k in obj) {
+            if (obj.hasOwnProperty(k)) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+var isObjectEmpty_forIn = function(obj) {
+    var k;
+    for (k in obj) {
+        if (obj.hasOwnProperty(k)) {
+            return false;
+        }
+    }
+    return true;
+};
+    
+module.exports = {
+    name: 'isObjectEmpty',
+    tests: {
+        "isObjectEmpty -> for..in": {
+            onComplete: function(){},
+            fn: function(){        
+                isObjectEmpty_forIn(moment());
+            },
+            async: false
+        },
+        "isObjectEmpty -> Object.keys": {
+            onComplete: function(){},
+            fn: function(){        
+                isObjectEmpty_keys(moment());
+            },
+            async: false
+        },
+        "isObjectEmpty -> Object.getOwnPropertyNames": {
+            onComplete: function(){},
+            fn: function(){        
+                isObjectEmpty_getOwnPropertyNames(moment());
+            },
+            async: false
+        }    
+    }
+};

--- a/src/lib/utils/is-object-empty.js
+++ b/src/lib/utils/is-object-empty.js
@@ -1,8 +1,12 @@
 export default function isObjectEmpty(obj) {
-    var k;
-    for (k in obj) {
-        // even if its not own property I'd still call it non-empty
-        return false;
+    if (Object.keys) {
+        return (Object.keys(obj).length === 0);
+    } else {
+        var k;
+        for (k in obj) {
+            // even if its not own property I'd still call it non-empty
+            return false;
+        }
+        return true;
     }
-    return true;
 }

--- a/src/lib/utils/is-object-empty.js
+++ b/src/lib/utils/is-object-empty.js
@@ -1,11 +1,12 @@
 export default function isObjectEmpty(obj) {
-    if (Object.keys) {
-        return (Object.keys(obj).length === 0);
+    if (Object.getOwnPropertyNames) {
+        return (Object.getOwnPropertyNames(obj).length === 0);
     } else {
         var k;
         for (k in obj) {
-            // even if its not own property I'd still call it non-empty
-            return false;
+            if (obj.hasOwnProperty(k)) {
+                return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
When using moment together with ChartJS, I found out that there is performance issue with `isObjectEmpty ` when rendering large datasets. This function takes around 30% of total time required to render the chart. 

When using `Object.keys`, it only takes ~2% of total time using Chrome 57. 

![screenshot 434](https://cloud.githubusercontent.com/assets/25081285/24832686/6ca33f82-1cb5-11e7-9b15-532000621e87.png)

![screenshot 431](https://cloud.githubusercontent.com/assets/25081285/24832688/74c23538-1cb5-11e7-8c8c-897f08e2eb94.png)

