### PR TITLE
Added locale en-ilֿ

### DIFF
--- a/src/locale/en-il.js
+++ b/src/locale/en-il.js
@@ -1,0 +1,54 @@
+//! moment.js locale configuration
+//! locale : English (Israel) [en-il]
+//! author : Chris Gedrim : https://github.com/chrisgedrim
+
+import moment from '../moment';
+
+export default moment.defineLocale('en-il', {
+    months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),
+    monthsShort : 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
+    weekdays : 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
+    weekdaysShort : 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
+    weekdaysMin : 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
+    longDateFormat : {
+        LT : 'HH:mm',
+        LTS : 'HH:mm:ss',
+        L : 'DD/MM/YYYY',
+        LL : 'D MMMM YYYY',
+        LLL : 'D MMMM YYYY HH:mm',
+        LLLL : 'dddd, D MMMM YYYY HH:mm'
+    },
+    calendar : {
+        sameDay : '[Today at] LT',
+        nextDay : '[Tomorrow at] LT',
+        nextWeek : 'dddd [at] LT',
+        lastDay : '[Yesterday at] LT',
+        lastWeek : '[Last] dddd [at] LT',
+        sameElse : 'L'
+    },
+    relativeTime : {
+        future : 'in %s',
+        past : '%s ago',
+        s : 'a few seconds',
+        m : 'a minute',
+        mm : '%d minutes',
+        h : 'an hour',
+        hh : '%d hours',
+        d : 'a day',
+        dd : '%d days',
+        M : 'a month',
+        MM : '%d months',
+        y : 'a year',
+        yy : '%d years'
+    },
+    dayOfMonthOrdinalParse: /\d{1,2}(st|nd|rd|th)/,
+    ordinal : function (number) {
+        var b = number % 10,
+            output = (~~(number % 100 / 10) === 1) ? 'th' :
+            (b === 1) ? 'st' :
+            (b === 2) ? 'nd' :
+            (b === 3) ? 'rd' : 'th';
+        return number + output;
+    }
+});
+

