### PR TITLE
[feature] add format constants to support output to HTML5 input type formats (see #3928)

### DIFF
--- a/src/moment.js
+++ b/src/moment.js
@@ -79,4 +79,17 @@ moment.relativeTimeThreshold = relativeTimeThreshold;
 moment.calendarFormat        = getCalendarFormat;
 moment.prototype             = fn;
 
+// currently HTML5 input type only supports 24-hour formats
+moment.HTML5_FMT = {
+    DATETIME_LOCAL: 'YYYY-MM-DDTHH:mm',             // <input type="datetime-local" />
+    DATETIME_LOCAL_SECONDS: 'YYYY-MM-DDTHH:mm:ss',  // <input type="datetime-local" step="1" />
+    DATETIME_LOCAL_MS: 'YYYY-MM-DDTHH:mm:ss.SSS',   // <input type="datetime-local" step="0.001" />
+    DATE: 'YYYY-MM-DD',                             // <input type="date" />
+    TIME: 'HH:mm',                                  // <input type="time" />
+    TIME_SECONDS: 'HH:mm:ss',                       // <input type="time" step="1" />
+    TIME_MS: 'HH:mm:ss.SSS',                        // <input type="time" step="0.001" />
+    WEEK: 'YYYY-[W]WW',                             // <input type="week" />
+    MONTH: 'YYYY-MM'                                // <input type="month" />
+};
+
 export default moment;

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -4,6 +4,19 @@ import moment from '../../moment';
 
 module('format');
 
+test('format using constants', function (assert) {
+    var m = moment('2017-09-01T23:40:40.678');
+    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL), '2017-09-01T23:40', 'datetime local format constant');
+    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS), '2017-09-01T23:40:40', 'datetime local format constant');
+    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL_MS), '2017-09-01T23:40:40.678', 'datetime local format constant with seconds and millis');
+    assert.equal(m.format(moment.HTML5_FMT.DATE), '2017-09-01', 'date format constant');
+    assert.equal(m.format(moment.HTML5_FMT.TIME), '23:40', 'time format constant');
+    assert.equal(m.format(moment.HTML5_FMT.TIME_SECONDS), '23:40:40', 'time format constant with seconds');
+    assert.equal(m.format(moment.HTML5_FMT.TIME_MS), '23:40:40.678', 'time format constant with seconds and millis');
+    assert.equal(m.format(moment.HTML5_FMT.WEEK), '2017-W35', 'week format constant');
+    assert.equal(m.format(moment.HTML5_FMT.MONTH), '2017-09', 'month format constant');
+});
+
 test('format YY', function (assert) {
     var b = moment(new Date(2009, 1, 14, 15, 25, 50, 125));
     assert.equal(b.format('YY'), '09', 'YY ---> 09');


### PR DESCRIPTION
This is an updated version of https://github.com/moment/moment/pull/4009 since it has become stale

fixes https://github.com/moment/moment/issues/3928

Changes:
Added format constants to be used when formatting a moment object to a string that HTML5 input can use, as specified in https://www.w3schools.com/html/html_form_input_types.asp

Supports the following types

- `datetime-local`
- `date`
- `time`
- `week`
- `month`