### PR TITLE
[bugfix] Fix day-of-week validation, fixes #4112

### DIFF
--- a/src/lib/create/from-array.js
+++ b/src/lib/create/from-array.js
@@ -80,6 +80,11 @@ export function configFromArray (config) {
     if (config._nextDay) {
         config._a[HOUR] = 24;
     }
+
+    // check for mismatching day of week
+    if (config._w && typeof config._w.d !== 'undefined' && config._w.d !== config._d.getDay()) {
+        getParsingFlags(config).weekdayMismatch = true;
+    }
 }
 
 function dayOfYearFromWeekInfo(config) {

--- a/src/lib/create/valid.js
+++ b/src/lib/create/valid.js
@@ -14,6 +14,7 @@ export function isValid(m) {
             !flags.empty &&
             !flags.invalidMonth &&
             !flags.invalidWeekday &&
+            !flags.weekdayMismatch &&
             !flags.nullInput &&
             !flags.invalidFormat &&
             !flags.userInvalidated &&

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -1225,7 +1225,8 @@ test('k, kk', function (assert) {
 });
 
 test('mismatching day-of-week and date', function (assert) {
-    assert.ok(!moment('Wed 08-10-2017', 'ddd MM-DD-YYYY').isValid(), 'because the day-of-the-week is incorrect for the date');
-    assert.ok(moment('Thu 08-10-2017', 'ddd MM-DD-YYYY').isValid(), 'because the day-of-the-week is correct for the date');
+    // string with format
+    assert.ok(!moment('Wed 08-10-2017', 'ddd MM-DD-YYYY').isValid(), 'because day of week is incorrect for the date');
+    assert.ok(moment('Thu 08-10-2017', 'ddd MM-DD-YYYY').isValid(), 'because day of week is correct for the date');
 });
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -1224,3 +1224,8 @@ test('k, kk', function (assert) {
     }
 });
 
+test('mismatching day-of-week and date', function (assert) {
+    assert.ok(!moment('Wed 08-10-2017', 'ddd MM-DD-YYYY').isValid(), 'because the day-of-the-week is incorrect for the date');
+    assert.ok(moment('Thu 08-10-2017', 'ddd MM-DD-YYYY').isValid(), 'because the day-of-the-week is correct for the date');
+});
+

--- a/src/test/moment/parsing_flags.js
+++ b/src/test/moment/parsing_flags.js
@@ -167,7 +167,7 @@ test('empty format array', function (assert) {
     assert.equal(flags('1982 May', []).invalidFormat, true, 'empty format array');
 });
 
-test('weekday mismatch', function(assert) {
+test('weekday mismatch', function (assert) {
     // string with format
     assert.equal(flags('Wed 08-10-2017', 'ddd MM-DD-YYYY').weekdayMismatch, true, 'day of week does not match date');
     assert.equal(flags('Thu 08-10-2017', 'ddd MM-DD-YYYY').weekdayMismatch, false, 'day of week matches date');

--- a/src/test/moment/parsing_flags.js
+++ b/src/test/moment/parsing_flags.js
@@ -166,3 +166,9 @@ test('empty format array', function (assert) {
     assert.equal(flags('1982 May', ['YYYY MMM']).invalidFormat, false, 'empty format array');
     assert.equal(flags('1982 May', []).invalidFormat, true, 'empty format array');
 });
+
+test('weekday mismatch', function(assert) {
+    // string with format
+    assert.equal(flags('Wed 08-10-2017', 'ddd MM-DD-YYYY').weekdayMismatch, true, 'day of week does not match date');
+    assert.equal(flags('Thu 08-10-2017', 'ddd MM-DD-YYYY').weekdayMismatch, false, 'day of week matches date');
+});


### PR DESCRIPTION
In response to issue #4112, this PR adds in weekday validation for string with format.

I've also added a test for this, since it was mentioned there wasn't one for this case. I wasn't sure if it should have been grouped with an existing test.

Any feedback is appreciated!