### PR TITLE
Adapt [ca] locale to Unicode CLDR data

### DIFF
--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -14,17 +14,18 @@ export default moment.defineLocale('ca', {
     monthsParseExact : true,
     weekdays : 'diumenge_dilluns_dimarts_dimecres_dijous_divendres_dissabte'.split('_'),
     weekdaysShort : 'dg._dl._dt._dc._dj._dv._ds.'.split('_'),
-    weekdaysMin : 'Dg_Dl_Dt_Dc_Dj_Dv_Ds'.split('_'),
+    weekdaysMin : 'dg_dl_dt_dc_dj_dv_ds'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
         L : 'DD/MM/YYYY',
-        LL : '[el] D MMMM [de] YYYY',
+        l : 'D/M/YYYY',
+        LL : 'D MMMM [de] YYYY',
         ll : 'D MMM YYYY',
-        LLL : '[el] D MMMM [de] YYYY [a les] H:mm',
+        LLL : 'D MMMM [de] YYYY [a les] H:mm',
         lll : 'D MMM YYYY, H:mm',
-        LLLL : '[el] dddd D MMMM [de] YYYY [a les] H:mm',
+        LLLL : 'dddd D MMMM [de] YYYY [a les] H:mm',
         llll : 'ddd D MMM YYYY, H:mm'
     },
     calendar : {


### PR DESCRIPTION
http://cldr.unicode.org/index/downloads

Standard date and time formats (full, long, medium, short) for gregorian calendar for "ca" locale don't use "el" prefix. 
Also, I lowercased weekdaysMin: day names (short or not) in Catalan are always lowercase.

It looks weird when formating standalone dates. Moment library doesn't know the context, and so this article can be "el", "al", "a", ... or many other words.
Imho moment should print standalone dates, unless it fully adapts to ICU standards.

Original author @juanghurtado 