### PR TITLE
[locale] Fix 4189: Updated time separator for German-Swiss locale

### DIFF
--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -29,12 +29,12 @@ export default moment.defineLocale('de-ch', {
     weekdaysMin : 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
-        LT: 'HH.mm',
-        LTS: 'HH.mm.ss',
+        LT: 'HH:mm',
+        LTS: 'HH:mm:ss',
         L : 'DD.MM.YYYY',
         LL : 'D. MMMM YYYY',
-        LLL : 'D. MMMM YYYY HH.mm',
-        LLLL : 'dddd, D. MMMM YYYY HH.mm'
+        LLL : 'D. MMMM YYYY HH:mm',
+        LLLL : 'dddd, D. MMMM YYYY HH:mm'
     },
     calendar : {
         sameDay: '[heute um] LT [Uhr]',

--- a/src/test/locale/de-ch.js
+++ b/src/test/locale/de-ch.js
@@ -22,7 +22,7 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, Do MMMM YYYY, h.mm.ss a',      'Sonntag, 14. Februar 2010, 3.25.50 pm'],
+            ['dddd, Do MMMM YYYY, h:mm:ss a',      'Sonntag, 14. Februar 2010, 3:25:50 pm'],
             ['ddd, hA',                            'So, 3PM'],
             ['M Mo MM MMMM MMM',                   '2 2. 02 Februar Feb.'],
             ['YYYY YY',                            '2010 10'],
@@ -36,15 +36,16 @@ test('format', function (assert) {
             ['s ss',                               '50 50'],
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45. day of the year'],
-            ['LTS',                                '15.25.50'],
+            ['LT',                                 '15:25'],
+            ['LTS',                                '15:25:50'],
             ['L',                                  '14.02.2010'],
             ['LL',                                 '14. Februar 2010'],
-            ['LLL',                                '14. Februar 2010 15.25'],
-            ['LLLL',                               'Sonntag, 14. Februar 2010 15.25'],
+            ['LLL',                                '14. Februar 2010 15:25'],
+            ['LLLL',                               'Sonntag, 14. Februar 2010 15:25'],
             ['l',                                  '14.2.2010'],
             ['ll',                                 '14. Feb. 2010'],
-            ['lll',                                '14. Feb. 2010 15.25'],
-            ['llll',                               'So, 14. Feb. 2010 15.25']
+            ['lll',                                '14. Feb. 2010 15:25'],
+            ['llll',                               'So, 14. Feb. 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -149,12 +150,12 @@ test('fromNow', function (assert) {
 test('calendar day', function (assert) {
     var a = moment().hours(12).minutes(0).seconds(0);
 
-    assert.equal(moment(a).calendar(),                   'heute um 12.00 Uhr',   'today at the same time');
-    assert.equal(moment(a).add({m: 25}).calendar(),      'heute um 12.25 Uhr',   'Now plus 25 min');
-    assert.equal(moment(a).add({h: 1}).calendar(),       'heute um 13.00 Uhr',   'Now plus 1 hour');
-    assert.equal(moment(a).add({d: 1}).calendar(),       'morgen um 12.00 Uhr',  'tomorrow at the same time');
-    assert.equal(moment(a).subtract({h: 1}).calendar(),  'heute um 11.00 Uhr',   'Now minus 1 hour');
-    assert.equal(moment(a).subtract({d: 1}).calendar(),  'gestern um 12.00 Uhr', 'yesterday at the same time');
+    assert.equal(moment(a).calendar(),                   'heute um 12:00 Uhr',   'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(),      'heute um 12:25 Uhr',   'Now plus 25 min');
+    assert.equal(moment(a).add({h: 1}).calendar(),       'heute um 13:00 Uhr',   'Now plus 1 hour');
+    assert.equal(moment(a).add({d: 1}).calendar(),       'morgen um 12:00 Uhr',  'tomorrow at the same time');
+    assert.equal(moment(a).subtract({h: 1}).calendar(),  'heute um 11:00 Uhr',   'Now minus 1 hour');
+    assert.equal(moment(a).subtract({d: 1}).calendar(),  'gestern um 12:00 Uhr', 'yesterday at the same time');
 });
 
 test('calendar next week', function (assert) {
@@ -202,4 +203,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0,  9]).format('w ww wo'),   '2 02 2.', 'Jan  9 2012 should be week 2');
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2.', 'Jan 15 2012 should be week 2');
 });
-


### PR DESCRIPTION
Should be a straight forward update. 

fixes #4189 