### PR TITLE
3.x Issue 2697 - Implementing null checks for comparison

### DIFF
--- a/src/lib/moment/compare.js
+++ b/src/lib/moment/compare.js
@@ -4,6 +4,9 @@ import { createLocal } from '../create/local';
 import isUndefined from '../utils/is-undefined';
 
 export function isAfter (input, units) {
+    if (isUndefined(input)) {
+        return false;
+    }
     var localInput = isMoment(input) ? input : createLocal(input);
     if (!(this.isValid() && localInput.isValid())) {
         return false;
@@ -17,6 +20,9 @@ export function isAfter (input, units) {
 }
 
 export function isBefore (input, units) {
+    if (isUndefined(input)) {
+        return false;
+    }
     var localInput = isMoment(input) ? input : createLocal(input);
     if (!(this.isValid() && localInput.isValid())) {
         return false;
@@ -36,6 +42,9 @@ export function isBetween (from, to, units, inclusivity) {
 }
 
 export function isSame (input, units) {
+    if (isUndefined(input)) {
+        return false;
+    }
     var localInput = isMoment(input) ? input : createLocal(input),
         inputMs;
     if (!(this.isValid() && localInput.isValid())) {

--- a/src/test/moment/is_after.js
+++ b/src/test/moment/is_after.js
@@ -175,3 +175,10 @@ test('is after invalid', function (assert) {
     assert.equal(m.isAfter(invalid, 'second'), false, 'invalid moment second');
     assert.equal(m.isAfter(invalid, 'milliseconds'), false, 'invalid moment milliseconds');
 });
+
+test('is after undefined and null', function (assert) {
+    var m = moment();
+    assert.equal(m.isAfter(), false, 'undefined date');
+    assert.equal(m.isAfter(undefined), false, 'undefined date');
+    assert.equal(m.isAfter(null), false, 'null date');
+});

--- a/src/test/moment/is_before.js
+++ b/src/test/moment/is_before.js
@@ -175,3 +175,10 @@ test('is before invalid', function (assert) {
     assert.equal(m.isBefore(invalid, 'second'), false, 'invalid moment second');
     assert.equal(m.isBefore(invalid, 'milliseconds'), false, 'invalid moment milliseconds');
 });
+
+test('is before undefined and null', function (assert) {
+    var m = moment();
+    assert.equal(m.isBefore(), false, 'undefined date');
+    assert.equal(m.isBefore(undefined), false, 'undefined date');
+    assert.equal(m.isBefore(null), false, 'null date');
+});

--- a/src/test/moment/is_same.js
+++ b/src/test/moment/is_same.js
@@ -149,3 +149,10 @@ test('is same with utc offset moments', function (assert) {
 test('is same with invalid moments', function (assert) {
     assert.equal(moment.invalid().isSame(moment.invalid()), false, 'invalid moments are not considered equal');
 });
+
+test('is same undefined and null', function (assert) {
+    var m = moment();
+    assert.equal(m.isSame(), false, 'blank is not considered equal');
+    assert.equal(m.isSame(undefined), false, 'undefined is not considered equal');
+    assert.equal(m.isSame(null), false, 'null is not considered equal');
+});


### PR DESCRIPTION
If the moment object passed in as the first parameter is undefined (as judged by the isUndefined function), then we always return false.

Change made on isBefore, isSame, and isAfter