### PR TITLE
[fixup] Rename gu-IN locale to gu

### DIFF
--- a/src/locale/gu.js
+++ b/src/locale/gu.js
@@ -1,6 +1,7 @@
 //! moment.js locale configuration
-//! locale : gujarati (gu-IN)
+//! locale : Gujarati [gu]
 //! author : Kaushik Thanki : https://github.com/Kaushik1987
+
 import moment from '../moment';
 
 var symbolMap = {
@@ -28,7 +29,7 @@ var symbolMap = {
         '૦': '0'
     };
 
-export default moment.defineLocale('gu-IN', {
+export default moment.defineLocale('gu', {
     months: 'જાન્યુઆરી_ફેબ્રુઆરી_માર્ચ_એપ્રિલ_મે_જૂન_જુલાઈ_ઑગસ્ટ_સપ્ટેમ્બર_ઑક્ટ્બર_નવેમ્બર_ડિસેમ્બર'.split('_'),
     monthsShort: 'જાન્યુ._ફેબ્રુ._માર્ચ_એપ્રિ._મે_જૂન_જુલા._ઑગ._સપ્ટે._ઑક્ટ્._નવે._ડિસે.'.split('_'),
     monthsParseExact: true,

--- a/src/test/locale/gu.js
+++ b/src/test/locale/gu.js
@@ -1,6 +1,6 @@
 import {localeModule, test} from '../qunit';
 import moment from '../../moment';
-localeModule('gu-IN');
+localeModule('gu');
 
 test('parse', function (assert) {
     var tests = 'જાન્યુઆરી જાન્યુ._ફેબ્રુઆરી ફેબ્રુ._માર્ચ માર્ચ_એપ્રિલ એપ્રિ._મે મે_જૂન જૂન_જુલાઈ જુલા._ઑગસ્ટ ઑગ._સપ્ટેમ્બર સપ્ટે._ઑક્ટ્બર ઑક્ટ્._નવેમ્બર નવે._ડિસેમ્બર ડિસે..'.split('_'), i;


### PR DESCRIPTION
Rename newly merged `gu-IN` locale to `gu`.