### PR TITLE
4024: fix incorrect date when changing year from leap to normal

### DIFF
--- a/src/lib/moment/get-set.js
+++ b/src/lib/moment/get-set.js
@@ -1,5 +1,6 @@
 import { normalizeUnits, normalizeObjectUnits } from '../units/aliases';
 import { getPrioritizedUnits } from '../units/priorities';
+import { isLeapYear } from '../units/year';
 import { hooks } from '../utils/hooks';
 import isFunction from '../utils/is-function';
 
@@ -22,6 +23,9 @@ export function get (mom, unit) {
 
 export function set (mom, unit, value) {
     if (mom.isValid() && !isNaN(value)) {
+        if (unit === 'FullYear' && mom._d.getMonth() === 1 && mom._d.getDate() === 29) {
+            mom._d.setDate(isLeapYear(value) ? 29 : 28);
+        }
         mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value);
     }
 }

--- a/src/test/moment/getters_setters.js
+++ b/src/test/moment/getters_setters.js
@@ -368,3 +368,20 @@ test('setters across DST -1', function (assert) {
 
     moment.updateOffset = oldUpdateOffset;
 });
+
+test('year setter', (assert) => {
+    // Normal year
+    var m = moment('2013-07-09T00:00:00+11:00').parseZone();
+    m.year(2017);
+    assert.equal(m.format(), '2017-07-09T00:00:00+11:00');
+
+    // Leap year at Feb 29, changing to normal year
+    m = moment('2012-02-29T00:00:00+11:00').parseZone();
+    m.year(2017);
+    assert.equal(m.format(), '2017-02-28T00:00:00+11:00');
+
+    // Leap year at Feb 29, changing to another leap year
+    m = moment('2012-02-29T00:00:00+11:00').parseZone();
+    m.year(2020);
+    assert.equal(m.format(), '2020-02-29T00:00:00+11:00');
+});


### PR DESCRIPTION
This is the fix for https://github.com/moment/moment/issues/4024

Changes:
If date is `29/02/xxxx`, in which `xxxx` is a leap year, then:

- when changing year to a normal year, the date should become `28/02/yyyy`
- when changing to a leap year, the date should become `29/02/zzzz`