### PR TITLE
[bugfix] Fix #4251: Avoid RFC2822 in utc() test

### DIFF
--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -354,8 +354,8 @@ test('string with format (timezone offset)', function (assert) {
     c = moment('2011 2 1 10 -05:00', 'YYYY MM DD HH Z');
     d = moment('2011 2 1 8 -07:00', 'YYYY MM DD HH Z');
     assert.equal(c.hours(), d.hours(), '10 am central time == 8 am pacific time');
-    e = moment.utc('Fri, 20 Jul 2012 17:15:00', 'ddd, DD MMM YYYY HH:mm:ss');
-    f = moment.utc('Fri, 20 Jul 2012 10:15:00 -0700', 'ddd, DD MMM YYYY HH:mm:ss ZZ');
+    e = moment.utc('20 07 2012 17:15:00', 'DD MM YYYY HH:mm:ss');
+    f = moment.utc('20 07 2012 10:15:00 -0700', 'DD MM YYYY HH:mm:ss ZZ');
     assert.equal(e.hours(), f.hours(), 'parse timezone offset in utc');
 });
 


### PR DESCRIPTION
In `zh-cn` locale (among others) the end of [string with format (timezone offset) unit-test](https://github.com/moment/moment/blob/328d51e7235b7a2d443bfdf69c1844939c115660/src/test/moment/create.js#L357) attempts to create two dates using RFC formatted strings passed to `moment.utc()` with explicit format strings.

This fails because it tries to parse the month and day-of-week using the users locale (`zh-cn`) instead of the English required to parse RFC2822.

This PR removes the locale-specific formatting from the unit-test.

Fixes #4251 