### PR TITLE
[bugfix] updateLocale now tries to load parent, fixes #3626

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -136,6 +136,12 @@ export function updateLocale(name, config) {
         if (locales[name] != null) {
             parentConfig = locales[name]._config;
         }
+        else {
+            locale = loadLocale(name);
+            if (locale != null) {
+                parentConfig = locale._config;
+            }
+        }
         config = mergeConfigs(parentConfig, config);
         locale = new Locale(config);
         locale.parentLocale = locales[name];

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -131,16 +131,11 @@ export function defineLocale (name, config) {
 
 export function updateLocale(name, config) {
     if (config != null) {
-        var locale, parentConfig = baseConfig;
+        var locale, tmpLocale, parentConfig = baseConfig;
         // MERGE
-        if (locales[name] != null) {
-            parentConfig = locales[name]._config;
-        }
-        else {
-            locale = loadLocale(name);
-            if (locale != null) {
-                parentConfig = locale._config;
-            }
+        tmpLocale = locales[name] || loadLocale(name);
+        if (tmpLocale != null) {
+            parentConfig = tmpLocale._config;
         }
         config = mergeConfigs(parentConfig, config);
         locale = new Locale(config);

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -133,7 +133,7 @@ export function updateLocale(name, config) {
     if (config != null) {
         var locale, tmpLocale, parentConfig = baseConfig;
         // MERGE
-        tmpLocale = locales[name] || loadLocale(name);
+        tmpLocale = loadLocale(name);
         if (tmpLocale != null) {
             parentConfig = tmpLocale._config;
         }

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -164,3 +164,11 @@ test('months', function (assert) {
     });
     assert.ok(moment.utc('2015-01-01', 'YYYY-MM-DD').format('MMMM'), 'First', 'months uses child');
 });
+
+test('update existing locale', function (assert) {
+    moment.updateLocale('de', {
+        monthsShort: ['JAN', 'FEB', 'MÄR', 'APR', 'MAI', 'JUN', 'JUL', 'AUG', 'SEP', 'OKT', 'NOV', 'DEZ']
+    });
+    assert.equal(moment('2017-02-01').format('YYYY MMM MMMM'), '2017 FEB Februar');
+    moment.updateLocale('de', null);
+});


### PR DESCRIPTION
This addresses #3626.

A fix was suggested in the comments but a PR wasn't submitted. I've refactored the suggested fix which will check if the locale to update exists (if not found in the currently loaded locales) and load it before merging. This mitigates the merge with the current set locale if the submitted locale isn't found in the loaded locales array.

Not sure if it should continue to merge if the locale to merge with can't be loaded, but this could be another issue to discuss.