### PR TITLE
[locale] pt: Fix capital letters in weekdays

### DIFF
--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -5,8 +5,8 @@
 import moment from '../moment';
 
 export default moment.defineLocale('pt', {
-    months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-    monthsShort : 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+    months : 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
+    monthsShort : 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
     weekdays : 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
     weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
     weekdaysMin : 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -7,7 +7,7 @@ import moment from '../moment';
 export default moment.defineLocale('pt', {
     months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
     monthsShort : 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
-    weekdays : 'Domingo_Segunda-Feira_Terça-Feira_Quarta-Feira_Quinta-Feira_Sexta-Feira_Sábado'.split('_'),
+    weekdays : 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
     weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
     weekdaysMin : 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),
     weekdaysParseExact : true,

--- a/src/test/locale/pt.js
+++ b/src/test/locale/pt.js
@@ -98,7 +98,7 @@ test('format month', function (assert) {
 });
 
 test('format week', function (assert) {
-    var expected = 'Domingo Dom Do_Segunda-Feira Seg 2ª_Terça-Feira Ter 3ª_Quarta-Feira Qua 4ª_Quinta-Feira Qui 5ª_Sexta-Feira Sex 6ª_Sábado Sáb Sá'.split('_'), i;
+    var expected = 'Domingo Dom Do_Segunda-feira Seg 2ª_Terça-feira Ter 3ª_Quarta-feira Qua 4ª_Quinta-feira Qui 5ª_Sexta-feira Sex 6ª_Sábado Sáb Sá'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }

--- a/src/test/locale/pt.js
+++ b/src/test/locale/pt.js
@@ -35,7 +35,7 @@ test('format', function (assert) {
             ['m mm',                               '25 25'],
             ['s ss',                               '50 50'],
             ['a A',                                'pm PM'],
-            ['[the] DDDo [day of the year]',       'o 45.º dia do ano'],
+            ['[the] DDDo [day of the year]',       'the 45º day of the year'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
             ['LL',                                 '14 de fevereiro de 2010'],

--- a/src/test/locale/pt.js
+++ b/src/test/locale/pt.js
@@ -24,7 +24,7 @@ test('format', function (assert) {
     var a = [
             ['dddd, MMMM Do YYYY, h:mm:ss a',      'Domingo, fevereiro 14º 2010, 3:25:50 pm'],
             ['ddd, hA',                            'Dom, 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2º 02 fevereiro Fev'],
+            ['M Mo MM MMMM MMM',                   '2 2º 02 fevereiro fev'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14º 14'],
             ['d do dddd ddd',                      '0 0º Domingo Dom'],

--- a/src/test/locale/pt.js
+++ b/src/test/locale/pt.js
@@ -22,9 +22,9 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Domingo, Fevereiro 14º 2010, 3:25:50 pm'],
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Domingo, fevereiro 14º 2010, 3:25:50 pm'],
             ['ddd, hA',                            'Dom, 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2º 02 Fevereiro Fev'],
+            ['M Mo MM MMMM MMM',                   '2 2º 02 fevereiro Fev'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14º 14'],
             ['d do dddd ddd',                      '0 0º Domingo Dom'],
@@ -35,12 +35,12 @@ test('format', function (assert) {
             ['m mm',                               '25 25'],
             ['s ss',                               '50 50'],
             ['a A',                                'pm PM'],
-            ['[the] DDDo [day of the year]',       'the 45º day of the year'],
+            ['[the] DDDo [day of the year]',       'o 45.º dia do ano'],
             ['LTS',                                '15:25:50'],
             ['L',                                  '14/02/2010'],
-            ['LL',                                 '14 de Fevereiro de 2010'],
-            ['LLL',                                '14 de Fevereiro de 2010 15:25'],
-            ['LLLL',                               'Domingo, 14 de Fevereiro de 2010 15:25'],
+            ['LL',                                 '14 de fevereiro de 2010'],
+            ['LLL',                                '14 de fevereiro de 2010 15:25'],
+            ['LLLL',                               'Domingo, 14 de fevereiro de 2010 15:25'],
             ['l',                                  '14/2/2010'],
             ['ll',                                 '14 de Fev de 2010'],
             ['lll',                                '14 de Fev de 2010 15:25'],


### PR DESCRIPTION
In Portuguese (Portugal) weekdays are in lowercase. So its required that working days will be like `Segunda-feira` not as the actual value `Segunda-Feira`

For those on grammar:
Even the first capital letter is only Ok when in a single word or the first word in a sentence. Regular usage (in the middle of a sentence) it would be all in lowercase.
But we can't control here when it will show one way or the other, so the initial capital letter!

Reference: https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/meses-e-dias-da-semana-outra-vez/3743