### PR TITLE
[locale] ca: Adapt to Unicode CLDR data

### DIFF
--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -14,17 +14,17 @@ export default moment.defineLocale('ca', {
     monthsParseExact : true,
     weekdays : 'diumenge_dilluns_dimarts_dimecres_dijous_divendres_dissabte'.split('_'),
     weekdaysShort : 'dg._dl._dt._dc._dj._dv._ds.'.split('_'),
-    weekdaysMin : 'Dg_Dl_Dt_Dc_Dj_Dv_Ds'.split('_'),
+    weekdaysMin : 'dg_dl_dt_dc_dj_dv_ds'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
         L : 'DD/MM/YYYY',
-        LL : '[el] D MMMM [de] YYYY',
+        LL : 'D MMMM [de] YYYY',
         ll : 'D MMM YYYY',
-        LLL : '[el] D MMMM [de] YYYY [a les] H:mm',
+        LLL : 'D MMMM [de] YYYY [a les] H:mm',
         lll : 'D MMM YYYY, H:mm',
-        LLLL : '[el] dddd D MMMM [de] YYYY [a les] H:mm',
+        LLLL : 'dddd D MMMM [de] YYYY [a les] H:mm',
         llll : 'ddd D MMM YYYY, H:mm'
     },
     calendar : {

--- a/src/test/locale/ca.js
+++ b/src/test/locale/ca.js
@@ -27,7 +27,7 @@ test('format', function (assert) {
             ['M Mo MM MMMM MMM',                   '2 2n 02 febrer febr.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14è 14'],
-            ['d do dddd ddd dd',                   '0 0è diumenge dg. Dg'],
+            ['d do dddd ddd dd',                   '0 0è diumenge dg. dg'],
             ['DDD DDDo DDDD',                      '45 45è 045'],
             ['w wo ww',                            '6 6a 06'],
             ['h hh',                               '3 03'],
@@ -38,9 +38,9 @@ test('format', function (assert) {
             ['[the] DDDo [day of the year]',       'the 45è day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 'el 14 de febrer de 2010'],
-            ['LLL',                                'el 14 de febrer de 2010 a les 15:25'],
-            ['LLLL',                               'el diumenge 14 de febrer de 2010 a les 15:25'],
+            ['LL',                                 '14 de febrer de 2010'],
+            ['LLL',                                '14 de febrer de 2010 a les 15:25'],
+            ['LLLL',                               'diumenge 14 de febrer de 2010 a les 15:25'],
             ['l',                                  '14/2/2010'],
             ['ll',                                 '14 febr. 2010'],
             ['lll',                                '14 febr. 2010, 15:25'],
@@ -98,7 +98,7 @@ test('format month', function (assert) {
 });
 
 test('format week', function (assert) {
-    var expected = 'diumenge dg. Dg_dilluns dl. Dl_dimarts dt. Dt_dimecres dc. Dc_dijous dj. Dj_divendres dv. Dv_dissabte ds. Ds'.split('_'), i;
+    var expected = 'diumenge dg. dg_dilluns dl. dl_dimarts dt. dt_dimecres dc. dc_dijous dj. dj_divendres dv. dv_dissabte ds. ds'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }


### PR DESCRIPTION
http://cldr.unicode.org/index/downloads

Standard date and time formats (full, long, medium, short) for gregorian calendar for "ca" locale don't use "el" prefix.
Also, I lowercased weekdaysMin: day names (short or not) in Catalan are always lowercase.

It looks weird when formating standalone dates. Moment library doesn't know the context, and so this article can be "el", "al", "a", ... or many other words.
Imho moment should print standalone dates, unless it fully adapts to ICU standards.

Original author @juanghurtado