### PR TITLE
[fixup] Fix RFC2822 rewrite, fixes #4077

### DIFF
--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -464,8 +464,8 @@ test('parsing RFC 2822', function (assert) {
         '(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  07:23:45 +0000 (GMT)': [2016, 10, 1, 7, 23, 45, 0],
         'Mon, 02 Jan 2017 06:00:00 -0800': [2017, 0, 2, 6, 0, 0, -8 * 60],
         'Mon, 02 Jan 2017 06:00:00 +0800': [2017, 0, 2, 6, 0, 0, +8 * 60],
-        'Mon, 02 Jan 2017 06:00:00 +0330': [2017, 0, 2, 6, 0, 0, + (3 * 60 + 30)],
-        'Mon, 02 Jan 2017 06:00:00 -0330': [2017, 0, 2, 6, 0, 0, - (3 * 60 + 30)],
+        'Mon, 02 Jan 2017 06:00:00 +0330': [2017, 0, 2, 6, 0, 0, +(3 * 60 + 30)],
+        'Mon, 02 Jan 2017 06:00:00 -0330': [2017, 0, 2, 6, 0, 0, -(3 * 60 + 30)],
         'Mon, 02 Jan 2017 06:00:00 PST': [2017, 0, 2, 6, 0, 0, -8 * 60],
         'Mon, 02 Jan 2017 06:00:00 PDT': [2017, 0, 2, 6, 0, 0, -7 * 60],
         'Mon, 02 Jan 2017 06:00:00 MST': [2017, 0, 2, 6, 0, 0, -7 * 60],
@@ -473,15 +473,15 @@ test('parsing RFC 2822', function (assert) {
         'Mon, 02 Jan 2017 06:00:00 CST': [2017, 0, 2, 6, 0, 0, -6 * 60],
         'Mon, 02 Jan 2017 06:00:00 CDT': [2017, 0, 2, 6, 0, 0, -5 * 60],
         'Mon, 02 Jan 2017 06:00:00 EST': [2017, 0, 2, 6, 0, 0, -5 * 60],
-        'Mon, 02 Jan 2017 06:00:00 EDT': [2017, 0, 2, 6, 0, 0, -4 * 60],
+        'Mon, 02 Jan 2017 06:00:00 EDT': [2017, 0, 2, 6, 0, 0, -4 * 60]
     };
 
-    var inp, tokens;
+    var inp, tokens, parseResult, expResult;
 
     for (inp in testCases) {
-        var tokens = testCases[inp];
-        var parseResult = moment(inp, moment.RFC_2822, true).parseZone();
-        var expResult = moment.utc(tokens.slice(0, 6)).utcOffset(tokens[6], true);
+        tokens = testCases[inp];
+        parseResult = moment(inp, moment.RFC_2822, true).parseZone();
+        expResult = moment.utc(tokens.slice(0, 6)).utcOffset(tokens[6], true);
         assert.ok(parseResult.isValid(), inp);
         assert.ok(parseResult.parsingFlags().rfc2822, inp + ' - rfc2822 parsingFlag');
         assert.equal(parseResult.utcOffset(), expResult.utcOffset(), inp + ' - zone');

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -456,34 +456,50 @@ test('cloning carrying over utc mode', function (assert) {
 
 test('parsing RFC 2822', function (assert) {
     var testCases = {
-        'clean RFC2822 datetime with all options': 'Tue, 01 Nov 2016 01:23:45 UT',
-        'clean RFC2822 datetime without comma': 'Tue 01 Nov 2016 02:23:45 GMT',
-        'clean RFC2822 datetime without seconds': 'Tue, 01 Nov 2016 03:23 +0000',
-        'clean RFC2822 datetime without century': 'Tue, 01 Nov 16 04:23:45 Z',
-        'clean RFC2822 datetime without day': '01 Nov 2016 05:23:45 z',
-        'clean RFC2822 datetime with single-digit day-of-month': 'Tue, 1 Nov 2016 06:23:45 GMT',
-        'RFC2822 datetime with CFWSs': '(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  07:23:45 +0000 (GMT)'
+        'Tue, 01 Nov 2016 01:23:45 UT': [2016, 10, 1, 1, 23, 45, 0],
+        'Sun, 12 Apr 2015 05:06:07 GMT': [2015, 3, 12, 5, 6, 7, 0],
+        'Tue, 01 Nov 2016 01:23:45 +0000': [2016, 10, 1, 1, 23, 45, 0],
+        'Tue, 01 Nov 16 04:23:45 Z': [2016, 10, 1, 4, 23, 45, 0],
+        '01 Nov 2016 05:23:45 z': [2016, 10, 1, 5, 23, 45, 0],
+        '(Init Comment) Tue,\n 1 Nov              2016 (Split\n Comment)  07:23:45 +0000 (GMT)': [2016, 10, 1, 7, 23, 45, 0],
+        'Mon, 02 Jan 2017 06:00:00 -0800': [2017, 0, 2, 6, 0, 0, -8 * 60],
+        'Mon, 02 Jan 2017 06:00:00 +0800': [2017, 0, 2, 6, 0, 0, +8 * 60],
+        'Mon, 02 Jan 2017 06:00:00 +0330': [2017, 0, 2, 6, 0, 0, + (3 * 60 + 30)],
+        'Mon, 02 Jan 2017 06:00:00 -0330': [2017, 0, 2, 6, 0, 0, - (3 * 60 + 30)],
+        'Mon, 02 Jan 2017 06:00:00 PST': [2017, 0, 2, 6, 0, 0, -8 * 60],
+        'Mon, 02 Jan 2017 06:00:00 PDT': [2017, 0, 2, 6, 0, 0, -7 * 60],
+        'Mon, 02 Jan 2017 06:00:00 MST': [2017, 0, 2, 6, 0, 0, -7 * 60],
+        'Mon, 02 Jan 2017 06:00:00 MDT': [2017, 0, 2, 6, 0, 0, -6 * 60],
+        'Mon, 02 Jan 2017 06:00:00 CST': [2017, 0, 2, 6, 0, 0, -6 * 60],
+        'Mon, 02 Jan 2017 06:00:00 CDT': [2017, 0, 2, 6, 0, 0, -5 * 60],
+        'Mon, 02 Jan 2017 06:00:00 EST': [2017, 0, 2, 6, 0, 0, -5 * 60],
+        'Mon, 02 Jan 2017 06:00:00 EDT': [2017, 0, 2, 6, 0, 0, -4 * 60],
     };
-    var testCase;
 
-    for (testCase in testCases) {
-        var testResult = moment(testCases[testCase], moment.RFC_2822, true);
-        assert.ok(testResult.isValid(), testResult);
-        assert.ok(testResult.parsingFlags().rfc2822, testResult + ' - rfc2822 parsingFlag');
+    var inp, tokens;
+
+    for (inp in testCases) {
+        var tokens = testCases[inp];
+        var parseResult = moment(inp, moment.RFC_2822, true).parseZone();
+        var expResult = moment.utc(tokens.slice(0, 6)).utcOffset(tokens[6], true);
+        assert.ok(parseResult.isValid(), inp);
+        assert.ok(parseResult.parsingFlags().rfc2822, inp + ' - rfc2822 parsingFlag');
+        assert.equal(parseResult.utcOffset(), expResult.utcOffset(), inp + ' - zone');
+        assert.equal(parseResult.valueOf(), expResult.valueOf(), inp + ' - correctness');
     }
 });
 
 test('non RFC 2822 strings', function (assert) {
     var testCases = {
         'RFC2822 datetime with all options but invalid day delimiter': 'Tue. 01 Nov 2016 01:23:45 GMT',
-        'RFC2822 datetime with mismatching Day (week v date)': 'Mon, 01 Nov 2016 01:23:45 GMT'
+        'RFC2822 datetime with mismatching Day (weekday v date)': 'Mon, 01 Nov 2016 01:23:45 GMT'
     };
     var testCase;
 
     for (testCase in testCases) {
         var testResult = moment(testCases[testCase], moment.RFC_2822, true);
-        assert.ok(!testResult.isValid(), testResult);
-        assert.ok(!testResult.parsingFlags().rfc2822, testResult + ' - rfc2822 parsingFlag');
+        assert.ok(!testResult.isValid(), testCase + ': ' + testResult + ' - is invalid rfc2822');
+        assert.ok(!testResult.parsingFlags().rfc2822, testCase + ': ' + testResult + ' - rfc2822 parsingFlag');
     }
 });
 


### PR DESCRIPTION
So here is why:
* tests were completely non-satisfactory, the only thing they tested was whether a given string parses or not
* the fixed timezones (PST, PDT...) were mostly wrongly defined
* UT fixed timezone was not defined in the map (only the regexp)
* (the **big** one) the parsing was completely wrong, the way it relied on `configFromArray`. It did make a lot of sense when you read the code, but what is needed is a UTC parse that goes back to non-utc (if the constructor was non-utc), so I just hardcoded the single line that replaces the whole function call
* (issue with old code) military timezones are basically deprecated (see https://github.com/moment/moment/pull/3938#issuecomment-320764198)