### PR TITLE
[locale] it: Remove comma between weekday and date, fixes #4133

### DIFF
--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -17,7 +17,7 @@ export default moment.defineLocale('it', {
         L : 'DD/MM/YYYY',
         LL : 'D MMMM YYYY',
         LLL : 'D MMMM YYYY HH:mm',
-        LLLL : 'dddd, D MMMM YYYY HH:mm'
+        LLLL : 'dddd D MMMM YYYY HH:mm'
     },
     calendar : {
         sameDay: '[Oggi alle] LT',

--- a/src/test/locale/it.js
+++ b/src/test/locale/it.js
@@ -40,11 +40,11 @@ test('format', function (assert) {
             ['L',                                  '14/02/2010'],
             ['LL',                                 '14 febbraio 2010'],
             ['LLL',                                '14 febbraio 2010 15:25'],
-            ['LLLL',                               'domenica, 14 febbraio 2010 15:25'],
+            ['LLLL',                               'domenica 14 febbraio 2010 15:25'],
             ['l',                                  '14/2/2010'],
             ['ll',                                 '14 feb 2010'],
             ['lll',                                '14 feb 2010 15:25'],
-            ['llll',                               'dom, 14 feb 2010 15:25']
+            ['llll',                               'dom 14 feb 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;


### PR DESCRIPTION
As described in issue #4133, there shouldn't be a comma between weekday and date in Italian locale.

I've checked this by comparing the output of:
```js
Intl.DateTimeFormat("it", {
  weekday: "long",
  day: "numeric",
  month: "long",
  year: "numeric",
  hour: "2-digit",
  minute: "2-digit"
}).format(new Date());
// "sabato 19 agosto 2017, 15:55"
```

(I've not addressed the fact that the browser-native `Intl` implementation puts a comma between the date and time as I'm not sure if moment is trying to mimic `Intl` functionality - and commas in that position are also missing in other locales - e.g. `de`, `en-us`, `en-gb`...)