### PR TITLE
Fix #4145: floating-point errors in ISO duration format

### DIFF
--- a/src/lib/duration/iso-string.js
+++ b/src/lib/duration/iso-string.js
@@ -1,5 +1,4 @@
 import absFloor from '../utils/abs-floor';
-import zeroFill from '../utils/zero-fill';
 var abs = Math.abs;
 
 export function toISOString() {
@@ -14,8 +13,7 @@ export function toISOString() {
         return this.localeData().invalidDate();
     }
 
-    var milliseconds = abs(this._milliseconds);
-    var seconds      = absFloor(milliseconds / 1000);
+    var seconds = abs(this._milliseconds) / 1000;
     var days         = abs(this._days);
     var months       = abs(this._months);
     var minutes, hours, years;
@@ -23,7 +21,6 @@ export function toISOString() {
     // 3600 seconds -> 60 minutes -> 1 hour
     minutes           = absFloor(seconds / 60);
     hours             = absFloor(minutes / 60);
-    milliseconds %= 1000;
     seconds %= 60;
     minutes %= 60;
 
@@ -38,7 +35,7 @@ export function toISOString() {
     var D = days;
     var h = hours;
     var m = minutes;
-    var s = (seconds || milliseconds) ? seconds + (milliseconds ? '.' + zeroFill(milliseconds, 3).replace(/0+$/, '') : '') : '';
+    var s = seconds ? seconds.toFixed(3).replace(/\.?0+$/, '') : '';
     var total = this.asSeconds();
 
     if (!total) {

--- a/src/lib/duration/iso-string.js
+++ b/src/lib/duration/iso-string.js
@@ -13,7 +13,8 @@ export function toISOString() {
         return this.localeData().invalidDate();
     }
 
-    var seconds = abs(this._milliseconds) / 1000;
+    var milliseconds = abs(this._milliseconds);
+    var seconds      = absFloor(milliseconds / 1000);
     var days         = abs(this._days);
     var months       = abs(this._months);
     var minutes, hours, years;
@@ -22,6 +23,7 @@ export function toISOString() {
     minutes           = absFloor(seconds / 60);
     hours             = absFloor(minutes / 60);
     seconds %= 60;
+    seconds += (milliseconds % 1000) / 1000;
     minutes %= 60;
 
     // 12 months -> 1 year

--- a/src/lib/duration/iso-string.js
+++ b/src/lib/duration/iso-string.js
@@ -1,4 +1,5 @@
 import absFloor from '../utils/abs-floor';
+import zeroFill from '../utils/zero-fill';
 var abs = Math.abs;
 
 export function toISOString() {
@@ -22,8 +23,8 @@ export function toISOString() {
     // 3600 seconds -> 60 minutes -> 1 hour
     minutes           = absFloor(seconds / 60);
     hours             = absFloor(minutes / 60);
+    milliseconds %= 1000;
     seconds %= 60;
-    seconds += (milliseconds % 1000) / 1000;
     minutes %= 60;
 
     // 12 months -> 1 year
@@ -37,7 +38,7 @@ export function toISOString() {
     var D = days;
     var h = hours;
     var m = minutes;
-    var s = seconds;
+    var s = (seconds || milliseconds) ? seconds + (milliseconds ? '.' + zeroFill(milliseconds, 3).replace(/0+$/, '') : '') : '';
     var total = this.asSeconds();
 
     if (!total) {

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -336,6 +336,7 @@ test('serialization to ISO 8601 duration strings', function (assert) {
     assert.equal(moment.duration({y: +1, M: 1}).toISOString(), 'P1Y1M', 'a month after a year in future');
     assert.equal(moment.duration({}).toISOString(), 'P0D', 'zero duration');
     assert.equal(moment.duration({M: 16, d:40, s: 86465}).toISOString(), 'P1Y4M40DT24H1M5S', 'all fields');
+    assert.equal(moment.duration({ms: 123456789}).toISOString(), 'PT34H17M36.789S', 'check floating-point errors');
 });
 
 test('toString acts as toISOString', function (assert) {

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -337,6 +337,7 @@ test('serialization to ISO 8601 duration strings', function (assert) {
     assert.equal(moment.duration({}).toISOString(), 'P0D', 'zero duration');
     assert.equal(moment.duration({M: 16, d:40, s: 86465}).toISOString(), 'P1Y4M40DT24H1M5S', 'all fields');
     assert.equal(moment.duration({ms: 123456789}).toISOString(), 'PT34H17M36.789S', 'check floating-point errors');
+    assert.equal(moment.duration({ms: 31952}).toISOString(), 'PT31.952S', 'check floating-point errors');
 });
 
 test('toString acts as toISOString', function (assert) {


### PR DESCRIPTION
Avoid a floating-point error during millisecond -> second conversion when formatting duration in ISO format.

Floating-point error is easy to trigger:
```js
console.log(String((123456789 / 1000) % 60));
```