### PR TITLE
[misc] Print console warning when setting non-existent locales

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -79,8 +79,10 @@ export function getSetGlobalLocale (key, values) {
             globalLocale = data;
         }
         else {
-            //warn user if arguments are passed but the locale could not be set
-            console.warn('Locale ' + key +  'not found. Did you forget to load it?');
+            if (typeof console !==  'undefined') && console.warn) {
+                //warn user if arguments are passed but the locale could not be set
+                console.warn('Locale ' + key +  'not found. Did you forget to load it?');
+            }
         }
     }
 

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -80,7 +80,7 @@ export function getSetGlobalLocale (key, values) {
         }
         else {
             //warn user if arguments are passed but the locale could not be set
-            console.warn('Locale ' + key +  'not found. Did you forget to load it?')
+            console.warn('Locale ' + key +  'not found. Did you forget to load it?');
         }
     }
 

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -79,7 +79,7 @@ export function getSetGlobalLocale (key, values) {
             globalLocale = data;
         }
         else {
-            if (typeof console !==  'undefined') && console.warn) {
+            if ((typeof console !==  'undefined') && console.warn) {
                 //warn user if arguments are passed but the locale could not be set
                 console.warn('Locale ' + key +  'not found. Did you forget to load it?');
             }

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -81,7 +81,7 @@ export function getSetGlobalLocale (key, values) {
         else {
             if ((typeof console !==  'undefined') && console.warn) {
                 //warn user if arguments are passed but the locale could not be set
-                console.warn('Locale ' + key +  'not found. Did you forget to load it?');
+                console.warn('Locale ' + key +  ' not found. Did you forget to load it?');
             }
         }
     }

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -78,6 +78,10 @@ export function getSetGlobalLocale (key, values) {
             // moment.duration._locale = moment._locale = data;
             globalLocale = data;
         }
+        else {
+            //warn user if arguments are passed but the locale could not be set
+            console.warn('Locale ' + key +  'not found. Did you forget to load it?')
+        }
     }
 
     return globalLocale._abbr;


### PR DESCRIPTION
Right now if the new locale being set is not available then it fails silently and just uses the existing global locale. A console warning would be useful to notify the user of such a failure.