### PR TITLE
[locale] lv: Avoid trailing dot after short date, fixes #4136

### DIFF
--- a/src/locale/lv.js
+++ b/src/locale/lv.js
@@ -50,7 +50,7 @@ export default moment.defineLocale('lv', {
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',
-        L : 'DD.MM.YYYY.',
+        L : 'DD.MM.YYYY',
         LL : 'YYYY. [gada] D. MMMM',
         LLL : 'YYYY. [gada] D. MMMM, HH:mm',
         LLLL : 'YYYY. [gada] D. MMMM, dddd, HH:mm'

--- a/src/test/locale/lv.js
+++ b/src/test/locale/lv.js
@@ -37,11 +37,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14.02.2010.'],
+            ['L',                                  '14.02.2010'],
             ['LL',                                 '2010. gada 14. februāris'],
             ['LLL',                                '2010. gada 14. februāris, 15:25'],
             ['LLLL',                               '2010. gada 14. februāris, svētdiena, 15:25'],
-            ['l',                                  '14.2.2010.'],
+            ['l',                                  '14.2.2010'],
             ['ll',                                 '2010. gada 14. feb'],
             ['lll',                                '2010. gada 14. feb, 15:25'],
             ['llll',                               '2010. gada 14. feb, Sv, 15:25']


### PR DESCRIPTION
As reported, and confirmed with:
```js
Intl.DateTimeFormat("lv", {
  day: "2-digit",
  month: "2-digit",
  year: "numeric",
}).format(new Date());
// "21.08.2017"
```
