### PR TITLE
[bugfix] Fix year setter on leap years, fixes #4024

### DIFF
--- a/src/lib/moment/get-set.js
+++ b/src/lib/moment/get-set.js
@@ -2,6 +2,8 @@ import { normalizeUnits, normalizeObjectUnits } from '../units/aliases';
 import { getPrioritizedUnits } from '../units/priorities';
 import { hooks } from '../utils/hooks';
 import isFunction from '../utils/is-function';
+import { daysInMonth } from '../units/month';
+import { isLeapYear } from '../units/year';
 
 export function makeGetSet (unit, keepTime) {
     return function (value) {
@@ -22,7 +24,12 @@ export function get (mom, unit) {
 
 export function set (mom, unit, value) {
     if (mom.isValid() && !isNaN(value)) {
-        mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value);
+        if (unit === 'FullYear' && isLeapYear(mom.year())) {
+            mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value, mom.month(), daysInMonth(value, mom.month()));
+        }
+        else {
+            mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value);
+        }
     }
 }
 

--- a/src/test/moment/getters_setters.js
+++ b/src/test/moment/getters_setters.js
@@ -269,6 +269,16 @@ test('day setter', function (assert) {
     assert.equal(moment(a).day(17).date(), 26, 'set from wednesday to second next wednesday');
 });
 
+test('year setter', function (assert) {
+    var a = moment([2015, 3, 15]);
+    assert.equal(moment(a).year(2016).format('YYYY-MM-DD'), '2016-04-15', 'set from 2015 to 2016');
+    assert.equal(moment(a).year(2011).format('YYYY-MM-DD'), '2011-04-15', 'set from 2015 to 2011');
+
+    var b = moment([2012, 1, 29]);
+    assert.equal(moment(b).year(2017).format('YYYY-MM-DD'), '2017-02-28', 'set from last day of february on a leap year to a non leap year');
+    assert.equal(moment(b).year(2004).format('YYYY-MM-DD'), '2004-02-29', 'set from last day of february on a leap year to a leap year');
+});
+
 test('object set ordering', function (assert) {
     var a = moment([2016,3,30]);
     assert.equal(a.set({date:31, month:4}).date(), 31, 'setter order automatically arranged by size');


### PR DESCRIPTION
This PR addresses issue #4024.

Setting the year from February 29th on leap year to some other date on a non leap year returned March 1st of the other date.

