### PR TITLE
Allow compilation without dynamic requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     ],
     "main": "./moment.js",
     "module": "./src/moment.js",
+    "react-native": "./src/moment-core.js",
     "typings": "./moment.d.ts",
     "engines": {
         "node": "*"

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -45,7 +45,7 @@ function chooseLocale(names) {
     return null;
 }
 
-var requireLocale = function() {};
+var requireLocale = function () {};
 
 export function setLocaleLoader(fn) {
     requireLocale = fn;

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -45,22 +45,19 @@ function chooseLocale(names) {
     return null;
 }
 
+var requireLocale = function() {};
+
+export function setLocaleLoader(fn) {
+    requireLocale = fn;
+}
+
 function loadLocale(name) {
     var oldLocale = null;
     // TODO: Find a better way to register and load all the locales in Node
     if (!locales[name] && (typeof module !== 'undefined') &&
             module && module.exports) {
         oldLocale = globalLocale._abbr;
-        try {
-            require('moment/locale/' + name);
-        } catch (e) {
-            // In the test environment, the external module 'moment'
-            // can't be resolved because we're running inside it.
-            // Fallback to using the old relative import
-            try {
-                require('./locale/' + name);
-            } catch (e) { }
-        }
+        requireLocale(name);
 
         // because defineLocale currently also sets the global locale, we
         // want to undo that for lazy loaded locales

--- a/src/locale/af.js
+++ b/src/locale/af.js
@@ -2,7 +2,7 @@
 //! locale : Afrikaans [af]
 //! author : Werner Mollentze : https://github.com/wernerm
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('af', {
     months : 'Januarie_Februarie_Maart_April_Mei_Junie_Julie_Augustus_September_Oktober_November_Desember'.split('_'),

--- a/src/locale/ar-dz.js
+++ b/src/locale/ar-dz.js
@@ -2,7 +2,7 @@
 //! locale : Arabic (Algeria) [ar-dz]
 //! author : Noureddine LOUAHEDJ : https://github.com/noureddineme
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ar-dz', {
     months : 'جانفي_فيفري_مارس_أفريل_ماي_جوان_جويلية_أوت_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),

--- a/src/locale/ar-kw.js
+++ b/src/locale/ar-kw.js
@@ -2,7 +2,7 @@
 //! locale : Arabic (Kuwait) [ar-kw]
 //! author : Nusret Parlak: https://github.com/nusretparlak
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ar-kw', {
     months : 'يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر'.split('_'),

--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -2,7 +2,7 @@
 //! locale : Arabic (Lybia) [ar-ly]
 //! author : Ali Hmer: https://github.com/kikoanis
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '1',

--- a/src/locale/ar-ma.js
+++ b/src/locale/ar-ma.js
@@ -3,7 +3,7 @@
 //! author : ElFadili Yassine : https://github.com/ElFadiliY
 //! author : Abdel Said : https://github.com/abdelsaid
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ar-ma', {
     months : 'يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر'.split('_'),

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -2,7 +2,7 @@
 //! locale : Arabic (Saudi Arabia) [ar-sa]
 //! author : Suhail Alkowaileet : https://github.com/xsoh
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '١',

--- a/src/locale/ar-tn.js
+++ b/src/locale/ar-tn.js
@@ -2,7 +2,7 @@
 //! locale  :  Arabic (Tunisia) [ar-tn]
 //! author : Nader Toukabri : https://github.com/naderio
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ar-tn', {
     months: 'جانفي_فيفري_مارس_أفريل_ماي_جوان_جويلية_أوت_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split('_'),

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -4,7 +4,7 @@
 //! author : Ahmed Elkhatib
 //! author : forabi https://github.com/forabi
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '١',

--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -2,7 +2,7 @@
 //! locale : Azerbaijani [az]
 //! author : topchiyev : https://github.com/topchiyev
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var suffixes = {
     1: '-inci',

--- a/src/locale/be.js
+++ b/src/locale/be.js
@@ -4,7 +4,7 @@
 //! author: Praleska: http://praleska.pro/
 //! Author : Menelion Elensúle : https://github.com/Oire
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function plural(word, num) {
     var forms = word.split('_');

--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -2,7 +2,7 @@
 //! locale : Bulgarian [bg]
 //! author : Krasen Borisov : https://github.com/kraz
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('bg', {
     months : 'януари_февруари_март_април_май_юни_юли_август_септември_октомври_ноември_декември'.split('_'),

--- a/src/locale/bm.js
+++ b/src/locale/bm.js
@@ -3,7 +3,7 @@
 //! author : Estelle Comment : https://github.com/estellecomment
 // Language contact person : Abdoufata Kane : https://github.com/abdoufata
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('bm', {
     months : 'Zanwuyekalo_Fewuruyekalo_Marisikalo_Awirilikalo_Mɛkalo_Zuwɛnkalo_Zuluyekalo_Utikalo_Sɛtanburukalo_ɔkutɔburukalo_Nowanburukalo_Desanburukalo'.split('_'),

--- a/src/locale/bn.js
+++ b/src/locale/bn.js
@@ -2,7 +2,7 @@
 //! locale : Bengali [bn]
 //! author : Kaushik Gandhi : https://github.com/kaushikgandhi
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '১',

--- a/src/locale/bo.js
+++ b/src/locale/bo.js
@@ -2,7 +2,7 @@
 //! locale : Tibetan [bo]
 //! author : Thupten N. Chakrishar : https://github.com/vajradog
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '༡',

--- a/src/locale/br.js
+++ b/src/locale/br.js
@@ -2,7 +2,7 @@
 //! locale : Breton [br]
 //! author : Jean-Baptiste Le Duigou : https://github.com/jbleduigou
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function relativeTimeWithMutation(number, withoutSuffix, key) {
     var format = {

--- a/src/locale/bs.js
+++ b/src/locale/bs.js
@@ -3,7 +3,7 @@
 //! author : Nedim Cholich : https://github.com/frontyard
 //! based on (hr) translation by Bojan Marković
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function translate(number, withoutSuffix, key) {
     var result = number + ' ';

--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -2,7 +2,7 @@
 //! locale : Catalan [ca]
 //! author : Juan G. Hurtado : https://github.com/juanghurtado
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ca', {
     months : {

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -2,7 +2,7 @@
 //! locale : Czech [cs]
 //! author : petrbela : https://github.com/petrbela
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var months = 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split('_'),
     monthsShort = 'led_úno_bře_dub_kvě_čvn_čvc_srp_zář_říj_lis_pro'.split('_');

--- a/src/locale/cv.js
+++ b/src/locale/cv.js
@@ -2,7 +2,7 @@
 //! locale : Chuvash [cv]
 //! author : Anatoly Mironov : https://github.com/mirontoli
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('cv', {
     months : 'кӑрлач_нарӑс_пуш_ака_май_ҫӗртме_утӑ_ҫурла_авӑн_юпа_чӳк_раштав'.split('_'),

--- a/src/locale/cy.js
+++ b/src/locale/cy.js
@@ -3,7 +3,7 @@
 //! author : Robert Allen : https://github.com/robgallen
 //! author : https://github.com/ryangreaves
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('cy', {
     months: 'Ionawr_Chwefror_Mawrth_Ebrill_Mai_Mehefin_Gorffennaf_Awst_Medi_Hydref_Tachwedd_Rhagfyr'.split('_'),

--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -2,7 +2,7 @@
 //! locale : Danish [da]
 //! author : Ulrik Nielsen : https://github.com/mrbase
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('da', {
     months : 'januar_februar_marts_april_maj_juni_juli_august_september_oktober_november_december'.split('_'),

--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -5,7 +5,7 @@
 //! author : Martin Groller : https://github.com/MadMG
 //! author : Mikolaj Dadela : https://github.com/mik01aj
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -4,7 +4,7 @@
 
 // based on: https://www.bk.admin.ch/dokumentation/sprachen/04915/05016/index.html?lang=de#
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -4,7 +4,7 @@
 //! author: Menelion Elensúle: https://github.com/Oire
 //! author : Mikolaj Dadela : https://github.com/mik01aj
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/dv.js
+++ b/src/locale/dv.js
@@ -2,7 +2,7 @@
 //! locale : Maldivian [dv]
 //! author : Jawish Hameed : https://github.com/jawish
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var months = [
     'ޖެނުއަރީ',

--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -2,7 +2,7 @@
 //! locale : Greek [el]
 //! author : Aggelos Karalias : https://github.com/mehiel
 
-import moment from '../moment';
+import moment from '../moment-core';
 import isFunction from '../lib/utils/is-function';
 
 export default moment.defineLocale('el', {

--- a/src/locale/en-au.js
+++ b/src/locale/en-au.js
@@ -2,7 +2,7 @@
 //! locale : English (Australia) [en-au]
 //! author : Jared Morse : https://github.com/jarcoal
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('en-au', {
     months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),

--- a/src/locale/en-ca.js
+++ b/src/locale/en-ca.js
@@ -2,7 +2,7 @@
 //! locale : English (Canada) [en-ca]
 //! author : Jonathan Abourbih : https://github.com/jonbca
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('en-ca', {
     months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),

--- a/src/locale/en-gb.js
+++ b/src/locale/en-gb.js
@@ -2,7 +2,7 @@
 //! locale : English (United Kingdom) [en-gb]
 //! author : Chris Gedrim : https://github.com/chrisgedrim
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('en-gb', {
     months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),

--- a/src/locale/en-ie.js
+++ b/src/locale/en-ie.js
@@ -2,7 +2,7 @@
 //! locale : English (Ireland) [en-ie]
 //! author : Chris Cartlidge : https://github.com/chriscartlidge
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('en-ie', {
     months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),

--- a/src/locale/en-nz.js
+++ b/src/locale/en-nz.js
@@ -2,7 +2,7 @@
 //! locale : English (New Zealand) [en-nz]
 //! author : Luke McGregor : https://github.com/lukemcgregor
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('en-nz', {
     months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -4,7 +4,7 @@
 //! author : Mia Nordentoft Imperatori : https://github.com/miestasmia
 //! comment : miestasmia corrected the translation by colindean
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('eo', {
     months : 'januaro_februaro_marto_aprilo_majo_junio_julio_aŭgusto_septembro_oktobro_novembro_decembro'.split('_'),

--- a/src/locale/es-do.js
+++ b/src/locale/es-do.js
@@ -1,7 +1,7 @@
 //! moment.js locale configuration
 //! locale : Spanish (Dominican Republic) [es-do]
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
     monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');

--- a/src/locale/es-us.js
+++ b/src/locale/es-us.js
@@ -2,7 +2,7 @@
 //! locale : Spanish(United State) [es-us]
 //! author : bustta : https://github.com/bustta
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
     monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -2,7 +2,7 @@
 //! locale : Spanish [es]
 //! author : Julio Napurí : https://github.com/julionc
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
     monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');

--- a/src/locale/et.js
+++ b/src/locale/et.js
@@ -3,7 +3,7 @@
 //! author : Henry Kehlmann : https://github.com/madhenry
 //! improvements : Illimar Tambek : https://github.com/ragulka
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/eu.js
+++ b/src/locale/eu.js
@@ -2,7 +2,7 @@
 //! locale : Basque [eu]
 //! author : Eneko Illarramendi : https://github.com/eillarra
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('eu', {
     months : 'urtarrila_otsaila_martxoa_apirila_maiatza_ekaina_uztaila_abuztua_iraila_urria_azaroa_abendua'.split('_'),

--- a/src/locale/fa.js
+++ b/src/locale/fa.js
@@ -2,7 +2,7 @@
 //! locale : Persian [fa]
 //! author : Ebrahim Byagowi : https://github.com/ebraminio
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '۱',

--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -2,7 +2,7 @@
 //! locale : Finnish [fi]
 //! author : Tarmo Aidantausta : https://github.com/bleadof
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var numbersPast = 'nolla yksi kaksi kolme neljä viisi kuusi seitsemän kahdeksan yhdeksän'.split(' '),
     numbersFuture = [

--- a/src/locale/fo.js
+++ b/src/locale/fo.js
@@ -2,7 +2,7 @@
 //! locale : Faroese [fo]
 //! author : Ragnar Johannesen : https://github.com/ragnar123
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('fo', {
     months : 'januar_februar_mars_apríl_mai_juni_juli_august_september_oktober_november_desember'.split('_'),

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -2,7 +2,7 @@
 //! locale : French (Canada) [fr-ca]
 //! author : Jonathan Abourbih : https://github.com/jonbca
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('fr-ca', {
     months : 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split('_'),

--- a/src/locale/fr-ch.js
+++ b/src/locale/fr-ch.js
@@ -2,7 +2,7 @@
 //! locale : French (Switzerland) [fr-ch]
 //! author : Gaspard Bucher : https://github.com/gaspard
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('fr-ch', {
     months : 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split('_'),

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -2,7 +2,7 @@
 //! locale : French [fr]
 //! author : John Fischer : https://github.com/jfroffice
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('fr', {
     months : 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split('_'),

--- a/src/locale/fy.js
+++ b/src/locale/fy.js
@@ -2,7 +2,7 @@
 //! locale : Frisian [fy]
 //! author : Robin van der Vliet : https://github.com/robin0van0der0v
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var monthsShortWithDots = 'jan._feb._mrt._apr._mai_jun._jul._aug._sep._okt._nov._des.'.split('_'),
     monthsShortWithoutDots = 'jan_feb_mrt_apr_mai_jun_jul_aug_sep_okt_nov_des'.split('_');

--- a/src/locale/gd.js
+++ b/src/locale/gd.js
@@ -2,7 +2,7 @@
 //! locale : Scottish Gaelic [gd]
 //! author : Jon Ashdown : https://github.com/jonashdown
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var months = [
     'Am Faoilleach', 'An Gearran', 'Am Màrt', 'An Giblean', 'An Cèitean', 'An t-Ògmhios', 'An t-Iuchar', 'An Lùnastal', 'An t-Sultain', 'An Dàmhair', 'An t-Samhain', 'An Dùbhlachd'

--- a/src/locale/gl.js
+++ b/src/locale/gl.js
@@ -2,7 +2,7 @@
 //! locale : Galician [gl]
 //! author : Juan G. Hurtado : https://github.com/juanghurtado
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('gl', {
     months : 'xaneiro_febreiro_marzo_abril_maio_xuño_xullo_agosto_setembro_outubro_novembro_decembro'.split('_'),

--- a/src/locale/gom-latn.js
+++ b/src/locale/gom-latn.js
@@ -2,7 +2,7 @@
 //! locale : Konkani Latin script [gom-latn]
 //! author : The Discoverer : https://github.com/WikiDiscoverer
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/gu.js
+++ b/src/locale/gu.js
@@ -2,7 +2,7 @@
 //! locale : Gujarati [gu]
 //! author : Kaushik Thanki : https://github.com/Kaushik1987
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
         '1': '૧',

--- a/src/locale/he.js
+++ b/src/locale/he.js
@@ -4,7 +4,7 @@
 //! author : Moshe Simantov : https://github.com/DevelopmentIL
 //! author : Tal Ater : https://github.com/TalAter
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('he', {
     months : 'ינואר_פברואר_מרץ_אפריל_מאי_יוני_יולי_אוגוסט_ספטמבר_אוקטובר_נובמבר_דצמבר'.split('_'),

--- a/src/locale/hi.js
+++ b/src/locale/hi.js
@@ -2,7 +2,7 @@
 //! locale : Hindi [hi]
 //! author : Mayank Singhal : https://github.com/mayanksinghal
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '१',

--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -2,7 +2,7 @@
 //! locale : Croatian [hr]
 //! author : Bojan Marković : https://github.com/bmarkovic
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function translate(number, withoutSuffix, key) {
     var result = number + ' ';

--- a/src/locale/hu.js
+++ b/src/locale/hu.js
@@ -2,7 +2,7 @@
 //! locale : Hungarian [hu]
 //! author : Adam Brunner : https://github.com/adambrunner
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var weekEndings = 'vasárnap hétfőn kedden szerdán csütörtökön pénteken szombaton'.split(' ');
 function translate(number, withoutSuffix, key, isFuture) {

--- a/src/locale/hy-am.js
+++ b/src/locale/hy-am.js
@@ -2,7 +2,7 @@
 //! locale : Armenian [hy-am]
 //! author : Armendarabyan : https://github.com/armendarabyan
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('hy-am', {
     months : {

--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -3,7 +3,7 @@
 //! author : Mohammad Satrio Utomo : https://github.com/tyok
 //! reference: http://id.wikisource.org/wiki/Pedoman_Umum_Ejaan_Bahasa_Indonesia_yang_Disempurnakan
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('id', {
     months : 'Januari_Februari_Maret_April_Mei_Juni_Juli_Agustus_September_Oktober_November_Desember'.split('_'),

--- a/src/locale/is.js
+++ b/src/locale/is.js
@@ -2,7 +2,7 @@
 //! locale : Icelandic [is]
 //! author : Hinrik Örn Sigurðsson : https://github.com/hinrik
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function plural(n) {
     if (n % 100 === 11) {

--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -3,7 +3,7 @@
 //! author : Lorenzo : https://github.com/aliem
 //! author: Mattia Larentis: https://github.com/nostalgiaz
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('it', {
     months : 'gennaio_febbraio_marzo_aprile_maggio_giugno_luglio_agosto_settembre_ottobre_novembre_dicembre'.split('_'),

--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -2,7 +2,7 @@
 //! locale : Japanese [ja]
 //! author : LI Long : https://github.com/baryon
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ja', {
     months : '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),

--- a/src/locale/jv.js
+++ b/src/locale/jv.js
@@ -3,7 +3,7 @@
 //! author : Rony Lantip : https://github.com/lantip
 //! reference: http://jv.wikipedia.org/wiki/Basa_Jawa
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('jv', {
     months : 'Januari_Februari_Maret_April_Mei_Juni_Juli_Agustus_September_Oktober_Nopember_Desember'.split('_'),

--- a/src/locale/ka.js
+++ b/src/locale/ka.js
@@ -2,7 +2,7 @@
 //! locale : Georgian [ka]
 //! author : Irakli Janiashvili : https://github.com/irakli-janiashvili
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ka', {
     months : {

--- a/src/locale/kk.js
+++ b/src/locale/kk.js
@@ -2,7 +2,7 @@
 //! locale : Kazakh [kk]
 //! authors : Nurlan Rakhimzhanov : https://github.com/nurlan
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var suffixes = {
     0: '-ші',

--- a/src/locale/km.js
+++ b/src/locale/km.js
@@ -2,7 +2,7 @@
 //! locale : Cambodian [km]
 //! author : Kruy Vanna : https://github.com/kruyvanna
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('km', {
     months: 'មករា_កុម្ភៈ_មីនា_មេសា_ឧសភា_មិថុនា_កក្កដា_សីហា_កញ្ញា_តុលា_វិច្ឆិកា_ធ្នូ'.split('_'),

--- a/src/locale/kn.js
+++ b/src/locale/kn.js
@@ -2,7 +2,7 @@
 //! locale : Kannada [kn]
 //! author : Rajeev Naik : https://github.com/rajeevnaikte
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '೧',

--- a/src/locale/ko.js
+++ b/src/locale/ko.js
@@ -3,7 +3,7 @@
 //! author : Kyungwook, Park : https://github.com/kyungw00k
 //! author : Jeeeyul Lee <jeeeyul@gmail.com>
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ko', {
     months : '1월_2월_3월_4월_5월_6월_7월_8월_9월_10월_11월_12월'.split('_'),

--- a/src/locale/ky.js
+++ b/src/locale/ky.js
@@ -3,7 +3,7 @@
 //! author : Chyngyz Arystan uulu : https://github.com/chyngyz
 
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var suffixes = {
     0: '-чү',

--- a/src/locale/lb.js
+++ b/src/locale/lb.js
@@ -3,7 +3,7 @@
 //! author : mweimerskirch : https://github.com/mweimerskirch
 //! author : David Raison : https://github.com/kwisatz
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/lo.js
+++ b/src/locale/lo.js
@@ -2,7 +2,7 @@
 //! locale : Lao [lo]
 //! author : Ryan Hart : https://github.com/ryanhart2
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('lo', {
     months : 'ມັງກອນ_ກຸມພາ_ມີນາ_ເມສາ_ພຶດສະພາ_ມິຖຸນາ_ກໍລະກົດ_ສິງຫາ_ກັນຍາ_ຕຸລາ_ພະຈິກ_ທັນວາ'.split('_'),

--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -2,7 +2,7 @@
 //! locale : Lithuanian [lt]
 //! author : Mindaugas Mozūras : https://github.com/mmozuras
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var units = {
     'm' : 'minutė_minutės_minutę',

--- a/src/locale/lv.js
+++ b/src/locale/lv.js
@@ -3,7 +3,7 @@
 //! author : Kristaps Karlsons : https://github.com/skakri
 //! author : Jānis Elmeris : https://github.com/JanisE
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var units = {
     'm': 'minūtes_minūtēm_minūte_minūtes'.split('_'),

--- a/src/locale/me.js
+++ b/src/locale/me.js
@@ -2,7 +2,7 @@
 //! locale : Montenegrin [me]
 //! author : Miodrag Nikač <miodrag@restartit.me> : https://github.com/miodragnikac
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var translator = {
     words: { //Different grammatical cases

--- a/src/locale/mi.js
+++ b/src/locale/mi.js
@@ -2,7 +2,7 @@
 //! locale : Maori [mi]
 //! author : John Corrigan <robbiecloset@gmail.com> : https://github.com/johnideal
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('mi', {
     months: 'Kohi-tāte_Hui-tanguru_Poutū-te-rangi_Paenga-whāwhā_Haratua_Pipiri_Hōngoingoi_Here-turi-kōkā_Mahuru_Whiringa-ā-nuku_Whiringa-ā-rangi_Hakihea'.split('_'),

--- a/src/locale/mk.js
+++ b/src/locale/mk.js
@@ -2,7 +2,7 @@
 //! locale : Macedonian [mk]
 //! author : Borislav Mickov : https://github.com/B0k0
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('mk', {
     months : 'јануари_февруари_март_април_мај_јуни_јули_август_септември_октомври_ноември_декември'.split('_'),

--- a/src/locale/ml.js
+++ b/src/locale/ml.js
@@ -2,7 +2,7 @@
 //! locale : Malayalam [ml]
 //! author : Floyd Pink : https://github.com/floydpink
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ml', {
     months : 'ജനുവരി_ഫെബ്രുവരി_മാർച്ച്_ഏപ്രിൽ_മേയ്_ജൂൺ_ജൂലൈ_ഓഗസ്റ്റ്_സെപ്റ്റംബർ_ഒക്ടോബർ_നവംബർ_ഡിസംബർ'.split('_'),

--- a/src/locale/mr.js
+++ b/src/locale/mr.js
@@ -3,7 +3,7 @@
 //! author : Harshad Kale : https://github.com/kalehv
 //! author : Vivek Athalye : https://github.com/vnathalye
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '१',

--- a/src/locale/ms-my.js
+++ b/src/locale/ms-my.js
@@ -3,7 +3,7 @@
 //! note : DEPRECATED, the correct one is [ms]
 //! author : Weldan Jamili : https://github.com/weldan
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ms-my', {
     months : 'Januari_Februari_Mac_April_Mei_Jun_Julai_Ogos_September_Oktober_November_Disember'.split('_'),

--- a/src/locale/ms.js
+++ b/src/locale/ms.js
@@ -2,7 +2,7 @@
 //! locale : Malay [ms]
 //! author : Weldan Jamili : https://github.com/weldan
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ms', {
     months : 'Januari_Februari_Mac_April_Mei_Jun_Julai_Ogos_September_Oktober_November_Disember'.split('_'),

--- a/src/locale/my.js
+++ b/src/locale/my.js
@@ -4,7 +4,7 @@
 //! author : David Rossellat : https://github.com/gholadr
 //! author : Tin Aung Lin : https://github.com/thanyawzinmin
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '၁',

--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -3,7 +3,7 @@
 //! authors : Espen Hovlandsdal : https://github.com/rexxars
 //!           Sigurd Gartmann : https://github.com/sigurdga
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('nb', {
     months : 'januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember'.split('_'),

--- a/src/locale/ne.js
+++ b/src/locale/ne.js
@@ -2,7 +2,7 @@
 //! locale : Nepalese [ne]
 //! author : suvash : https://github.com/suvash
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '१',

--- a/src/locale/nl-be.js
+++ b/src/locale/nl-be.js
@@ -3,7 +3,7 @@
 //! author : Joris Röling : https://github.com/jorisroling
 //! author : Jacob Middag : https://github.com/middagj
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var monthsShortWithDots = 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split('_'),
     monthsShortWithoutDots = 'jan_feb_mrt_apr_mei_jun_jul_aug_sep_okt_nov_dec'.split('_');

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -3,7 +3,7 @@
 //! author : Joris Röling : https://github.com/jorisroling
 //! author : Jacob Middag : https://github.com/middagj
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var monthsShortWithDots = 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split('_'),
     monthsShortWithoutDots = 'jan_feb_mrt_apr_mei_jun_jul_aug_sep_okt_nov_dec'.split('_');

--- a/src/locale/nn.js
+++ b/src/locale/nn.js
@@ -2,7 +2,7 @@
 //! locale : Nynorsk [nn]
 //! author : https://github.com/mechuwind
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('nn', {
     months : 'januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember'.split('_'),

--- a/src/locale/pa-in.js
+++ b/src/locale/pa-in.js
@@ -2,7 +2,7 @@
 //! locale : Punjabi (India) [pa-in]
 //! author : Harpreet Singh : https://github.com/harpreetkhalsagtbit
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '੧',

--- a/src/locale/pl.js
+++ b/src/locale/pl.js
@@ -2,7 +2,7 @@
 //! locale : Polish [pl]
 //! author : Rafal Hirsz : https://github.com/evoL
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var monthsNominative = 'styczeń_luty_marzec_kwiecień_maj_czerwiec_lipiec_sierpień_wrzesień_październik_listopad_grudzień'.split('_'),
     monthsSubjective = 'stycznia_lutego_marca_kwietnia_maja_czerwca_lipca_sierpnia_września_października_listopada_grudnia'.split('_');

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -2,7 +2,7 @@
 //! locale : Portuguese (Brazil) [pt-br]
 //! author : Caio Ribeiro Pereira : https://github.com/caio-ribeiro-pereira
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('pt-br', {
     months : 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -2,7 +2,7 @@
 //! locale : Portuguese [pt]
 //! author : Jefferson : https://github.com/jalex79
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('pt', {
     months : 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),

--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -3,7 +3,7 @@
 //! author : Vlad Gurdiga : https://github.com/gurdiga
 //! author : Valentin Agachi : https://github.com/avaly
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function relativeTimeWithPlural(number, withoutSuffix, key) {
     var format = {

--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -4,7 +4,7 @@
 //! Author : Menelion Elensúle : https://github.com/Oire
 //! author : Коренберг Марк : https://github.com/socketpair
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function plural(word, num) {
     var forms = word.split('_');

--- a/src/locale/sd.js
+++ b/src/locale/sd.js
@@ -2,7 +2,7 @@
 //! locale : Sindhi [sd]
 //! author : Narain Sagar : https://github.com/narainsagar
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var months = [
     'جنوري',

--- a/src/locale/se.js
+++ b/src/locale/se.js
@@ -3,7 +3,7 @@
 //! authors : Bård Rolstad Henriksen : https://github.com/karamell
 
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('se', {
     months : 'ođđajagemánnu_guovvamánnu_njukčamánnu_cuoŋománnu_miessemánnu_geassemánnu_suoidnemánnu_borgemánnu_čakčamánnu_golggotmánnu_skábmamánnu_juovlamánnu'.split('_'),

--- a/src/locale/si.js
+++ b/src/locale/si.js
@@ -2,7 +2,7 @@
 //! locale : Sinhalese [si]
 //! author : Sampath Sitinamaluwa : https://github.com/sampathsris
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 /*jshint -W100*/
 export default moment.defineLocale('si', {

--- a/src/locale/sk.js
+++ b/src/locale/sk.js
@@ -3,7 +3,7 @@
 //! author : Martin Minka : https://github.com/k2s
 //! based on work of petrbela : https://github.com/petrbela
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var months = 'január_február_marec_apríl_máj_jún_júl_august_september_október_november_december'.split('_'),
     monthsShort = 'jan_feb_mar_apr_máj_jún_júl_aug_sep_okt_nov_dec'.split('_');

--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -2,7 +2,7 @@
 //! locale : Slovenian [sl]
 //! author : Robert Sedovšek : https://github.com/sedovsek
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var result = number + ' ';

--- a/src/locale/sq.js
+++ b/src/locale/sq.js
@@ -4,7 +4,7 @@
 //! author : Menelion Elensúle : https://github.com/Oire
 //! author : Oerd Cukalla : https://github.com/oerd
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('sq', {
     months : 'Janar_Shkurt_Mars_Prill_Maj_Qershor_Korrik_Gusht_Shtator_Tetor_Nëntor_Dhjetor'.split('_'),

--- a/src/locale/sr-cyrl.js
+++ b/src/locale/sr-cyrl.js
@@ -2,7 +2,7 @@
 //! locale : Serbian Cyrillic [sr-cyrl]
 //! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var translator = {
     words: { //Different grammatical cases

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -2,7 +2,7 @@
 //! locale : Serbian [sr]
 //! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var translator = {
     words: { //Different grammatical cases

--- a/src/locale/ss.js
+++ b/src/locale/ss.js
@@ -3,7 +3,7 @@
 //! author : Nicolai Davies<mail@nicolai.io> : https://github.com/nicolaidavies
 
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('ss', {
     months : "Bhimbidvwane_Indlovana_Indlov'lenkhulu_Mabasa_Inkhwekhweti_Inhlaba_Kholwane_Ingci_Inyoni_Imphala_Lweti_Ingongoni".split('_'),

--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -2,7 +2,7 @@
 //! locale : Swedish [sv]
 //! author : Jens Alm : https://github.com/ulmus
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('sv', {
     months : 'januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december'.split('_'),

--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -2,7 +2,7 @@
 //! locale : Swahili [sw]
 //! author : Fahad Kassim : https://github.com/fadsel
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('sw', {
     months : 'Januari_Februari_Machi_Aprili_Mei_Juni_Julai_Agosti_Septemba_Oktoba_Novemba_Desemba'.split('_'),

--- a/src/locale/ta.js
+++ b/src/locale/ta.js
@@ -2,7 +2,7 @@
 //! locale : Tamil [ta]
 //! author : Arjunkumar Krishnamoorthy : https://github.com/tk120404
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var symbolMap = {
     '1': '௧',

--- a/src/locale/te.js
+++ b/src/locale/te.js
@@ -2,7 +2,7 @@
 //! locale : Telugu [te]
 //! author : Krishna Chaitanya Thota : https://github.com/kcthota
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('te', {
     months : 'జనవరి_ఫిబ్రవరి_మార్చి_ఏప్రిల్_మే_జూన్_జూలై_ఆగస్టు_సెప్టెంబర్_అక్టోబర్_నవంబర్_డిసెంబర్'.split('_'),

--- a/src/locale/tet.js
+++ b/src/locale/tet.js
@@ -3,7 +3,7 @@
 //! author : Joshua Brooks : https://github.com/joshbrooks
 //! author : Onorio De J. Afonso : https://github.com/marobo
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('tet', {
     months : 'Janeiru_Fevereiru_Marsu_Abril_Maiu_Juniu_Juliu_Augustu_Setembru_Outubru_Novembru_Dezembru'.split('_'),

--- a/src/locale/th.js
+++ b/src/locale/th.js
@@ -2,7 +2,7 @@
 //! locale : Thai [th]
 //! author : Kridsada Thanabulpong : https://github.com/sirn
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('th', {
     months : 'มกราคม_กุมภาพันธ์_มีนาคม_เมษายน_พฤษภาคม_มิถุนายน_กรกฎาคม_สิงหาคม_กันยายน_ตุลาคม_พฤศจิกายน_ธันวาคม'.split('_'),

--- a/src/locale/tl-ph.js
+++ b/src/locale/tl-ph.js
@@ -2,7 +2,7 @@
 //! locale : Tagalog (Philippines) [tl-ph]
 //! author : Dan Hagman : https://github.com/hagmandan
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('tl-ph', {
     months : 'Enero_Pebrero_Marso_Abril_Mayo_Hunyo_Hulyo_Agosto_Setyembre_Oktubre_Nobyembre_Disyembre'.split('_'),

--- a/src/locale/tlh.js
+++ b/src/locale/tlh.js
@@ -2,7 +2,7 @@
 //! locale : Klingon [tlh]
 //! author : Dominika Kruk : https://github.com/amaranthrose
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var numbersNouns = 'pagh_wa’_cha’_wej_loS_vagh_jav_Soch_chorgh_Hut'.split('_');
 

--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -3,7 +3,7 @@
 //! authors : Erhan Gundogan : https://github.com/erhangundogan,
 //!           Burak Yiğit Kaya: https://github.com/BYK
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var suffixes = {
     1: '\'inci',

--- a/src/locale/tzl.js
+++ b/src/locale/tzl.js
@@ -3,7 +3,7 @@
 //! author : Robin van der Vliet : https://github.com/robin0van0der0v
 //! author : Iustì Canun
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 // After the year there should be a slash and the amount of years since December 26, 1979 in Roman numerals.
 // This is currently too difficult (maybe even impossible) to add.

--- a/src/locale/tzm-latn.js
+++ b/src/locale/tzm-latn.js
@@ -2,7 +2,7 @@
 //! locale : Central Atlas Tamazight Latin [tzm-latn]
 //! author : Abdel Said : https://github.com/abdelsaid
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('tzm-latn', {
     months : 'innayr_brˤayrˤ_marˤsˤ_ibrir_mayyw_ywnyw_ywlywz_ɣwšt_šwtanbir_ktˤwbrˤ_nwwanbir_dwjnbir'.split('_'),

--- a/src/locale/tzm.js
+++ b/src/locale/tzm.js
@@ -2,7 +2,7 @@
 //! locale : Central Atlas Tamazight [tzm]
 //! author : Abdel Said : https://github.com/abdelsaid
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('tzm', {
     months : 'ⵉⵏⵏⴰⵢⵔ_ⴱⵕⴰⵢⵕ_ⵎⴰⵕⵚ_ⵉⴱⵔⵉⵔ_ⵎⴰⵢⵢⵓ_ⵢⵓⵏⵢⵓ_ⵢⵓⵍⵢⵓⵣ_ⵖⵓⵛⵜ_ⵛⵓⵜⴰⵏⴱⵉⵔ_ⴽⵟⵓⴱⵕ_ⵏⵓⵡⴰⵏⴱⵉⵔ_ⴷⵓⵊⵏⴱⵉⵔ'.split('_'),

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -3,7 +3,7 @@
 //! author : zemlanin : https://github.com/zemlanin
 //! Author : Menelion Elensúle : https://github.com/Oire
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 function plural(word, num) {
     var forms = word.split('_');

--- a/src/locale/ur.js
+++ b/src/locale/ur.js
@@ -3,7 +3,7 @@
 //! author : Sawood Alam : https://github.com/ibnesayeed
 //! author : Zack : https://github.com/ZackVision
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 var months = [
     'جنوری',

--- a/src/locale/uz-latn.js
+++ b/src/locale/uz-latn.js
@@ -2,7 +2,7 @@
 //! locale : Uzbek Latin [uz-latn]
 //! author : Rasulbek Mirzayev : github.com/Rasulbeeek
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('uz-latn', {
     months : 'Yanvar_Fevral_Mart_Aprel_May_Iyun_Iyul_Avgust_Sentabr_Oktabr_Noyabr_Dekabr'.split('_'),

--- a/src/locale/uz.js
+++ b/src/locale/uz.js
@@ -2,7 +2,7 @@
 //! locale : Uzbek [uz]
 //! author : Sardor Muminov : https://github.com/muminoff
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('uz', {
     months : 'январ_феврал_март_апрел_май_июн_июл_август_сентябр_октябр_ноябр_декабр'.split('_'),

--- a/src/locale/vi.js
+++ b/src/locale/vi.js
@@ -2,7 +2,7 @@
 //! locale : Vietnamese [vi]
 //! author : Bang Nguyen : https://github.com/bangnk
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('vi', {
     months : 'tháng 1_tháng 2_tháng 3_tháng 4_tháng 5_tháng 6_tháng 7_tháng 8_tháng 9_tháng 10_tháng 11_tháng 12'.split('_'),

--- a/src/locale/x-pseudo.js
+++ b/src/locale/x-pseudo.js
@@ -2,7 +2,7 @@
 //! locale : Pseudo [x-pseudo]
 //! author : Andrew Hood : https://github.com/andrewhood125
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('x-pseudo', {
     months : 'J~áñúá~rý_F~ébrú~árý_~Márc~h_Áp~ríl_~Máý_~Júñé~_Júl~ý_Áú~gúst~_Sép~témb~ér_Ó~ctób~ér_Ñ~óvém~bér_~Décé~mbér'.split('_'),

--- a/src/locale/yo.js
+++ b/src/locale/yo.js
@@ -2,7 +2,7 @@
 //! locale : Yoruba Nigeria [yo]
 //! author : Atolagbe Abisoye : https://github.com/andela-batolagbe
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('yo', {
     months : 'Sẹ́rẹ́_Èrèlè_Ẹrẹ̀nà_Ìgbé_Èbibi_Òkùdu_Agẹmo_Ògún_Owewe_Ọ̀wàrà_Bélú_Ọ̀pẹ̀̀'.split('_'),

--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -3,7 +3,7 @@
 //! author : suupic : https://github.com/suupic
 //! author : Zeno Zeng : https://github.com/zenozeng
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('zh-cn', {
     months : '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),

--- a/src/locale/zh-hk.js
+++ b/src/locale/zh-hk.js
@@ -4,7 +4,7 @@
 //! author : Chris Lam : https://github.com/hehachris
 //! author : Konstantin : https://github.com/skfd
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('zh-hk', {
     months : '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),

--- a/src/locale/zh-tw.js
+++ b/src/locale/zh-tw.js
@@ -3,7 +3,7 @@
 //! author : Ben : https://github.com/ben-lin
 //! author : Chris Lam : https://github.com/hehachris
 
-import moment from '../moment';
+import moment from '../moment-core';
 
 export default moment.defineLocale('zh-tw', {
     months : '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),

--- a/src/moment-core.js
+++ b/src/moment-core.js
@@ -1,0 +1,82 @@
+//! moment.js
+//! version : 2.18.1
+//! authors : Tim Wood, Iskren Chernev, Moment.js contributors
+//! license : MIT
+//! momentjs.com
+
+import { hooks as moment, setHookCallback } from './lib/utils/hooks';
+
+moment.version = '2.18.1';
+
+import {
+    min,
+    max,
+    now,
+    isMoment,
+    momentPrototype as fn,
+    createUTC       as utc,
+    createUnix      as unix,
+    createLocal     as local,
+    createInvalid   as invalid,
+    createInZone    as parseZone
+} from './lib/moment/moment';
+
+import {
+    getCalendarFormat
+} from './lib/moment/calendar';
+
+import {
+    defineLocale,
+    updateLocale,
+    getSetGlobalLocale as locale,
+    getLocale          as localeData,
+    listLocales        as locales,
+    listMonths         as months,
+    listMonthsShort    as monthsShort,
+    listWeekdays       as weekdays,
+    listWeekdaysMin    as weekdaysMin,
+    listWeekdaysShort  as weekdaysShort
+} from './lib/locale/locale';
+
+import {
+    isDuration,
+    createDuration              as duration,
+    getSetRelativeTimeRounding  as relativeTimeRounding,
+    getSetRelativeTimeThreshold as relativeTimeThreshold
+} from './lib/duration/duration';
+
+import { normalizeUnits } from './lib/units/units';
+
+import isDate from './lib/utils/is-date';
+
+setHookCallback(local);
+
+moment.fn                    = fn;
+moment.min                   = min;
+moment.max                   = max;
+moment.now                   = now;
+moment.utc                   = utc;
+moment.unix                  = unix;
+moment.months                = months;
+moment.isDate                = isDate;
+moment.locale                = locale;
+moment.invalid               = invalid;
+moment.duration              = duration;
+moment.isMoment              = isMoment;
+moment.weekdays              = weekdays;
+moment.parseZone             = parseZone;
+moment.localeData            = localeData;
+moment.isDuration            = isDuration;
+moment.monthsShort           = monthsShort;
+moment.weekdaysMin           = weekdaysMin;
+moment.defineLocale          = defineLocale;
+moment.updateLocale          = updateLocale;
+moment.locales               = locales;
+moment.weekdaysShort         = weekdaysShort;
+moment.normalizeUnits        = normalizeUnits;
+moment.relativeTimeRounding  = relativeTimeRounding;
+moment.relativeTimeThreshold = relativeTimeThreshold;
+moment.calendarFormat        = getCalendarFormat;
+moment.prototype             = fn;
+
+export default moment;

--- a/src/moment.js
+++ b/src/moment.js
@@ -1,82 +1,18 @@
-//! moment.js
-//! version : 2.18.1
-//! authors : Tim Wood, Iskren Chernev, Moment.js contributors
-//! license : MIT
-//! momentjs.com
+import moment from "./moment-core";
 
-import { hooks as moment, setHookCallback } from './lib/utils/hooks';
+import { setLocaleLoader } from "./lib/locale/locales";
 
-moment.version = '2.18.1';
-
-import {
-    min,
-    max,
-    now,
-    isMoment,
-    momentPrototype as fn,
-    createUTC       as utc,
-    createUnix      as unix,
-    createLocal     as local,
-    createInvalid   as invalid,
-    createInZone    as parseZone
-} from './lib/moment/moment';
-
-import {
-    getCalendarFormat
-} from './lib/moment/calendar';
-
-import {
-    defineLocale,
-    updateLocale,
-    getSetGlobalLocale as locale,
-    getLocale          as localeData,
-    listLocales        as locales,
-    listMonths         as months,
-    listMonthsShort    as monthsShort,
-    listWeekdays       as weekdays,
-    listWeekdaysMin    as weekdaysMin,
-    listWeekdaysShort  as weekdaysShort
-} from './lib/locale/locale';
-
-import {
-    isDuration,
-    createDuration              as duration,
-    getSetRelativeTimeRounding  as relativeTimeRounding,
-    getSetRelativeTimeThreshold as relativeTimeThreshold
-} from './lib/duration/duration';
-
-import { normalizeUnits } from './lib/units/units';
-
-import isDate from './lib/utils/is-date';
-
-setHookCallback(local);
-
-moment.fn                    = fn;
-moment.min                   = min;
-moment.max                   = max;
-moment.now                   = now;
-moment.utc                   = utc;
-moment.unix                  = unix;
-moment.months                = months;
-moment.isDate                = isDate;
-moment.locale                = locale;
-moment.invalid               = invalid;
-moment.duration              = duration;
-moment.isMoment              = isMoment;
-moment.weekdays              = weekdays;
-moment.parseZone             = parseZone;
-moment.localeData            = localeData;
-moment.isDuration            = isDuration;
-moment.monthsShort           = monthsShort;
-moment.weekdaysMin           = weekdaysMin;
-moment.defineLocale          = defineLocale;
-moment.updateLocale          = updateLocale;
-moment.locales               = locales;
-moment.weekdaysShort         = weekdaysShort;
-moment.normalizeUnits        = normalizeUnits;
-moment.relativeTimeRounding  = relativeTimeRounding;
-moment.relativeTimeThreshold = relativeTimeThreshold;
-moment.calendarFormat        = getCalendarFormat;
-moment.prototype             = fn;
+setLocaleLoader(function(name) {
+    try {
+        require('moment/locale/' + name);
+    } catch (e) {
+        // In the test environment, the external module 'moment'
+        // can't be resolved because we're running inside it.
+        // Fallback to using the old relative import
+        try {
+            require('./locale/' + name);
+        } catch (e) { }
+    }
+})
 
 export default moment;

--- a/src/moment.js
+++ b/src/moment.js
@@ -1,8 +1,8 @@
-import moment from "./moment-core";
+import moment from './moment-core';
 
-import { setLocaleLoader } from "./lib/locale/locales";
+import { setLocaleLoader } from './lib/locale/locales';
 
-setLocaleLoader(function(name) {
+setLocaleLoader(function (name) {
     try {
         require('moment/locale/' + name);
     } catch (e) {

--- a/src/moment.js
+++ b/src/moment.js
@@ -2,15 +2,17 @@ import moment from './moment-core';
 
 import { setLocaleLoader } from './lib/locale/locales';
 
+var hackedRequireToIgnoreError = require;
+
 setLocaleLoader(function (name) {
     try {
-        require('moment/locale/' + name);
+        hackedRequireToIgnoreError('moment/locale/' + name);
     } catch (e) {
         // In the test environment, the external module 'moment'
         // can't be resolved because we're running inside it.
         // Fallback to using the old relative import
         try {
-            require('./locale/' + name);
+            hackedRequireToIgnoreError('./locale/' + name);
         } catch (e) { }
     }
 });

--- a/src/moment.js
+++ b/src/moment.js
@@ -6,15 +6,8 @@ var hackedRequireToIgnoreError = require;
 
 setLocaleLoader(function (name) {
     try {
-        hackedRequireToIgnoreError('moment/locale/' + name);
-    } catch (e) {
-        // In the test environment, the external module 'moment'
-        // can't be resolved because we're running inside it.
-        // Fallback to using the old relative import
-        try {
-            hackedRequireToIgnoreError('./locale/' + name);
-        } catch (e) { }
-    }
+        hackedRequireToIgnoreError('./locale/' + name);
+    } catch (e) { }
 });
 
 export default moment;

--- a/src/moment.js
+++ b/src/moment.js
@@ -13,6 +13,6 @@ setLocaleLoader(function(name) {
             require('./locale/' + name);
         } catch (e) { }
     }
-})
+});
 
 export default moment;

--- a/tasks/transpile.js
+++ b/tasks/transpile.js
@@ -63,11 +63,18 @@ module.exports = function (grunt) {
                 '../moment',
                 '../../moment',
                 path.resolve('src/moment'),
-                path.resolve('build/tmp/moment')
+                path.resolve('build/tmp/moment'),
+                './moment-core',
+                '../moment-core',
+                '../../moment-core',
+                path.resolve('src/moment-core'),
+                path.resolve('build/tmp/moment-core')
             ];
             bundleOpts.globals = {};
             bundleOpts.globals[path.resolve('src/moment')] = 'moment';
             bundleOpts.globals[path.resolve('build/tmp/moment')] = 'moment';
+            bundleOpts.globals[path.resolve('src/moment-core')] = 'moment';
+            bundleOpts.globals[path.resolve('build/tmp/moment-core')] = 'moment';
         }
 
         return rollup(rollupOpts).then(function (bundle) {


### PR DESCRIPTION
The current master build of metro-packager/react-native really doesn’t like dynamic require statements. Importing the current version of moment produces the error

    TransformError: /.../moment/moment.js: require() must have a single string literal argument

This update moves things around so that it is possible to import a version of moment without lazy loaded locales (src/moment-core.js, as big as the diff looks, it’s just a rename). The existing loader is injected in moment.js, which reexports moment so that the previous behaviour of src/moment.js remains unchanged. 
