### PR TITLE
Correct ES6 export

### DIFF
--- a/moment.es6.js
+++ b/moment.es6.js
@@ -52,6 +52,6 @@ export {
     getSetRelativeTimeThreshold as relativeTimeThreshold
 } from './src/lib/duration/duration';
 
-import { normalizeUnits } from './src/lib/units/units';
+export { normalizeUnits } from './src/lib/units/units';
 
 export isDate from './src/lib/utils/is-date';

--- a/moment.es6.js
+++ b/moment.es6.js
@@ -1,0 +1,57 @@
+//! moment.js
+//! version : 2.18.1
+//! authors : Tim Wood, Iskren Chernev, Moment.js contributors
+//! license : MIT
+//! momentjs.com
+
+import { setHookCallback } from './src/lib/utils/hooks';
+import { createLocal as local, momentPrototype as fn } from './src/lib/moment/moment';
+
+import { hooks as moment } from './src/lib/utils/hooks';
+
+moment.prototype = fn;
+moment.version = '2.18.1';
+setHookCallback(local);
+
+export default moment;
+
+export {
+    min,
+    max,
+    now,
+    isMoment,
+    momentPrototype as fn,
+    createUTC       as utc,
+    createUnix      as unix,
+    createLocal     as local,
+    createInvalid   as invalid,
+    createInZone    as parseZone
+} from './src/lib/moment/moment';
+
+export {
+    getCalendarFormat as calendarFormat
+} from './src/lib/moment/calendar';
+
+export {
+    defineLocale,
+    updateLocale,
+    getSetGlobalLocale as locale,
+    getLocale          as localeData,
+    listLocales        as locales,
+    listMonths         as months,
+    listMonthsShort    as monthsShort,
+    listWeekdays       as weekdays,
+    listWeekdaysMin    as weekdaysMin,
+    listWeekdaysShort  as weekdaysShort
+} from './src/lib/locale/locale';
+
+export {
+    isDuration,
+    createDuration as duration,
+    getSetRelativeTimeRounding as relativeTimeRounding,
+    getSetRelativeTimeThreshold as relativeTimeThreshold
+} from './src/lib/duration/duration';
+
+import { normalizeUnits } from './src/lib/units/units';
+
+export isDate from './src/lib/utils/is-date';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "ender"
     ],
     "main": "./moment.js",
-    "jsnext:main": "./src/moment.js",
+    "module": "./moment.es6.js",
+    "jsnext:main": "./moment.es6.js",
     "typings": "./moment.d.ts",
     "engines": {
         "node": "*"


### PR DESCRIPTION
Currently Moment.js ES6 export is not really an ES6 export, it's just an older ES5 export rewritten with `import`s and `export`s.
The goal of ES6 is not using different words but rather exporting different parts of the package independently.
This PR shows the right way of doing an ES6 export for a package.
It is meant as an illustration which can be merged if the moment internals allow that.
Otherwise it's 180 KiloBytes which is unacceptable and will eventually have to go.