--- a/src/test/locale/en-il.js
+++ b/src/test/locale/en-il.js
@@ -1,0 +1,214 @@
+import {localeModule, test} from '../qunit';
+import moment from '../../moment';
+localeModule('en-il');
+
+test('parse', function (assert) {
+    var tests = 'January Jan_February Feb_March Mar_April Apr_May May_June Jun_July Jul_August Aug_September Sep_October Oct_November Nov_December Dec'.split('_'), i;
+    function equalTest(input, mmm, i) {
+        assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
+    }
+    for (i = 0; i < 12; i++) {
+        tests[i] = tests[i].split(' ');
+        equalTest(tests[i][0], 'MMM', i);
+        equalTest(tests[i][1], 'MMM', i);
+        equalTest(tests[i][0], 'MMMM', i);
+        equalTest(tests[i][1], 'MMMM', i);
+        equalTest(tests[i][0].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i][1].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i][0].toLocaleUpperCase(), 'MMMM', i);
+        equalTest(tests[i][1].toLocaleUpperCase(), 'MMMM', i);
+    }
+});
+
+test('format', function (assert) {
+    var a = [
+            ['dddd, MMMM Do YYYY, h:mm:ss a',      'Sunday, February 14th 2010, 3:25:50 pm'],
+            ['ddd, hA',                            'Sun, 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2nd 02 February Feb'],
+            ['YYYY YY',                            '2010 10'],
+            ['D Do DD',                            '14 14th 14'],
+            ['d do dddd ddd dd',                   '0 0th Sunday Sun Su'],
+            ['DDD DDDo DDDD',                      '45 45th 045'],
+            ['w wo ww',                            '8 8th 08'],
+            ['h hh',                               '3 03'],
+            ['H HH',                               '15 15'],
+            ['m mm',                               '25 25'],
+            ['s ss',                               '50 50'],
+            ['a A',                                'pm PM'],
+            ['[the] DDDo [day of the year]',       'the 45th day of the year'],
+            ['LTS',                                '15:25:50'],
+            ['L',                                  '14/02/2010'],
+            ['LL',                                 '14 February 2010'],
+            ['LLL',                                '14 February 2010 15:25'],
+            ['LLLL',                               'Sunday, 14 February 2010 15:25'],
+            ['l',                                  '14/2/2010'],
+            ['ll',                                 '14 Feb 2010'],
+            ['lll',                                '14 Feb 2010 15:25'],
+            ['llll',                               'Sun, 14 Feb 2010 15:25']
+        ],
+        b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
+        i;
+    for (i = 0; i < a.length; i++) {
+        assert.equal(b.format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
+    }
+});
+
+test('format ordinal', function (assert) {
+    assert.equal(moment([2011, 0, 1]).format('DDDo'), '1st', '1st');
+    assert.equal(moment([2011, 0, 2]).format('DDDo'), '2nd', '2nd');
+    assert.equal(moment([2011, 0, 3]).format('DDDo'), '3rd', '3rd');
+    assert.equal(moment([2011, 0, 4]).format('DDDo'), '4th', '4th');
+    assert.equal(moment([2011, 0, 5]).format('DDDo'), '5th', '5th');
+    assert.equal(moment([2011, 0, 6]).format('DDDo'), '6th', '6th');
+    assert.equal(moment([2011, 0, 7]).format('DDDo'), '7th', '7th');
+    assert.equal(moment([2011, 0, 8]).format('DDDo'), '8th', '8th');
+    assert.equal(moment([2011, 0, 9]).format('DDDo'), '9th', '9th');
+    assert.equal(moment([2011, 0, 10]).format('DDDo'), '10th', '10th');
+
+    assert.equal(moment([2011, 0, 11]).format('DDDo'), '11th', '11th');
+    assert.equal(moment([2011, 0, 12]).format('DDDo'), '12th', '12th');
+    assert.equal(moment([2011, 0, 13]).format('DDDo'), '13th', '13th');
+    assert.equal(moment([2011, 0, 14]).format('DDDo'), '14th', '14th');
+    assert.equal(moment([2011, 0, 15]).format('DDDo'), '15th', '15th');
+    assert.equal(moment([2011, 0, 16]).format('DDDo'), '16th', '16th');
+    assert.equal(moment([2011, 0, 17]).format('DDDo'), '17th', '17th');
+    assert.equal(moment([2011, 0, 18]).format('DDDo'), '18th', '18th');
+    assert.equal(moment([2011, 0, 19]).format('DDDo'), '19th', '19th');
+    assert.equal(moment([2011, 0, 20]).format('DDDo'), '20th', '20th');
+
+    assert.equal(moment([2011, 0, 21]).format('DDDo'), '21st', '21st');
+    assert.equal(moment([2011, 0, 22]).format('DDDo'), '22nd', '22nd');
+    assert.equal(moment([2011, 0, 23]).format('DDDo'), '23rd', '23rd');
+    assert.equal(moment([2011, 0, 24]).format('DDDo'), '24th', '24th');
+    assert.equal(moment([2011, 0, 25]).format('DDDo'), '25th', '25th');
+    assert.equal(moment([2011, 0, 26]).format('DDDo'), '26th', '26th');
+    assert.equal(moment([2011, 0, 27]).format('DDDo'), '27th', '27th');
+    assert.equal(moment([2011, 0, 28]).format('DDDo'), '28th', '28th');
+    assert.equal(moment([2011, 0, 29]).format('DDDo'), '29th', '29th');
+    assert.equal(moment([2011, 0, 30]).format('DDDo'), '30th', '30th');
+
+    assert.equal(moment([2011, 0, 31]).format('DDDo'), '31st', '31st');
+});
+
+test('format month', function (assert) {
+    var expected = 'January Jan_February Feb_March Mar_April Apr_May May_June Jun_July Jul_August Aug_September Sep_October Oct_November Nov_December Dec'.split('_'), i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
+    }
+});
+
+test('format week', function (assert) {
+    var expected = 'Sunday Sun Su_Monday Mon Mo_Tuesday Tue Tu_Wednesday Wed We_Thursday Thu Th_Friday Fri Fr_Saturday Sat Sa'.split('_'), i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
+    }
+});
+
+test('from', function (assert) {
+    var start = moment([2007, 1, 28]);
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 44}), true),  'a few seconds', '44 seconds = a few seconds');
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 45}), true),  'a minute',      '45 seconds = a minute');
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 89}), true),  'a minute',      '89 seconds = a minute');
+    assert.equal(start.from(moment([2007, 1, 28]).add({s: 90}), true),  '2 minutes',     '90 seconds = 2 minutes');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 44}), true),  '44 minutes',    '44 minutes = 44 minutes');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 45}), true),  'an hour',       '45 minutes = an hour');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 89}), true),  'an hour',       '89 minutes = an hour');
+    assert.equal(start.from(moment([2007, 1, 28]).add({m: 90}), true),  '2 hours',       '90 minutes = 2 hours');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 5}), true),   '5 hours',       '5 hours = 5 hours');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 21}), true),  '21 hours',      '21 hours = 21 hours');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 22}), true),  'a day',         '22 hours = a day');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 35}), true),  'a day',         '35 hours = a day');
+    assert.equal(start.from(moment([2007, 1, 28]).add({h: 36}), true),  '2 days',        '36 hours = 2 days');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 1}), true),   'a day',         '1 day = a day');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 5}), true),   '5 days',        '5 days = 5 days');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 25}), true),  '25 days',       '25 days = 25 days');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 26}), true),  'a month',       '26 days = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 30}), true),  'a month',       '30 days = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 43}), true),  'a month',       '43 days = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 46}), true),  '2 months',      '46 days = 2 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 74}), true),  '2 months',      '75 days = 2 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 76}), true),  '3 months',      '76 days = 3 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({M: 1}), true),   'a month',       '1 month = a month');
+    assert.equal(start.from(moment([2007, 1, 28]).add({M: 5}), true),   '5 months',      '5 months = 5 months');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 345}), true), 'a year',        '345 days = a year');
+    assert.equal(start.from(moment([2007, 1, 28]).add({d: 548}), true), '2 years',       '548 days = 2 years');
+    assert.equal(start.from(moment([2007, 1, 28]).add({y: 1}), true),   'a year',        '1 year = a year');
+    assert.equal(start.from(moment([2007, 1, 28]).add({y: 5}), true),   '5 years',       '5 years = 5 years');
+});
+
+test('suffix', function (assert) {
+    assert.equal(moment(30000).from(0), 'in a few seconds',  'prefix');
+    assert.equal(moment(0).from(30000), 'a few seconds ago', 'suffix');
+});
+
+test('now from now', function (assert) {
+    assert.equal(moment().fromNow(), 'a few seconds ago',  'now from now should display as in the past');
+});
+
+test('fromNow', function (assert) {
+    assert.equal(moment().add({s: 30}).fromNow(), 'in a few seconds', 'in a few seconds');
+    assert.equal(moment().add({d: 5}).fromNow(), 'in 5 days', 'in 5 days');
+});
+
+test('calendar day', function (assert) {
+    var a = moment().hours(12).minutes(0).seconds(0);
+
+    assert.equal(moment(a).calendar(),                   'Today at 12:00',      'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(),      'Today at 12:25',      'Now plus 25 min');
+    assert.equal(moment(a).add({h: 1}).calendar(),       'Today at 13:00',      'Now plus 1 hour');
+    assert.equal(moment(a).add({d: 1}).calendar(),       'Tomorrow at 12:00',   'tomorrow at the same time');
+    assert.equal(moment(a).subtract({h: 1}).calendar(),  'Today at 11:00',      'Now minus 1 hour');
+    assert.equal(moment(a).subtract({d: 1}).calendar(),  'Yesterday at 12:00',  'yesterday at the same time');
+});
+
+test('calendar next week', function (assert) {
+    var i, m;
+    for (i = 2; i < 7; i++) {
+        m = moment().add({d: i});
+        assert.equal(m.calendar(),       m.format('dddd [at] LT'),  'Today + ' + i + ' days current time');
+        m.hours(0).minutes(0).seconds(0).milliseconds(0);
+        assert.equal(m.calendar(),       m.format('dddd [at] LT'),  'Today + ' + i + ' days beginning of day');
+        m.hours(23).minutes(59).seconds(59).milliseconds(999);
+        assert.equal(m.calendar(),       m.format('dddd [at] LT'),  'Today + ' + i + ' days end of day');
+    }
+});
+
+test('calendar last week', function (assert) {
+    var i, m;
+
+    for (i = 2; i < 7; i++) {
+        m = moment().subtract({d: i});
+        assert.equal(m.calendar(),       m.format('[Last] dddd [at] LT'),  'Today - ' + i + ' days current time');
+        m.hours(0).minutes(0).seconds(0).milliseconds(0);
+        assert.equal(m.calendar(),       m.format('[Last] dddd [at] LT'),  'Today - ' + i + ' days beginning of day');
+        m.hours(23).minutes(59).seconds(59).milliseconds(999);
+        assert.equal(m.calendar(),       m.format('[Last] dddd [at] LT'),  'Today - ' + i + ' days end of day');
+    }
+});
+
+test('calendar all else', function (assert) {
+    var weeksAgo = moment().subtract({w: 1}),
+        weeksFromNow = moment().add({w: 1});
+
+    assert.equal(weeksAgo.calendar(),       weeksAgo.format('L'),  '1 week ago');
+    assert.equal(weeksFromNow.calendar(),   weeksFromNow.format('L'),  'in 1 week');
+
+    weeksAgo = moment().subtract({w: 2});
+    weeksFromNow = moment().add({w: 2});
+
+    assert.equal(weeksAgo.calendar(),       weeksAgo.format('L'),  '2 weeks ago');
+    assert.equal(weeksFromNow.calendar(),   weeksFromNow.format('L'),  'in 2 weeks');
+});
+
+test('weeks year starting sunday formatted', function (assert) {
+    assert.equal(moment([2012, 0,  1]).format('w ww wo'), '1 01 1st', 'Jan  1 2012 should be week 1');
+    assert.equal(moment([2012, 0,  7]).format('w ww wo'), '1 01 1st', 'Jan  7 2012 should be week 1');
+    assert.equal(moment([2012, 0,  8]).format('w ww wo'), '2 02 2nd', 'Jan  8 2012 should be week 2');
+    assert.equal(moment([2012, 0, 14]).format('w ww wo'), '2 02 2nd', 'Jan 14 2012 should be week 2');
+    assert.equal(moment([2012, 0, 15]).format('w ww wo'), '3 03 3rd', 'Jan 15 2012 should be week 3');
+});
+
+test('days start on sunday', function (assert) {
+    assert.equal(moment().startOf('week').format('dddd'), 'Sunday', 'First day of the week should be Sunday');
+});
+


### PR DESCRIPTION
Israel has many English speaking citizens / visitors, however, none of the existing English locales match the needed configuration in Israel.

en-il vs en-gb:
1. The first day of the week is Sunday.
2. The first week of the year is the week of January 1st.

en-il vs en-us:
1. The calendar format is DD/MM/YYYY.
2. It uses 24 hours clock.

This pull request includes tests.