### PR TITLE
[bugfix] Support '+' for duration components when parsing

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -14,7 +14,7 @@ var aspNetRegex = /^(\-|\+)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)(\.\d*)?)?$/;
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
 // and further modified to allow for strings containing both week and day
-var isoRegex = /^(-|\+)?P(?:((?:-|\+)?[0-9,.]*)Y)?(?:((?:-|\+)?[0-9,.]*)M)?(?:((?:-|\+)?[0-9,.]*)W)?(?:((?:-|\+)?[0-9,.]*)D)?(?:T(?:((?:-|\+)?[0-9,.]*)H)?(?:((?:-|\+)?[0-9,.]*)M)?(?:((?:-|\+)?[0-9,.]*)S)?)?$/;
+var isoRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/;
 
 export function createDuration (input, key) {
     var duration = input,
@@ -38,7 +38,7 @@ export function createDuration (input, key) {
             duration.milliseconds = input;
         }
     } else if (!!(match = aspNetRegex.exec(input))) {
-        sign = (match[1] === '-') ? -1 : (match[1] === '+') ? 1 : 1;
+        sign = (match[1] === '-') ? -1 : 1;
         duration = {
             y  : 0,
             d  : toInt(match[DATE])                         * sign,

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -14,7 +14,7 @@ var aspNetRegex = /^(\-|\+)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)(\.\d*)?)?$/;
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
 // and further modified to allow for strings containing both week and day
-var isoRegex = /^(-|\+)?P(?:(-?[0-9,.]*)Y)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)W)?(?:(-?[0-9,.]*)D)?(?:T(?:(-?[0-9,.]*)H)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)S)?)?$/;
+var isoRegex = /^(-|\+)?P(?:((?:-|\+)?[0-9,.]*)Y)?(?:((?:-|\+)?[0-9,.]*)M)?(?:((?:-|\+)?[0-9,.]*)W)?(?:((?:-|\+)?[0-9,.]*)D)?(?:T(?:((?:-|\+)?[0-9,.]*)H)?(?:((?:-|\+)?[0-9,.]*)M)?(?:((?:-|\+)?[0-9,.]*)S)?)?$/;
 
 export function createDuration (input, key) {
     var duration = input,

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -9,12 +9,12 @@ import { createLocal } from '../create/local';
 import { createInvalid as invalid } from './valid';
 
 // ASP.NET json date format regex
-var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)(\.\d*)?)?$/;
+var aspNetRegex = /^(\-|\+)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)(\.\d*)?)?$/;
 
 // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
 // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere
 // and further modified to allow for strings containing both week and day
