### PR TITLE
[locale] es-do: Update month parsing to be dot lenient, fixes #3629

### DIFF
--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -1,29 +1,29 @@
-import { normalizeUnits } from '../units/aliases';
+import {normalizeUnits} from '../units/aliases';
 
-export function startOf (units) {
+export function startOf(units) {
     units = normalizeUnits(units);
     // the following switch intentionally omits break keywords
     // to utilize falling through the cases.
     switch (units) {
         case 'year':
             this.month(0);
-            /* falls through */
+        /* falls through */
         case 'quarter':
         case 'month':
             this.date(1);
-            /* falls through */
+        /* falls through */
         case 'week':
         case 'isoWeek':
         case 'day':
         case 'date':
             this.hours(0);
-            /* falls through */
+        /* falls through */
         case 'hour':
             this.minutes(0);
-            /* falls through */
+        /* falls through */
         case 'minute':
             this.seconds(0);
-            /* falls through */
+        /* falls through */
         case 'second':
             this.milliseconds(0);
     }
@@ -44,7 +44,7 @@ export function startOf (units) {
     return this;
 }
 
-export function endOf (units) {
+export function endOf(units) {
     units = normalizeUnits(units);
     if (units === undefined || units === 'millisecond') {
         return this;
@@ -55,5 +55,15 @@ export function endOf (units) {
         units = 'day';
     }
 
-    return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
+    switch (units) {
+        case 'day':
+            var endOfDay = this.startOf(units).add(1, units).subtract(1, 'ms');
+            endOfDay.hours(23);
+            endOfDay.minutes(59);
+            endOfDay.seconds(59);
+            endOfDay.milliseconds(999);
+            return endOfDay;
+        default:
+         return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
+    }
 }

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -1,29 +1,29 @@
-import {normalizeUnits} from '../units/aliases';
+import { normalizeUnits } from '../units/aliases';
 
-export function startOf(units) {
+export function startOf (units) {
     units = normalizeUnits(units);
     // the following switch intentionally omits break keywords
     // to utilize falling through the cases.
     switch (units) {
         case 'year':
             this.month(0);
-        /* falls through */
+            /* falls through */
         case 'quarter':
         case 'month':
             this.date(1);
-        /* falls through */
+            /* falls through */
         case 'week':
         case 'isoWeek':
         case 'day':
         case 'date':
             this.hours(0);
-        /* falls through */
+            /* falls through */
         case 'hour':
             this.minutes(0);
-        /* falls through */
+            /* falls through */
         case 'minute':
             this.seconds(0);
-        /* falls through */
+            /* falls through */
         case 'second':
             this.milliseconds(0);
     }
@@ -44,7 +44,7 @@ export function startOf(units) {
     return this;
 }
 
-export function endOf(units) {
+export function endOf (units) {
     units = normalizeUnits(units);
     if (units === undefined || units === 'millisecond') {
         return this;
@@ -55,15 +55,5 @@ export function endOf(units) {
         units = 'day';
     }
 
-    switch (units) {
-        case 'day':
-            var endOfDay = this.startOf(units).add(1, units).subtract(1, 'ms');
-            endOfDay.hours(23);
-            endOfDay.minutes(59);
-            endOfDay.seconds(59);
-            endOfDay.milliseconds(999);
-            return endOfDay;
-        default:
-         return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
-    }
+    return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
 }

--- a/src/locale/es-do.js
+++ b/src/locale/es-do.js
@@ -6,6 +6,9 @@ import moment from '../moment';
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
     monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');
 
+var monthsParse = [/^ene/i, /^feb/i, /^mar/i, /^abr/i, /^may/i, /^jun/i, /^jul/i, /^ago/i, /^sep/i, /^oct/i, /^nov/i, /^dic/i];
+var monthsRegex = /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene\.?|feb\.?|mar\.?|abr\.?|may\.?|jun\.?|jul\.?|ago\.?|sep\.?|oct\.?|nov\.?|dic\.?)/i;
+
 export default moment.defineLocale('es-do', {
     months : 'enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre'.split('_'),
     monthsShort : function (m, format) {
@@ -17,7 +20,13 @@ export default moment.defineLocale('es-do', {
             return monthsShortDot[m.month()];
         }
     },
-    monthsParseExact : true,
+    monthsRegex: monthsRegex,
+    monthsShortRegex: monthsRegex,
+    monthsStrictRegex: /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)/i,
+    monthsShortStrictRegex: /^(ene\.?|feb\.?|mar\.?|abr\.?|may\.?|jun\.?|jul\.?|ago\.?|sep\.?|oct\.?|nov\.?|dic\.?)/i,
+    monthsParse: monthsParse,
+    longMonthsParse: monthsParse,
+    shortMonthsParse: monthsParse,
     weekdays : 'domingo_lunes_martes_miércoles_jueves_viernes_sábado'.split('_'),
     weekdaysShort : 'dom._lun._mar._mié._jue._vie._sáb.'.split('_'),
     weekdaysMin : 'do_lu_ma_mi_ju_vi_sá'.split('_'),

--- a/src/test/locale/es-do.js
+++ b/src/test/locale/es-do.js
@@ -212,7 +212,7 @@ test('weeks year starting sunday formatted', function (assert) {
 });
 
 test('test short months proper', function (assert) {
-    var str = "02-ago-2016"; // "02-ago-2016"
+    var str = '02-ago-2016'; // "02-ago-2016"
     assert.equal(moment(str, 'DD-MMM-YYYY').month(), '7', '02-ago-2016 month should be 7');
 });
 

--- a/src/test/locale/es-do.js
+++ b/src/test/locale/es-do.js
@@ -212,7 +212,7 @@ test('weeks year starting sunday formatted', function (assert) {
 });
 
 test('test short months proper', function (assert) {
-    var str = moment(new Date(2016, 7, 2)).format('DD-MMM-YYYY'); // "02-ago-2016"
+    var str = "02-ago-2016"; // "02-ago-2016"
     assert.equal(moment(str, 'DD-MMM-YYYY').month(), '7', '02-ago-2016 month should be 7');
 });
 

--- a/src/test/locale/es-do.js
+++ b/src/test/locale/es-do.js
@@ -211,3 +211,9 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2º', 'Jan 15 2012 should be week 2');
 });
 
+test('test short months proper', function (assert) {
+    var str = moment(new Date(2016, 7, 2)).format('DD-MMM-YYYY'); // "02-ago-2016"
+    assert.equal(moment(str, 'DD-MMM-YYYY').month(), '7', '02-ago-2016 month should be 7');
+});
+
+


### PR DESCRIPTION
The es and es-do locales had the same issue with date parsing of format D-MMM-YYYY . Both locales had code to test for /-MMM-/, so i added the fix for es, to es-do as well. Also added the appropriate test