### PR TITLE
[misc] jslint: Refactor to avoid unreachable 'break' after 'return'

### DIFF
--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -65,8 +65,8 @@ function translate(number, withoutSuffix, key, isFuture) {
                 result = result + 'lety';
             }
             break;
-    return result;
     }
+    return result;
 }
 
 export default moment.defineLocale('cs', {

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -22,7 +22,6 @@ function translate(number, withoutSuffix, key, isFuture) {
             } else {
                 return result + 'minutami';
             }
-            break;
         case 'h':  // an hour / in an hour / an hour ago
             return withoutSuffix ? 'hodina' : (isFuture ? 'hodinu' : 'hodinou');
         case 'hh': // 9 hours / in 9 hours / 9 hours ago
@@ -31,7 +30,6 @@ function translate(number, withoutSuffix, key, isFuture) {
             } else {
                 return result + 'hodinami';
             }
-            break;
         case 'd':  // a day / in a day / a day ago
             return (withoutSuffix || isFuture) ? 'den' : 'dnem';
         case 'dd': // 9 days / in 9 days / 9 days ago
@@ -40,7 +38,6 @@ function translate(number, withoutSuffix, key, isFuture) {
             } else {
                 return result + 'dny';
             }
-            break;
         case 'M':  // a month / in a month / a month ago
             return (withoutSuffix || isFuture) ? 'měsíc' : 'měsícem';
         case 'MM': // 9 months / in 9 months / 9 months ago
@@ -49,7 +46,6 @@ function translate(number, withoutSuffix, key, isFuture) {
             } else {
                 return result + 'měsíci';
             }
-            break;
         case 'y':  // a year / in a year / a year ago
             return (withoutSuffix || isFuture) ? 'rok' : 'rokem';
         case 'yy': // 9 years / in 9 years / 9 years ago
@@ -58,7 +54,6 @@ function translate(number, withoutSuffix, key, isFuture) {
             } else {
                 return result + 'lety';
             }
-            break;
     }
 }
 

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -14,8 +14,10 @@ function translate(number, withoutSuffix, key, isFuture) {
     switch (key) {
         case 's':  // a few seconds / in a few seconds / a few seconds ago
             result = (withoutSuffix || isFuture) ? 'pár sekund' : 'pár sekundami';
+            break;
         case 'm':  // a minute / in a minute / a minute ago
             result = withoutSuffix ? 'minuta' : (isFuture ? 'minutu' : 'minutou');
+            break;
         case 'mm': // 9 minutes / in 9 minutes / 9 minutes ago
             if (withoutSuffix || isFuture) {
                 result = result + (plural(number) ? 'minuty' : 'minut');
@@ -25,6 +27,7 @@ function translate(number, withoutSuffix, key, isFuture) {
             break;
         case 'h':  // an hour / in an hour / an hour ago
             result = withoutSuffix ? 'hodina' : (isFuture ? 'hodinu' : 'hodinou');
+            break;
         case 'hh': // 9 hours / in 9 hours / 9 hours ago
             if (withoutSuffix || isFuture) {
                 result = result + (plural(number) ? 'hodiny' : 'hodin');
@@ -34,6 +37,7 @@ function translate(number, withoutSuffix, key, isFuture) {
             break;
         case 'd':  // a day / in a day / a day ago
             result = (withoutSuffix || isFuture) ? 'den' : 'dnem';
+            break;
         case 'dd': // 9 days / in 9 days / 9 days ago
             if (withoutSuffix || isFuture) {
                 result = result + (plural(number) ? 'dny' : 'dní');
@@ -43,6 +47,7 @@ function translate(number, withoutSuffix, key, isFuture) {
             break;
         case 'M':  // a month / in a month / a month ago
             result = (withoutSuffix || isFuture) ? 'měsíc' : 'měsícem';
+            break;
         case 'MM': // 9 months / in 9 months / 9 months ago
             if (withoutSuffix || isFuture) {
                 result = result + (plural(number) ? 'měsíce' : 'měsíců');
@@ -52,12 +57,14 @@ function translate(number, withoutSuffix, key, isFuture) {
             break;
         case 'y':  // a year / in a year / a year ago
             result = (withoutSuffix || isFuture) ? 'rok' : 'rokem';
+            break;
         case 'yy': // 9 years / in 9 years / 9 years ago
             if (withoutSuffix || isFuture) {
                 result = result + (plural(number) ? 'roky' : 'let');
             } else {
                 result = result + 'lety';
             }
+            break;
     return result;
     }
 }

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -13,47 +13,52 @@ function translate(number, withoutSuffix, key, isFuture) {
     var result = number + ' ';
     switch (key) {
         case 's':  // a few seconds / in a few seconds / a few seconds ago
-            return (withoutSuffix || isFuture) ? 'pár sekund' : 'pár sekundami';
+            result = (withoutSuffix || isFuture) ? 'pár sekund' : 'pár sekundami';
         case 'm':  // a minute / in a minute / a minute ago
-            return withoutSuffix ? 'minuta' : (isFuture ? 'minutu' : 'minutou');
+            result = withoutSuffix ? 'minuta' : (isFuture ? 'minutu' : 'minutou');
         case 'mm': // 9 minutes / in 9 minutes / 9 minutes ago
             if (withoutSuffix || isFuture) {
-                return result + (plural(number) ? 'minuty' : 'minut');
+                result = result + (plural(number) ? 'minuty' : 'minut');
             } else {
-                return result + 'minutami';
+                result = result + 'minutami';
             }
+            break;
         case 'h':  // an hour / in an hour / an hour ago
-            return withoutSuffix ? 'hodina' : (isFuture ? 'hodinu' : 'hodinou');
+            result = withoutSuffix ? 'hodina' : (isFuture ? 'hodinu' : 'hodinou');
         case 'hh': // 9 hours / in 9 hours / 9 hours ago
             if (withoutSuffix || isFuture) {
-                return result + (plural(number) ? 'hodiny' : 'hodin');
+                result = result + (plural(number) ? 'hodiny' : 'hodin');
             } else {
-                return result + 'hodinami';
+                result = result + 'hodinami';
             }
+            break;
         case 'd':  // a day / in a day / a day ago
-            return (withoutSuffix || isFuture) ? 'den' : 'dnem';
+            result = (withoutSuffix || isFuture) ? 'den' : 'dnem';
         case 'dd': // 9 days / in 9 days / 9 days ago
             if (withoutSuffix || isFuture) {
-                return result + (plural(number) ? 'dny' : 'dní');
+                result = result + (plural(number) ? 'dny' : 'dní');
             } else {
-                return result + 'dny';
+                result = result + 'dny';
             }
+            break;
         case 'M':  // a month / in a month / a month ago
-            return (withoutSuffix || isFuture) ? 'měsíc' : 'měsícem';
+            result = (withoutSuffix || isFuture) ? 'měsíc' : 'měsícem';
         case 'MM': // 9 months / in 9 months / 9 months ago
             if (withoutSuffix || isFuture) {
-                return result + (plural(number) ? 'měsíce' : 'měsíců');
+                result = result + (plural(number) ? 'měsíce' : 'měsíců');
             } else {
-                return result + 'měsíci';
+                result = result + 'měsíci';
             }
+            break;
         case 'y':  // a year / in a year / a year ago
-            return (withoutSuffix || isFuture) ? 'rok' : 'rokem';
+            result = (withoutSuffix || isFuture) ? 'rok' : 'rokem';
         case 'yy': // 9 years / in 9 years / 9 years ago
             if (withoutSuffix || isFuture) {
-                return result + (plural(number) ? 'roky' : 'let');
+                result = result + (plural(number) ? 'roky' : 'let');
             } else {
-                return result + 'lety';
+                result = result + 'lety';
             }
+    return result;
     }
 }
 


### PR DESCRIPTION
Break in switch causes "Unreachable 'break' after 'return'." warning with JSLint