-var isoRegex = /^(-)?P(?:(-?[0-9,.]*)Y)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)W)?(?:(-?[0-9,.]*)D)?(?:T(?:(-?[0-9,.]*)H)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)S)?)?$/;
+var isoRegex = /^(-|\+)?P(?:(-?[0-9,.]*)Y)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)W)?(?:(-?[0-9,.]*)D)?(?:T(?:(-?[0-9,.]*)H)?(?:(-?[0-9,.]*)M)?(?:(-?[0-9,.]*)S)?)?$/;
 
 export function createDuration (input, key) {
     var duration = input,
@@ -38,7 +38,7 @@ export function createDuration (input, key) {
             duration.milliseconds = input;
         }
     } else if (!!(match = aspNetRegex.exec(input))) {
-        sign = (match[1] === '-') ? -1 : 1;
+        sign = (match[1] === '-') ? -1 : (match[1] === '+') ? 1 : 1;
         duration = {
             y  : 0,
             d  : toInt(match[DATE])                         * sign,
@@ -48,7 +48,7 @@ export function createDuration (input, key) {
             ms : toInt(absRound(match[MILLISECOND] * 1000)) * sign // the millisecond decimal point is included in the match
         };
     } else if (!!(match = isoRegex.exec(input))) {
-        sign = (match[1] === '-') ? -1 : 1;
+        sign = (match[1] === '-') ? -1 : (match[1] === '+') ? 1 : 1;
         duration = {
             y : parseIso(match[2], sign),
             M : parseIso(match[3], sign),

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -261,6 +261,9 @@ test('instantiation from serialized C# TimeSpan with high millisecond precision'
 
     assert.equal(moment.duration('-00:00:15.7205000').seconds(), -15, '15 seconds');
     assert.equal(moment.duration('-00:00:15.7205000').milliseconds(), -721, '721 milliseconds');
+
+    assert.equal(moment.duration('+00:00:15.7205000').seconds(), 15, '15 seconds');
+    assert.equal(moment.duration('+00:00:15.7205000').milliseconds(), 721, '721 milliseconds');
 });
 
 test('instatiation from serialized C# TimeSpan maxValue', function (assert) {
@@ -289,6 +292,19 @@ test('instatiation from serialized C# TimeSpan minValue', function (assert) {
     assert.equal(d.milliseconds(), -478, '478 milliseconds');
 });
 
+test('instatiation from serialized C# TimeSpan maxValue with + sign', function (assert) {
+    var d = moment.duration('+10675199.02:48:05.4775808');
+
+    assert.equal(d.years(), 29227, '29653 years');
+    assert.equal(d.months(), 8, '8 day');
+    assert.equal(d.days(), 12, '12 day');  // if you have to change this value -- just do it
+
+    assert.equal(d.hours(), 2, '2 hours');
+    assert.equal(d.minutes(), 48, '48 minutes');
+    assert.equal(d.seconds(), 5, '5 seconds');
+    assert.equal(d.milliseconds(), 478, '478 milliseconds');
+});
+
 test('instantiation from ISO 8601 duration', function (assert) {
     assert.equal(moment.duration('P1Y2M3DT4H5M6S').asSeconds(), moment.duration({y: 1, M: 2, d: 3, h: 4, m: 5, s: 6}).asSeconds(), 'all fields');
     assert.equal(moment.duration('P3W3D').asSeconds(), moment.duration({w: 3, d: 3}).asSeconds(), 'week and day fields');
@@ -296,6 +312,7 @@ test('instantiation from ISO 8601 duration', function (assert) {
     assert.equal(moment.duration('PT1M').asSeconds(), moment.duration({m: 1}).asSeconds(), 'single minute field');
     assert.equal(moment.duration('P1MT2H').asSeconds(), moment.duration({M: 1, h: 2}).asSeconds(), 'random fields missing');
     assert.equal(moment.duration('-P60D').asSeconds(), moment.duration({d: -60}).asSeconds(), 'negative days');
+    assert.equal(moment.duration('+P60D').asSeconds(), moment.duration({d: 60}).asSeconds(), 'positive days');
     assert.equal(moment.duration('PT0.5S').asSeconds(), moment.duration({s: 0.5}).asSeconds(), 'fractional seconds');
     assert.equal(moment.duration('PT0,5S').asSeconds(), moment.duration({s: 0.5}).asSeconds(), 'fractional seconds (comma)');
 });
@@ -306,6 +323,10 @@ test('serialization to ISO 8601 duration strings', function (assert) {
     assert.equal(moment.duration({m: -1}).toISOString(), '-PT1M', 'one minute ago');
     assert.equal(moment.duration({s: -0.5}).toISOString(), '-PT0.5S', 'one half second ago');
     assert.equal(moment.duration({y: -1, M: 1}).toISOString(), '-P11M', 'a month after a year ago');
+    assert.equal(moment.duration({M: +1}).toISOString(), 'P1M', 'one month ago');
+    assert.equal(moment.duration({m: +1}).toISOString(), 'PT1M', 'one minute ago');
+    assert.equal(moment.duration({s: +0.5}).toISOString(), 'PT0.5S', 'one half second ago');
+    assert.equal(moment.duration({y: +1, M: 1}).toISOString(), 'P1Y1M', 'a month after a year in future');
     assert.equal(moment.duration({}).toISOString(), 'P0D', 'zero duration');
     assert.equal(moment.duration({M: 16, d:40, s: 86465}).toISOString(), 'P1Y4M40DT24H1M5S', 'all fields');
 });
@@ -316,6 +337,10 @@ test('toString acts as toISOString', function (assert) {
     assert.equal(moment.duration({m: -1}).toString(), '-PT1M', 'one minute ago');
     assert.equal(moment.duration({s: -0.5}).toString(), '-PT0.5S', 'one half second ago');
     assert.equal(moment.duration({y: -1, M: 1}).toString(), '-P11M', 'a month after a year ago');
+    assert.equal(moment.duration({M: +1}).toString(), 'P1M', 'one month ago');
+    assert.equal(moment.duration({m: +1}).toString(), 'PT1M', 'one minute ago');
+    assert.equal(moment.duration({s: +0.5}).toString(), 'PT0.5S', 'one half second ago');
+    assert.equal(moment.duration({y: +1, M: 1}).toString(), 'P1Y1M', 'a month after a year in future');
     assert.equal(moment.duration({}).toString(), 'P0D', 'zero duration');
     assert.equal(moment.duration({M: 16, d:40, s: 86465}).toString(), 'P1Y4M40DT24H1M5S', 'all fields');
 });
@@ -339,6 +364,8 @@ test('`isodate` (python) test cases', function (assert) {
     assert.equal(moment.duration('P1DT12H').asSeconds(), moment.duration({d: 1, h: 12}).asSeconds(), 'python isodate 10');
     assert.equal(moment.duration('-P2W').asSeconds(), moment.duration({w: -2}).asSeconds(), 'python isodate 11');
     assert.equal(moment.duration('-P2.2W').asSeconds(), moment.duration({w: -2.2}).asSeconds(), 'python isodate 12');
+    assert.equal(moment.duration('+P2W').asSeconds(), moment.duration({w: 2}).asSeconds(), 'python isodate 11');
+    assert.equal(moment.duration('+P2.2W').asSeconds(), moment.duration({w: 2.2}).asSeconds(), 'python isodate 12');
     assert.equal(moment.duration('P1DT2H3M4S').asSeconds(), moment.duration({d: 1, h: 2, m: 3, s: 4}).asSeconds(), 'python isodate 13');
     assert.equal(moment.duration('P1DT2H3M').asSeconds(), moment.duration({d: 1, h: 2, m: 3}).asSeconds(), 'python isodate 14');
     assert.equal(moment.duration('P1DT2H').asSeconds(), moment.duration({d: 1, h: 2}).asSeconds(), 'python isodate 15');
@@ -357,6 +384,18 @@ test('`isodate` (python) test cases', function (assert) {
     assert.equal(moment.duration('P-3Y-6M-4DT-12H-30M-5S').asSeconds(), moment.duration({y: -3, M: -6, d: -4, h: -12, m: -30, s: -5}).asSeconds(), 'python isodate 28');
     assert.equal(moment.duration('-P-2W').asSeconds(), moment.duration({w: 2}).asSeconds(), 'python isodate 29');
     assert.equal(moment.duration('P-2W').asSeconds(), moment.duration({w: -2}).asSeconds(), 'python isodate 30');
+    assert.equal(moment.duration('+P2Y').asSeconds(), moment.duration({y: 2}).asSeconds(), 'python isodate 31');
+    assert.equal(moment.duration('+P3Y6M4DT12H30M5S').asSeconds(), moment.duration({y: 3, M: 6, d: 4, h: 12, m: 30, s: 5}).asSeconds(), 'python isodate 32');
+    assert.equal(moment.duration('+P1DT2H3M4S').asSeconds(), moment.duration({d: 1, h: 2, m: 3, s: 4}).asSeconds(), 'python isodate 34');
+    assert.equal(moment.duration('PT+6H3M').asSeconds(), moment.duration({h: 6, m: 3}).asSeconds(), 'python isodate 35');
+    assert.equal(moment.duration('+PT+6H3M').asSeconds(), moment.duration({h: 6, m: 3}).asSeconds(), 'python isodate 36');
+    assert.equal(moment.duration('+PT-6H3M').asSeconds(), moment.duration({h: -6, m: 3}).asSeconds(), 'python isodate 37');
+    assert.equal(moment.duration('+P+3Y+6M+4DT+12H+30M+5S').asSeconds(), moment.duration({y: 3, M: 6, d: 4, h: 12, m: 30, s: 5}).asSeconds(), 'python isodate 38');
+    assert.equal(moment.duration('+P-3Y-6M-4DT-12H-30M-5S').asSeconds(), moment.duration({y: -3, M: -6, d: -4, h: -12, m: -30, s: -5}).asSeconds(), 'python isodate 39');
+    assert.equal(moment.duration('P+3Y+6M+4DT+12H+30M+5S').asSeconds(), moment.duration({y: 3, M: 6, d: 4, h: 12, m: 30, s: 5}).asSeconds(), 'python isodate 40');
+    assert.equal(moment.duration('+P+2W').asSeconds(), moment.duration({w: 2}).asSeconds(), 'python isodate 41');
+    assert.equal(moment.duration('+P-2W').asSeconds(), moment.duration({w: -2}).asSeconds(), 'python isodate 41');
+    assert.equal(moment.duration('P+2W').asSeconds(), moment.duration({w: 2}).asSeconds(), 'python isodate 43');
 });
 
 test('ISO 8601 misuse cases', function (assert) {
@@ -409,6 +448,7 @@ test('humanize duration with suffix', function (assert) {
     moment.locale('en');
     assert.equal(moment.duration({seconds:  44}).humanize(true),  'in a few seconds', '44 seconds = a few seconds');
     assert.equal(moment.duration({seconds: -44}).humanize(true),  'a few seconds ago', '44 seconds = a few seconds');
+    assert.equal(moment.duration({seconds: +44}).humanize(true),  'in a few seconds', '44 seconds = a few seconds');
 });
 
 test('bubble value up', function (assert) {
@@ -623,17 +663,33 @@ test('add and bubble', function (assert) {
     assert.equal(d.hours(), -23, '-1 day + 1 hour == -23 hour (component)');
     assert.equal(d.asHours(), -23, '-1 day + 1 hour == -23 hours');
 
+    d = moment.duration(+1, 'day').add(1, 'hour');
+    assert.equal(d.hours(), 1, '1 day + 1 hour == 1 hour (component)');
+    assert.equal(d.asHours(), 25, '1 day + 1 hour == 25 hour');
+
     d = moment.duration(-1, 'year').add(1, 'day');
     assert.equal(d.days(), -30, '- 1 year + 1 day == -30 days (component)');
     assert.equal(d.months(), -11, '- 1 year + 1 day == -11 months (component)');
     assert.equal(d.years(), 0, '- 1 year + 1 day == 0 years (component)');
     assert.equal(d.asDays(), -364, '- 1 year + 1 day == -364 days');
 
+    d = moment.duration(+1, 'year').add(1, 'day');
+    assert.equal(d.days(), 1, '+ 1 year + 1 day == 1 days (component)');
+    assert.equal(d.months(), 0, '+ 1 year + 1 day == 0 month (component)');
+    assert.equal(d.years(), 1, '+ 1 year + 1 day == 1 year (component)');
+    assert.equal(d.asDays(), 366, '+ 1 year + 1 day == +366 day');
+
     d = moment.duration(-1, 'year').add(1, 'hour');
     assert.equal(d.hours(), -23, '- 1 year + 1 hour == -23 hours (component)');
     assert.equal(d.days(), -30, '- 1 year + 1 hour == -30 days (component)');
     assert.equal(d.months(), -11, '- 1 year + 1 hour == -11 months (component)');
     assert.equal(d.years(), 0, '- 1 year + 1 hour == 0 years (component)');
+
+    d = moment.duration(+1, 'year').add(1, 'hour');
+    assert.equal(d.hours(), 1, '+ 1 year + 1 hour == 1 hour (component)');
+    assert.equal(d.days(), 0, '+ 1 year + 1 hour == 1 day (component)');
+    assert.equal(d.months(), 0, '+ 1 year + 1 hour == 1 month (component)');
+    assert.equal(d.years(), 1, '+ 1 year + 1 hour == 1 year (component)');
 });
 
 test('subtract and bubble', function (assert) {


### PR DESCRIPTION
Updated regex to support positive sign in addition to a negative sign. The `sign` is assigned a value of 1 if the regex finds "+" in the beginning.