### PR TITLE
Fix #4031 - Missing ES6 module during tree shaking

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -52,7 +52,7 @@ function loadLocale(name) {
             module && module.exports) {
         try {
             oldLocale = globalLocale._abbr;
-            require('./locale/' + name);
+            require('moment/locale/' + name);
             // because defineLocale currently also sets the global locale, we
             // want to undo that for lazy loaded locales
             getSetGlobalLocale(oldLocale);


### PR DESCRIPTION
Fixes a relative import issue. This doesn't address the bigger problems with the function, but at the very least it makes it work correctly when targeting ES6.