### PR TITLE
Enhancing parsing ISO string with ignorable canonical zone ID. Resolves #4159

### DIFF
--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -9,7 +9,7 @@ import {defaultLocaleWeekdaysShort} from '../units/day-of-week';
 
 // iso 8601 regex
 // 0000-00-00 0000-W00 or 0000-W00-0 + T + 00 or 00:00 or 00:00:00 or 00:00:00.000 + +00:00 or +0000 or +00)
-var extendedIsoRegex = /^\s*((?:[+-]\d{6}|\d{4})-(?:\d\d-\d\d|W\d\d-\d|W\d\d|\d\d\d|\d\d))(?:(T| )(\d\d(?::\d\d(?::\d\d(?:[.,]\d+)?)?)?)([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?$/;
+var extendedIsoRegex = /^\s*((?:[+-]\d{6}|\d{4})-(?:\d\d-\d\d|W\d\d-\d|W\d\d|\d\d\d|\d\d))(?:(T| )(\d\d(?::\d\d(?::\d\d(?:[.,]\d+)?)?)?)([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?(?:\[[\w\/\+\-\d]*\])?$/;
 var basicIsoRegex = /^\s*((?:[+-]\d{6}|\d{4})(?:\d\d\d\d|W\d\d\d|W\d\d|\d\d\d|\d\d))(?:(T| )(\d\d(?:\d\d(?:\d\d(?:[.,]\d+)?)?)?)([\+\-]\d\d(?::?\d\d)?|\s*Z)?)?$/;
 
 var tzRegex = /Z|[+-]\d\d(?::?\d\d)?/;

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -864,6 +864,20 @@ test('parsing iso Z timezone into local', function (assert) {
     assert.equal(m.utc().format('YYYY-MM-DDTHH:mm:ss.SSS'), '2011-10-08T18:04:20.111', 'moment should be able to parse ISO 2011-10-08T18:04:20.111Z');
 });
 
+test('iso strings with optional (ignorable) Canonical Zone ID', function (assert) {
+    var i, formats = [
+        ['2011-10-08T18:04:20-12:00[Etc/GMT+12]',                    '2011-10-09T06:04:20.000'],
+        ['2011-10-08T18:04:20.1-06:00[America/Indiana/Tell_City]',   '2011-10-09T00:04:20.100'],
+        ['2011-10-08T18:04:20.11+01:00[Etc/GMT-1]',                  '2011-10-08T17:04:20.110'],
+        ['2011-10-08T18:04:20.111+01:00[CET]',                       '2011-10-08T17:04:20.111']
+    ];
+
+    for (i = 0; i < formats.length; i++) {
+        assert.equal(moment(formats[i][0]).utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+            formats[i][1], 'moment should be able to parse ISO ' + formats[i][0]);
+    }
+});
+
 test('parsing iso with more subsecond precision digits', function (assert) {
     assert.equal(moment.utc('2013-07-31T22:00:00.0000000Z').format(), '2013-07-31T22:00:00Z', 'more than 3 subsecond digits');
 });


### PR DESCRIPTION
Adding support for ignorable Canonical Zone ID ISO string parsing so that
```javascript
    var moment = require('moment') 
    var mom = moment('2007-12-03T10:15:30+01:00[Europe/Paris]');
```
can be also properly handled by _moment.js_.