### PR TITLE
[locale] fr: REORDER weekdays

### DIFF
--- a/locale/fr.js
+++ b/locale/fr.js
@@ -14,9 +14,9 @@ var fr = moment.defineLocale('fr', {
     months : 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split('_'),
     monthsShort : 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'.split('_'),
     monthsParseExact : true,
-    weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
-    weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdays : 'lundi_mardi_mercredi_jeudi_vendredi_samedi_dimanche'.split('_'),
+    weekdaysShort : 'lun._mar._mer._jeu._ven._sam._dim.'.split('_'),
+    weekdaysMin : 'lu_ma_me_je_ve_sa_di'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',


### PR DESCRIPTION
- Fix the week days order.

While the `dow` was correctly set to Monday, the actual weekdays were still starting on Sunday.

- Fix the case of weekdaysMin

In French, the days of the week are all in lowercase. The min version of the weekdays had were starting with an uppercase.