### PR TITLE
[bugfix] Fix #3883 lazy load parentLocale in defineLocale, fallback to global if missing

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -42,7 +42,7 @@ function chooseLocale(names) {
         }
         i++;
     }
-    return null;
+    return globalLocale;
 }
 
 function loadLocale(name) {

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -84,7 +84,7 @@ export function getSetGlobalLocale (key, values) {
 
 export function defineLocale (name, config) {
     if (config !== null) {
-        var parentConfig = baseConfig;
+        var locale, parentConfig = baseConfig;
         config.abbr = name;
         if (locales[name] != null) {
             deprecateSimple('defineLocaleOverride',
@@ -97,14 +97,19 @@ export function defineLocale (name, config) {
             if (locales[config.parentLocale] != null) {
                 parentConfig = locales[config.parentLocale]._config;
             } else {
-                if (!localeFamilies[config.parentLocale]) {
-                    localeFamilies[config.parentLocale] = [];
+                locale = loadLocale(config.parentLocale);
+                if (locale != null) {
+                    parentConfig = locale._config;
+                } else {
+                    if (!localeFamilies[config.parentLocale]) {
+                        localeFamilies[config.parentLocale] = [];
+                    }
+                    localeFamilies[config.parentLocale].push({
+                        name: name,
+                        config: config
+                    });
+                    return null;
                 }
-                localeFamilies[config.parentLocale].push({
-                    name: name,
-                    config: config
-                });
-                return null;
             }
         }
         locales[name] = new Locale(mergeConfigs(parentConfig, config));

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -183,3 +183,13 @@ test('define child locale before parent', function (assert) {
 
     assert.equal(moment().locale('months-x').month(0).format('MMMM'), 'First', 'loading child before parent locale works');
 });
+
+test('lazy load parentLocale', function (assert) {
+    moment.defineLocale('de', null);
+
+    moment.defineLocale('de_test', {
+        parentLocale: 'de',
+        monthsShort: ['M1', 'M2', 'M3', 'M4', 'M5', 'M6', 'M7', 'M8', 'M9', 'M10', 'M11', 'M12']
+    });
+    assert.equal(moment.locale(), 'de_test', 'failed to lazy load parentLocale');
+});

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -173,6 +173,9 @@ test('define child locale before parent', function (assert) {
         months : 'First_Second_Third_Fourth_Fifth_Sixth_Seventh_Eighth_Ninth_Tenth_Eleventh_Twelveth '.split('_')
     });
     assert.equal(moment.locale(), 'en', 'failed to set a locale requiring missing parent');
+
+    assert.equal(moment('00:00:00 01/January/2017', 'HH:mm:ss DD/MMM/YYYY', 'months-x').locale(), 'en', 'creating moment using child with undefined parent defaults to global');
+
     moment.defineLocale('base-months-x', {
         months : 'One_Two_Three_Four_Five_Six_Seven_Eight_Nine_Ten_Eleven_Twelve'.split('_')
     });


### PR DESCRIPTION
Fixes #3883. It's currently possible to define a locale with a parent that is not yet defined. However, in the case of this bug when attempting to create a moment using a child locale with a parent that hasn't been loaded yet or hasn't been defined causes an exception to be thrown during prepareConfig.

This fix first attempts to load the parent locale during `defineLocale` if it can't be found initially.  If in the case that a moment is created or a locale is set with a child who's parent can't be loaded or hasn't been defined, `chooseLocale` returns the global locale instead of null. This mitigates the error described in this bug report in the instance the parentLocale can't be located, and follows the same logic when defining a child can't load a parent. I've added a test for this case.

As this is an edge case it may not be necessary, but makes for a nicer experience rather than having an unhandled exception thrown. I considered adding a warning in `chooseLocale` but this affected a number of tests. 

Also, a warning was previously shown to indicate the parentLocale is missing but was removed (assuming due to the ability to define a parent after a child). However, the documentation specifies that it should still show the warning? I'm assuming in this instance the documentation needs updating.

Apologies if these scenarios have already been discussed and addressed.