### PR TITLE
[bugfix] Fix endOf for daylight saving time

### DIFF
--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -55,5 +55,5 @@ export function endOf (units) {
         units = 'day';
     }
 
-    return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
+    return this.add(1, (units === 'isoWeek' ? 'week' : units)).startOf(units).subtract(1, 'ms');
 }


### PR DESCRIPTION
The endOf formula was not working for the day that the daylight saving
time starts.

Couldn't run tests locally, but running the test code worked.

resolves https://github.com/moment/moment/issues/4249