### PR TITLE
[bugfix] fix(local_update): normalize locale name on updating locale

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -141,6 +141,7 @@ export function defineLocale (name, config) {
 }
 
 export function updateLocale(name, config) {
+    name = normalizeLocale(name);
     if (config != null) {
         var locale, tmpLocale, parentConfig = baseConfig;
         // MERGE

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -194,7 +194,12 @@ export function getLocale (key) {
         key = [key];
     }
 
-    return chooseLocale(key.map(normalizeLocale));
+    var normalizedKey = [];
+    for (var i = 0; i < key.length; i++) {
+        normalizedKey.push(normalizeLocale(key[i]));
+    }
+
+    return chooseLocale(normalizedKey);
 }
 
 export function listLocales() {

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -25,9 +25,9 @@ function chooseLocale(names) {
     var i = 0, j, next, locale, split;
 
     while (i < names.length) {
-        split = normalizeLocale(names[i]).split('-');
+        split = names[i].split('-');
         j = split.length;
-        next = normalizeLocale(names[i + 1]);
+        next = names[i + 1];
         next = next ? next.split('-') : null;
         while (j > 0) {
             locale = loadLocale(split.slice(0, j).join('-'));
@@ -194,7 +194,7 @@ export function getLocale (key) {
         key = [key];
     }
 
-    return chooseLocale(key);
+    return chooseLocale(key.map(normalizeLocale));
 }
 
 export function listLocales() {

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -89,6 +89,7 @@ export function getSetGlobalLocale (key, values) {
 }
 
 export function defineLocale (name, config) {
+    name = normalizeLocale(name);
     if (config !== null) {
         var locale, parentConfig = baseConfig;
         config.abbr = name;

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -188,13 +188,13 @@ test('normalize local name', function (assert) {
     moment.defineLocale('duration-1', {
         relativeTime: {
             s : 'a few seconds',
-            ss : '%d Seconds',
+            ss : '%d Seconds'
         }
     });
     moment.locale('Duration_1');
     moment.updateLocale('Duration_1', {
         relativeTime: {
-            s : 'A few seconds',
+            s : 'A few seconds'
         }
     });
     var start = moment([2007, 1, 28]);

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -182,3 +182,46 @@ test('reset locale', function (assert) {
     moment.updateLocale('de', null);
     assert.equal(moment('2017-02-01').format('YYYY MMM MMMM'), resultBeforeUpdate);
 });
+
+test('duration', function (assert) {
+    moment.defineLocale("duration-1", null);
+    moment.defineLocale("duration-1", {
+        relativeTime: {
+            s : 'a few seconds',
+            ss : '%d Seconds',
+            m : 'a minute',
+            mm : '%d Minutes',
+            h : 'an hour',
+            hh : '%d Hours',
+            d : 'a day',
+            dd : '%d Days',
+            M : 'a month',
+            MM : '%d Months',
+            y : 'a year',
+            yy : '%d Years'
+        }
+    });
+    moment.locale("Duration_1");
+    moment.updateLocale("Duration_1", {
+        relativeTime: {
+            s : 'A few seconds',
+            m : 'A minute',
+            h : 'An hour',
+            d : 'A day',
+            M : 'A month',
+            y : 'A year',
+        }
+    });
+    assert.ok(moment().add({s: 5}).fromNow(), "A few seconds", "s uses child");
+    assert.ok(moment().add({s: 50}).fromNow(), "50 Seconds", "ss uses base");
+    assert.ok(moment().add({m: 1}).fromNow(), "A minute", "m uses child");
+    assert.ok(moment().add({m: 50}).fromNow(), "50 Minutes", "mm uses base");
+    assert.ok(moment().add({h: 1}).fromNow(), "An hour", "h uses child");
+    assert.ok(moment().add({h: 20}).fromNow(), "20 Hours", "hh uses base");
+    assert.ok(moment().add({d: 1}).fromNow(), "A day", "d uses child");
+    assert.ok(moment().add({d: 20}).fromNow(), "20 Days", "dd uses base");
+    assert.ok(moment().add({M: 1}).fromNow(), "A Month", "M uses child");
+    assert.ok(moment().add({M: 10}).fromNow(), "10 Months", "MM uses base");
+    assert.ok(moment().add({y: 1}).fromNow(), "A year", "y uses child");
+    assert.ok(moment().add({y: 10}).fromNow(), "10 Years", "yy uses base");
+});

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -183,7 +183,7 @@ test('reset locale', function (assert) {
     assert.equal(moment('2017-02-01').format('YYYY MMM MMMM'), resultBeforeUpdate);
 });
 
-test('duration', function (assert) {
+test('from', function (assert) {
     moment.defineLocale('duration-1', null);
     moment.defineLocale('duration-1', {
         relativeTime: {
@@ -212,16 +212,19 @@ test('duration', function (assert) {
             y : 'A year'
         }
     });
-    assert.ok(moment().add({s: 5}).fromNow(), 'A few seconds', 's uses child');
-    assert.ok(moment().add({s: 50}).fromNow(), '50 Seconds', 'ss uses base');
-    assert.ok(moment().add({m: 1}).fromNow(), 'A minute', 'm uses child');
-    assert.ok(moment().add({m: 50}).fromNow(), '50 Minutes', 'mm uses base');
-    assert.ok(moment().add({h: 1}).fromNow(), 'An hour', 'h uses child');
-    assert.ok(moment().add({h: 20}).fromNow(), '20 Hours', 'hh uses base');
-    assert.ok(moment().add({d: 1}).fromNow(), 'A day', 'd uses child');
-    assert.ok(moment().add({d: 20}).fromNow(), '20 Days', 'dd uses base');
-    assert.ok(moment().add({M: 1}).fromNow(), 'A Month', 'M uses child');
-    assert.ok(moment().add({M: 10}).fromNow(), '10 Months', 'MM uses base');
-    assert.ok(moment().add({y: 1}).fromNow(), 'A year', 'y uses child');
-    assert.ok(moment().add({y: 10}).fromNow(), '10 Years', 'yy uses base');
+    var start = moment([2007, 1, 28]);
+    moment.relativeTimeThreshold('ss', 3);
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 3}), true), 'A few seconds', 's uses child');
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true), '44 Seconds', 'ss uses base');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 1}), true), 'A minute', 'm uses child');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 30}), true), '30 Minutes', 'mm uses base');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 1}), true), 'An hour', 'h uses child');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 20}), true), '20 Hours', 'hh uses base');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 1}), true), 'A day', 'd uses child');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 20}), true), '20 Days', 'dd uses base');
+    assert.equal(start.from(moment([2007, 1, 28]).add({M: 1}), true), 'A month', 'M uses child');
+    assert.equal(start.from(moment([2007, 1, 28]).add({M: 10}), true), '10 Months', 'MM uses base');
+    assert.equal(start.from(moment([2007, 1, 28]).add({y: 1}), true), 'A year', 'y uses child');
+    assert.equal(start.from(moment([2007, 1, 28]).add({y: 10}), true), '10 Years', 'yy uses base');
+    moment.relativeTimeThreshold('ss', 44);
 });

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -184,22 +184,28 @@ test('reset locale', function (assert) {
 });
 
 test('normalize local name', function (assert) {
-    moment.defineLocale('duration-1', null);
-    moment.defineLocale('duration-1', {
+    moment.defineLocale('custom-locale-1', null);
+    moment.defineLocale('custom-locale-1', {
         relativeTime: {
             s : 'a few seconds',
             ss : '%d Seconds'
         }
     });
-    moment.locale('Duration_1');
-    moment.updateLocale('Duration_1', {
+    // it should load custom-locale-1
+    moment.locale('Custom-locale_1');
+    moment.updateLocale('Custom-locale_1', {
         relativeTime: {
             s : 'A few seconds'
         }
     });
     var start = moment([2007, 1, 28]);
+
+    const previousThreshold = moment.relativeTimeThreshold('ss');
+
     moment.relativeTimeThreshold('ss', 3);
     assert.equal(start.from(moment([2007, 1, 28]).add({s: 3}), true), 'A few seconds', 's uses child');
-    assert.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true), '44 Seconds', 'ss uses base');
-    moment.relativeTimeThreshold('ss', 44);
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: previousThreshold}), true), '44 Seconds', 'ss uses base');
+
+    // tear down
+    moment.relativeTimeThreshold('ss', previousThreshold);
 });

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -184,8 +184,8 @@ test('reset locale', function (assert) {
 });
 
 test('duration', function (assert) {
-    moment.defineLocale("duration-1", null);
-    moment.defineLocale("duration-1", {
+    moment.defineLocale('duration-1', null);
+    moment.defineLocale('duration-1', {
         relativeTime: {
             s : 'a few seconds',
             ss : '%d Seconds',
@@ -201,27 +201,27 @@ test('duration', function (assert) {
             yy : '%d Years'
         }
     });
-    moment.locale("Duration_1");
-    moment.updateLocale("Duration_1", {
+    moment.locale('Duration_1');
+    moment.updateLocale('Duration_1', {
         relativeTime: {
             s : 'A few seconds',
             m : 'A minute',
             h : 'An hour',
             d : 'A day',
             M : 'A month',
-            y : 'A year',
+            y : 'A year'
         }
     });
-    assert.ok(moment().add({s: 5}).fromNow(), "A few seconds", "s uses child");
-    assert.ok(moment().add({s: 50}).fromNow(), "50 Seconds", "ss uses base");
-    assert.ok(moment().add({m: 1}).fromNow(), "A minute", "m uses child");
-    assert.ok(moment().add({m: 50}).fromNow(), "50 Minutes", "mm uses base");
-    assert.ok(moment().add({h: 1}).fromNow(), "An hour", "h uses child");
-    assert.ok(moment().add({h: 20}).fromNow(), "20 Hours", "hh uses base");
-    assert.ok(moment().add({d: 1}).fromNow(), "A day", "d uses child");
-    assert.ok(moment().add({d: 20}).fromNow(), "20 Days", "dd uses base");
-    assert.ok(moment().add({M: 1}).fromNow(), "A Month", "M uses child");
-    assert.ok(moment().add({M: 10}).fromNow(), "10 Months", "MM uses base");
-    assert.ok(moment().add({y: 1}).fromNow(), "A year", "y uses child");
-    assert.ok(moment().add({y: 10}).fromNow(), "10 Years", "yy uses base");
+    assert.ok(moment().add({s: 5}).fromNow(), 'A few seconds', 's uses child');
+    assert.ok(moment().add({s: 50}).fromNow(), '50 Seconds', 'ss uses base');
+    assert.ok(moment().add({m: 1}).fromNow(), 'A minute', 'm uses child');
+    assert.ok(moment().add({m: 50}).fromNow(), '50 Minutes', 'mm uses base');
+    assert.ok(moment().add({h: 1}).fromNow(), 'An hour', 'h uses child');
+    assert.ok(moment().add({h: 20}).fromNow(), '20 Hours', 'hh uses base');
+    assert.ok(moment().add({d: 1}).fromNow(), 'A day', 'd uses child');
+    assert.ok(moment().add({d: 20}).fromNow(), '20 Days', 'dd uses base');
+    assert.ok(moment().add({M: 1}).fromNow(), 'A Month', 'M uses child');
+    assert.ok(moment().add({M: 10}).fromNow(), '10 Months', 'MM uses base');
+    assert.ok(moment().add({y: 1}).fromNow(), 'A year', 'y uses child');
+    assert.ok(moment().add({y: 10}).fromNow(), '10 Years', 'yy uses base');
 });

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -183,48 +183,23 @@ test('reset locale', function (assert) {
     assert.equal(moment('2017-02-01').format('YYYY MMM MMMM'), resultBeforeUpdate);
 });
 
-test('from', function (assert) {
+test('normalize local name', function (assert) {
     moment.defineLocale('duration-1', null);
     moment.defineLocale('duration-1', {
         relativeTime: {
             s : 'a few seconds',
             ss : '%d Seconds',
-            m : 'a minute',
-            mm : '%d Minutes',
-            h : 'an hour',
-            hh : '%d Hours',
-            d : 'a day',
-            dd : '%d Days',
-            M : 'a month',
-            MM : '%d Months',
-            y : 'a year',
-            yy : '%d Years'
         }
     });
     moment.locale('Duration_1');
     moment.updateLocale('Duration_1', {
         relativeTime: {
             s : 'A few seconds',
-            m : 'A minute',
-            h : 'An hour',
-            d : 'A day',
-            M : 'A month',
-            y : 'A year'
         }
     });
     var start = moment([2007, 1, 28]);
     moment.relativeTimeThreshold('ss', 3);
     assert.equal(start.from(moment([2007, 1, 28]).add({s: 3}), true), 'A few seconds', 's uses child');
     assert.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true), '44 Seconds', 'ss uses base');
-    assert.equal(start.from(moment([2007, 1, 28]).add({m: 1}), true), 'A minute', 'm uses child');
-    assert.equal(start.from(moment([2007, 1, 28]).add({m: 30}), true), '30 Minutes', 'mm uses base');
-    assert.equal(start.from(moment([2007, 1, 28]).add({h: 1}), true), 'An hour', 'h uses child');
-    assert.equal(start.from(moment([2007, 1, 28]).add({h: 20}), true), '20 Hours', 'hh uses base');
-    assert.equal(start.from(moment([2007, 1, 28]).add({d: 1}), true), 'A day', 'd uses child');
-    assert.equal(start.from(moment([2007, 1, 28]).add({d: 20}), true), '20 Days', 'dd uses base');
-    assert.equal(start.from(moment([2007, 1, 28]).add({M: 1}), true), 'A month', 'M uses child');
-    assert.equal(start.from(moment([2007, 1, 28]).add({M: 10}), true), '10 Months', 'MM uses base');
-    assert.equal(start.from(moment([2007, 1, 28]).add({y: 1}), true), 'A year', 'y uses child');
-    assert.equal(start.from(moment([2007, 1, 28]).add({y: 10}), true), '10 Years', 'yy uses base');
     moment.relativeTimeThreshold('ss', 44);
 });


### PR DESCRIPTION
This PR fixes a bug in `fromNow` when unnormalized locale name is used in `updateLocale`.