### PR TITLE
[bugfix] Make auto locale loading for node not mess webpack, fixes #4031, #2979, #3872

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -50,13 +50,21 @@ function loadLocale(name) {
     // TODO: Find a better way to register and load all the locales in Node
     if (!locales[name] && (typeof module !== 'undefined') &&
             module && module.exports) {
+        oldLocale = globalLocale._abbr;
         try {
-            oldLocale = globalLocale._abbr;
-            require('./locale/' + name);
-            // because defineLocale currently also sets the global locale, we
-            // want to undo that for lazy loaded locales
-            getSetGlobalLocale(oldLocale);
-        } catch (e) { }
+            require('moment/locale/' + name);
+        } catch (e) {
+            // In the test environment, the external module 'moment'
+            // can't be resolved because we're running inside it.
+            // Fallback to using the old relative import
+            try {
+                require('./locale/' + name);
+            } catch (e) { }
+        }
+
+        // because defineLocale currently also sets the global locale, we
+        // want to undo that for lazy loaded locales
+        getSetGlobalLocale(oldLocale);
     }
     return locales[name];
 }


### PR DESCRIPTION
Reopening this PR now that tests are passing.

Cannot import the locale relatively, since the code exists
in a different location in the bundled ES5 module than it
does in ES6.

In order to run tests locally (where the external 'moment'
library can't be loaded), fall back to using the relative import.