### PR TITLE
Add support for consuming typings in global scope

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -711,3 +711,4 @@ declare namespace moment {
 }
 
 export = moment;
+export as namespace moment;


### PR DESCRIPTION
From (I think) TypeScript 2.1+ the recommended export formula for libraries which support UMD is to use the `export as namespace` structure. Without this, one cannot use the typed `moment` global variable. See this as a reference: https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#support-for-umd-module-definitions