### PR TITLE
Fix year setter for random days in leap year

### DIFF
--- a/src/lib/moment/get-set.js
+++ b/src/lib/moment/get-set.js
@@ -24,7 +24,7 @@ export function get (mom, unit) {
 
 export function set (mom, unit, value) {
     if (mom.isValid() && !isNaN(value)) {
-        if (unit === 'FullYear' && isLeapYear(mom.year())) {
+        if (unit === 'FullYear' && isLeapYear(mom.year()) && mom.month() === 1 && mom.date() === 29) {
             mom._d['set' + (mom._isUTC ? 'UTC' : '') + unit](value, mom.month(), daysInMonth(value, mom.month()));
         }
         else {

--- a/src/test/moment/getters_setters.js
+++ b/src/test/moment/getters_setters.js
@@ -277,6 +277,10 @@ test('year setter', function (assert) {
     var b = moment([2012, 1, 29]);
     assert.equal(moment(b).year(2017).format('YYYY-MM-DD'), '2017-02-28', 'set from last day of february on a leap year to a non leap year');
     assert.equal(moment(b).year(2004).format('YYYY-MM-DD'), '2004-02-29', 'set from last day of february on a leap year to a leap year');
+
+    var c = moment([2012, 9, 4]);
+    assert.equal(moment(c).year(2017).format('YYYY-MM-DD'), '2017-10-04', 'set from a random day on a leap year to a non leap year');
+    assert.equal(moment(c).year(2004).format('YYYY-MM-DD'), '2004-10-04', 'set from a random day on a leap year to a leap year');
 });
 
 test('object set ordering', function (assert) {


### PR DESCRIPTION
When changing a year from a random day (not the 29th of february) of a leap year, the day is shifted to the end of the month.

Fixes #4238