### PR TITLE
Fixed german locales

### DIFF
--- a/locale/de-at.js
+++ b/locale/de-at.js
@@ -19,7 +19,7 @@ function processRelativeTime(number, withoutSuffix, key, isFuture) {
         'h': ['eine Stunde', 'einer Stunde'],
         'd': ['ein Tag', 'einem Tag'],
         'dd': [number + ' Tage', number + ' Tagen'],
-        'M': ['ein Monat', 'einem Monat'],
+        'M': ['einen Monat', 'einem Monat'],
         'MM': [number + ' Monate', number + ' Monaten'],
         'y': ['ein Jahr', 'einem Jahr'],
         'yy': [number + ' Jahre', number + ' Jahren']

--- a/locale/de-ch.js
+++ b/locale/de-ch.js
@@ -18,7 +18,7 @@ function processRelativeTime(number, withoutSuffix, key, isFuture) {
         'h': ['eine Stunde', 'einer Stunde'],
         'd': ['ein Tag', 'einem Tag'],
         'dd': [number + ' Tage', number + ' Tagen'],
-        'M': ['ein Monat', 'einem Monat'],
+        'M': ['einen Monat', 'einem Monat'],
         'MM': [number + ' Monate', number + ' Monaten'],
         'y': ['ein Jahr', 'einem Jahr'],
         'yy': [number + ' Jahre', number + ' Jahren']

--- a/locale/de.js
+++ b/locale/de.js
@@ -18,7 +18,7 @@ function processRelativeTime(number, withoutSuffix, key, isFuture) {
         'h': ['eine Stunde', 'einer Stunde'],
         'd': ['ein Tag', 'einem Tag'],
         'dd': [number + ' Tage', number + ' Tagen'],
-        'M': ['ein Monat', 'einem Monat'],
+        'M': ['einen Monat', 'einem Monat'],
         'MM': [number + ' Monate', number + ' Monaten'],
         'y': ['ein Jahr', 'einem Jahr'],
         'yy': [number + ' Jahre', number + ' Jahren']


### PR DESCRIPTION
Fixed german translation for "ein Monat" (to "einen Monat") in all three german translations. Can you approve this, @lluchs? 