### PR TITLE
[locale] set french weekdaysMin in lowercase

### DIFF
--- a/locale/fr-ca.js
+++ b/locale/fr-ca.js
@@ -16,7 +16,7 @@ var frCa = moment.defineLocale('fr-ca', {
     monthsParseExact : true,
     weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
     weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdaysMin : 'di_lu_ma_me_je_ve_sa'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',

--- a/locale/fr-ch.js
+++ b/locale/fr-ch.js
@@ -16,7 +16,7 @@ var frCh = moment.defineLocale('fr-ch', {
     monthsParseExact : true,
     weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
     weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdaysMin : 'di_lu_ma_me_je_ve_sa'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',

--- a/locale/fr.js
+++ b/locale/fr.js
@@ -16,7 +16,7 @@ var fr = moment.defineLocale('fr', {
     monthsParseExact : true,
     weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
     weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdaysMin : 'di_lu_ma_me_je_ve_sa'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -10,7 +10,7 @@ export default moment.defineLocale('fr-ca', {
     monthsParseExact : true,
     weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
     weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdaysMin : 'di_lu_ma_me_je_ve_sa'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',

--- a/src/locale/fr-ch.js
+++ b/src/locale/fr-ch.js
@@ -10,7 +10,7 @@ export default moment.defineLocale('fr-ch', {
     monthsParseExact : true,
     weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
     weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdaysMin : 'di_lu_ma_me_je_ve_sa'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -10,7 +10,7 @@ export default moment.defineLocale('fr', {
     monthsParseExact : true,
     weekdays : 'dimanche_lundi_mardi_mercredi_jeudi_vendredi_samedi'.split('_'),
     weekdaysShort : 'dim._lun._mar._mer._jeu._ven._sam.'.split('_'),
-    weekdaysMin : 'Di_Lu_Ma_Me_Je_Ve_Sa'.split('_'),
+    weekdaysMin : 'di_lu_ma_me_je_ve_sa'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',

--- a/src/test/locale/fr-ca.js
+++ b/src/test/locale/fr-ca.js
@@ -30,7 +30,7 @@ test('format', function (assert) {
             ['M Mo MM MMMM MMM',              '2 2e 02 février févr.'],
             ['YYYY YY',                       '2010 10'],
             ['D Do DD',                       '14 14e 14'],
-            ['d do dddd ddd dd',              '0 0e dimanche dim. Di'],
+            ['d do dddd ddd dd',              '0 0e dimanche dim. di'],
             ['DDD DDDo DDDD',                 '45 45e 045'],
             ['w wo ww',                       '8 8e 08'],
             ['h hh',                          '3 03'],
@@ -121,7 +121,7 @@ test('format month', function (assert) {
 
 test('format week', function (assert) {
     var i,
-        expected = 'dimanche dim. Di_lundi lun. Lu_mardi mar. Ma_mercredi mer. Me_jeudi jeu. Je_vendredi ven. Ve_samedi sam. Sa'.split('_');
+        expected = 'dimanche dim. di_lundi lun. lu_mardi mar. ma_mercredi mer. me_jeudi jeu. je_vendredi ven. ve_samedi sam. sa'.split('_');
 
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);

--- a/src/test/locale/fr-ch.js
+++ b/src/test/locale/fr-ch.js
@@ -30,7 +30,7 @@ test('format', function (assert) {
             ['M Mo MM MMMM MMM',              '2 2e 02 février févr.'],
             ['YYYY YY',                       '2010 10'],
             ['D Do DD',                       '14 14e 14'],
-            ['d do dddd ddd dd',              '0 0e dimanche dim. Di'],
+            ['d do dddd ddd dd',              '0 0e dimanche dim. di'],
             ['DDD DDDo DDDD',                 '45 45e 045'],
             ['w wo ww',                       '6 6e 06'],
             ['h hh',                          '3 03'],
@@ -121,7 +121,7 @@ test('format month', function (assert) {
 
 test('format week', function (assert) {
     var i,
-        expected = 'dimanche dim. Di_lundi lun. Lu_mardi mar. Ma_mercredi mer. Me_jeudi jeu. Je_vendredi ven. Ve_samedi sam. Sa'.split('_');
+        expected = 'dimanche dim. di_lundi lun. lu_mardi mar. ma_mercredi mer. me_jeudi jeu. je_vendredi ven. ve_samedi sam. sa'.split('_');
 
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);

--- a/src/test/locale/fr.js
+++ b/src/test/locale/fr.js
@@ -30,7 +30,7 @@ test('format', function (assert) {
             ['M Mo MM MMMM MMM',              '2 2e 02 février févr.'],
             ['YYYY YY',                       '2010 10'],
             ['D Do DD',                       '14 14 14'],
-            ['d do dddd ddd dd',              '0 0e dimanche dim. Di'],
+            ['d do dddd ddd dd',              '0 0e dimanche dim. di'],
             ['DDD DDDo DDDD',                 '45 45e 045'],
             ['w wo ww',                       '6 6e 06'],
             ['h hh',                          '3 03'],
@@ -121,7 +121,7 @@ test('format month', function (assert) {
 
 test('format week', function (assert) {
     var i,
-        expected = 'dimanche dim. Di_lundi lun. Lu_mardi mar. Ma_mercredi mer. Me_jeudi jeu. Je_vendredi ven. Ve_samedi sam. Sa'.split('_');
+        expected = 'dimanche dim. di_lundi lun. lu_mardi mar. ma_mercredi mer. me_jeudi jeu. je_vendredi ven. ve_samedi sam. sa'.split('_');
 
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);


### PR DESCRIPTION
As discussed in #4038, in french (from France and Belgium anyway, not sure at all about fr-ch and fr-ca), weekdays are written in lowercase.

And having the weekdaysMin capitalise wasn't making any real sense.