### PR TITLE
[pkg] webpack,babel: Make require path cross-platform

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -52,7 +52,7 @@ function loadLocale(name) {
             module && module.exports) {
         try {
             oldLocale = globalLocale._abbr;
-            require('./locale/' + name);
+            require('.' + path.sep + 'locale' + path.sep + name);  //path.join throws an error in webpack
             // because defineLocale currently also sets the global locale, we
             // want to undo that for lazy loaded locales
             getSetGlobalLocale(oldLocale);


### PR DESCRIPTION
fixes an issue when compiling with webpack/babel on Windows

issues: #2979, #4031, #3872,