### PR TITLE
#1428: Updated Danish 'L' dateformat to use dots rather than slashes, aligning with article from DSN.

### DIFF
--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -13,7 +13,7 @@ export default moment.defineLocale('da', {
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',
-        L : 'DD/MM/YYYY',
+        L : 'DD.MM.YYYY',
         LL : 'D. MMMM YYYY',
         LLL : 'D. MMMM YYYY HH:mm',
         LLLL : 'dddd [d.] D. MMMM YYYY [kl.] HH:mm'

--- a/src/test/locale/da.js
+++ b/src/test/locale/da.js
@@ -37,11 +37,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[den] DDDo [dag på året]',           'den 45. dag på året'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14/02/2010'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '14. februar 2010'],
             ['LLL',                                '14. februar 2010 15:25'],
             ['LLLL',                               'søndag d. 14. februar 2010 kl. 15:25'],
-            ['l',                                  '14/2/2010'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '14. feb 2010'],
             ['lll',                                '14. feb 2010 15:25'],
             ['llll',                               'søn d. 14. feb 2010 kl. 15:25']


### PR DESCRIPTION
See argumentation at https://github.com/moment/moment/issues/1428#issuecomment-299046240

I kept the zero padding even though DSN says that it's "usually not requried," but it seems to be the way it's done in every other momentjs locale. This way `l` would give the DSN recommended output, while `L` would give one that's close, but has the zero padding. I don't think it would make sense to force those two to be the same. Input welcome if there is a better way to do this.

This is further complicated by the fact that DSN recommends three different formats, `D.M.YYYY`, `D.M.YY` and `YYYY-MM-DD`. I picked the one that is stated to be "traditional" with dots and full year specification.