### PR TITLE
4024 modify leap year to non

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -561,7 +561,7 @@ function set$1 (mom, unit, value) {
         * if: month == february && date == 29
         * then: set the date to 28
         */
-        unit === 'FullYear' && mom._d.getMonth() === 1 && mom._d.getDate() === 29 && mom._d.setDate(28);
+        unit === 'FullYear' && mom._d.getMonth() === 1 && mom._d.getDate() === 29 && mom._d.setDate(isLeapYear(value) ? 29 : 28);
         mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value);
     }
 }

--- a/moment.js
+++ b/moment.js
@@ -561,11 +561,7 @@ function set$1 (mom, unit, value) {
         * if: month == february && date == 29
         * then: set the date to 28
         */
-        if(unit === 'FullYear') {
-            if(mom._d.getMonth() === 1 && mom._d.getDate() === 29 ) {
-                mom._d.setDate(28);
-            }
-        }
+        unit === 'FullYear' && mom._d.getMonth() === 1 && mom._d.getDate() === 29 && mom._d.setDate(28);
         mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value);
     }
 }

--- a/moment.js
+++ b/moment.js
@@ -556,6 +556,16 @@ function get (mom, unit) {
 
 function set$1 (mom, unit, value) {
     if (mom.isValid()) {
+        /**
+        * Check for set (@year)
+        * if: month == february && date == 29
+        * then: set the date to 28
+        */
+        if(unit === 'FullYear') {
+            if(mom._d.getMonth() === 1 && mom._d.getDate() === 29 ) {
+                mom._d.setDate(28);
+            }
+        }
         mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value);
     }
 }


### PR DESCRIPTION
#4024 Fix

## Breakdowns:
- [x] check for month and date for leap year
- [x] set date to either 28 or 29 depending on isLeapYear of year value passed.

note: since the issue is caused by Date(), the approach I took is to check for the value passed to year() function.