### PR TITLE
[locale] tr: Improve calendar text for next/prev week

### DIFF
--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -43,9 +43,9 @@ export default moment.defineLocale('tr', {
     calendar : {
         sameDay : '[bugün saat] LT',
         nextDay : '[yarın saat] LT',
-        nextWeek : '[haftaya] dddd [saat] LT',
+        nextWeek : '[gelecek] dddd [saat] LT',
         lastDay : '[dün] LT',
-        lastWeek : '[geçen hafta] dddd [saat] LT',
+        lastWeek : '[geçen] dddd [saat] LT',
         sameElse : 'L'
     },
     relativeTime : {

--- a/src/test/locale/tr.js
+++ b/src/test/locale/tr.js
@@ -176,11 +176,11 @@ test('calendar next week', function (assert) {
     var i, m;
     for (i = 2; i < 7; i++) {
         m = moment().add({d: i});
-        assert.equal(m.calendar(),       m.format('[haftaya] dddd [saat] LT'),  'Today + ' + i + ' days current time');
+        assert.equal(m.calendar(),       m.format('[gelecek] dddd [saat] LT'),  'Today + ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),       m.format('[haftaya] dddd [saat] LT'),  'Today + ' + i + ' days beginning of day');
+        assert.equal(m.calendar(),       m.format('[gelecek] dddd [saat] LT'),  'Today + ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),       m.format('[haftaya] dddd [saat] LT'),  'Today + ' + i + ' days end of day');
+        assert.equal(m.calendar(),       m.format('[gelecek] dddd [saat] LT'),  'Today + ' + i + ' days end of day');
     }
 });
 
@@ -188,11 +188,11 @@ test('calendar last week', function (assert) {
     var i, m;
     for (i = 2; i < 7; i++) {
         m = moment().subtract({d: i});
-        assert.equal(m.calendar(),       m.format('[geçen hafta] dddd [saat] LT'),  'Today - ' + i + ' days current time');
+        assert.equal(m.calendar(),       m.format('[geçen] dddd [saat] LT'),  'Today - ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),       m.format('[geçen hafta] dddd [saat] LT'),  'Today - ' + i + ' days beginning of day');
+        assert.equal(m.calendar(),       m.format('[geçen] dddd [saat] LT'),  'Today - ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),       m.format('[geçen hafta] dddd [saat] LT'),  'Today - ' + i + ' days end of day');
+        assert.equal(m.calendar(),       m.format('[geçen] dddd [saat] LT'),  'Today - ' + i + ' days end of day');
     }
 });
 


### PR DESCRIPTION
Turkish locale calendar issue https://github.com/moment/moment/issues/4006

Translations changed as below:
`[haftaya]` -> `[gelecek]`
`[geçen hafta]` -> `[geçen]`