### PR TITLE
[bugfix] Verify utc date weekdays using local weekday (fixes #4227)

### DIFF
--- a/src/lib/create/from-array.js
+++ b/src/lib/create/from-array.js
@@ -21,7 +21,7 @@ function currentDateArray(config) {
 // note: all values past the year are optional and will default to the lowest possible value.
 // [year, month, day , hour, minute, second, millisecond]
 export function configFromArray (config) {
-    var i, date, input = [], currentDate, yearToUse;
+    var i, date, input = [], currentDate, localDate, yearToUse;
 
     if (config._d) {
         return;
@@ -70,7 +70,8 @@ export function configFromArray (config) {
         config._a[HOUR] = 0;
     }
 
-    config._d = (config._useUTC ? createUTCDate : createDate).apply(null, input);
+    localDate = createDate.apply(null, input);
+    config._d = config._useUTC ? createUTCDate.apply(null, input) : localDate;
     // Apply timezone offset from input. The actual utcOffset can be changed
     // with parseZone.
     if (config._tzm != null) {
@@ -82,7 +83,7 @@ export function configFromArray (config) {
     }
 
     // check for mismatching day of week
-    if (config._w && typeof config._w.d !== 'undefined' && config._w.d !== config._d.getDay()) {
+    if (config._w && typeof config._w.d !== 'undefined' && config._w.d !== localDate.getDay()) {
         getParsingFlags(config).weekdayMismatch = true;
     }
 }

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -750,6 +750,13 @@ test('parsing iso week year/week/weekday', function (assert) {
     assert.equal(moment.utc('2012-W01').format(), '2012-01-02T00:00:00Z', '2012 week 1 (1st Jan Sun)');
 });
 
+test('parsing weekday on utc dates verifies day acccording to local time', function (assert) {
+    assert.ok(moment.utc('Mon 03:59', 'ddd HH:mm').isValid(), 'Monday 03:59 (crosses UTC date');
+    assert.ok(moment.utc('Monday 03:59', 'dddd HH:mm').isValid(), 'Monday 03:59 (crosses UTC date)');
+    assert.ok(moment.utc('Mon 04:00', 'ddd HH:mm').isValid(), 'Monday 04:00');
+    assert.ok(moment.utc('Monday 04:00', 'dddd HH:mm').isValid(), 'Monday 04:00');
+});
+
 test('parsing week year/week/weekday (dow 1, doy 4)', function (assert) {
     moment.locale('dow:1,doy:4', {week: {dow: 1, doy: 4}});
 


### PR DESCRIPTION
This fixes https://github.com/moment/moment/issues/4227 where datestrings with `ddd` or `dddd` in the format returned "Invalid Date" for times that would have different dates locally than in UTC.

This bug was introduced in 2.19.0 with the introduction of the `check for mismatching day of week` if condition. The issue stems from `Date.prototype.getDay()` returns the day of week according to local time whereas for a .utc date `config._w.d` would be the day of week according to UTC. For example, since I live somewhere currently with UTC−04:00 offset, 
```js
(new Date('2017-10-28T03:59:59Z')).getDay() // -> 5
(new Date('2017-10-28T04:00:00Z')).getDay() // -> 6
```

I was able to write test cases that failed for *me* beforehand and work after my change. However, since it uses the built-in localization and Date object behind the scenes, the tests are specific to the timezone of the machine they're run on. I would really appreciate any pointers on how to make these test cases more robust (I haven't seen anything similar in the existing test base, and I've tried overwriting `Date.prototype.getTimezoneOffset` to no avail).