### PR TITLE
[misc] TS: Add specs & tests for moment.RFC_2822

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -704,6 +704,7 @@ declare namespace moment {
    * Constant used to enable explicit ISO_8601 format parsing.
    */
   export var ISO_8601: MomentBuiltinFormat;
+  export var RFC_2822: MomentBuiltinFormat;
 
   export var defaultFormat: string;
   export var defaultFormatUtc: string;

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -40,6 +40,13 @@ moment(day.toISOString(), [moment.ISO_8601]);
 moment(day.toISOString(), [moment.ISO_8601], true);
 moment(day.toISOString(), [moment.ISO_8601], "en", true);
 
+moment(day.toUTCString(), moment.RFC_2822);
+moment(day.toUTCString(), moment.RFC_2822, true);
+moment(day.toUTCString(), moment.RFC_2822, "en", true);
+moment(day.toUTCString(), [moment.RFC_2822]);
+moment(day.toUTCString(), [moment.RFC_2822], true);
+moment(day.toUTCString(), [moment.RFC_2822], "en", true);
+
 var a = moment([2012]);
 var b = moment(a);
 a.year(2000);


### PR DESCRIPTION
Not much to say, the typescript declaration wasn't added when RFC_2822 parsing was added in 2.18.

Fixes #4033 