### PR TITLE
[bugfix] Fix startOf/endOf DST issues while boosting performance

### DIFF
--- a/src/lib/create/date-from-array.js
+++ b/src/lib/create/date-from-array.js
@@ -20,7 +20,7 @@ export function createDate (y, m, d, h, M, s, ms) {
 
 export function createUTCDate (y) {
     var date;
-    // the date constructor remaps years 0-99 to 1900-1999
+    // the Date.UTC function remaps years 0-99 to 1900-1999
     if (y < 100 && y >= 0) {
         var args = Array.prototype.slice.call(arguments);
         args[0] = y + 400;

--- a/src/lib/create/date-from-array.js
+++ b/src/lib/create/date-from-array.js
@@ -1,15 +1,9 @@
 export function createDate (y, m, d, h, M, s, ms) {
-    var date;
     // the date constructor remaps years 0-99 to 1900-1999
     var remapYears = (y < 100 && y >= 0);
     // can't just apply() to create a date:
     // https://stackoverflow.com/q/181348
-    if (arguments.length === 3) {
-        // Special-case: handles dates that don't start at midnight
-        date = new Date(remapYears ? y + 400 : y, m, d);
-    } else {
-        date = new Date(remapYears ? y + 400 : y, m, d, h, M, s, ms);
-    }
+    var date = new Date(remapYears ? y + 400 : y, m, d, h, M, s, ms);
 
     if (remapYears && isFinite(date.getFullYear())) {
         date.setFullYear(y);

--- a/src/lib/create/date-from-array.js
+++ b/src/lib/create/date-from-array.js
@@ -1,12 +1,16 @@
 export function createDate (y, m, d, h, M, s, ms) {
-    // the date constructor remaps years 0-99 to 1900-1999
-    var remapYears = (y < 100 && y >= 0);
     // can't just apply() to create a date:
     // https://stackoverflow.com/q/181348
-    var date = new Date(remapYears ? y + 400 : y, m, d, h, M, s, ms);
-
-    if (remapYears && isFinite(date.getFullYear())) {
-        date.setFullYear(y);
+    var date;
+    // the date constructor remaps years 0-99 to 1900-1999
+    if (y < 100 && y >= 0) {
+        // preserve leap years using a full 400 year cycle, then reset
+        date = new Date(y + 400, m, d, h, M, s, ms);
+        if (isFinite(date.getFullYear())) {
+            date.setFullYear(y);
+        }
+    } else {
+        date = new Date(y, m, d, h, M, s, ms);
     }
 
     return date;
@@ -17,6 +21,7 @@ export function createUTCDate (y) {
     // the Date.UTC function remaps years 0-99 to 1900-1999
     if (y < 100 && y >= 0) {
         var args = Array.prototype.slice.call(arguments);
+        // preserve leap years using a full 400 year cycle, then reset
         args[0] = y + 400;
         date = new Date(Date.UTC.apply(null, args));
         if (isFinite(date.getUTCFullYear())) {

--- a/src/lib/create/date-from-array.js
+++ b/src/lib/create/date-from-array.js
@@ -1,21 +1,36 @@
 export function createDate (y, m, d, h, M, s, ms) {
+    var date;
+    // the date constructor remaps years 0-99 to 1900-1999
+    var remapYears = (y < 100 && y >= 0);
     // can't just apply() to create a date:
     // https://stackoverflow.com/q/181348
-    var date = new Date(y, m, d, h, M, s, ms);
+    if (arguments.length === 3) {
+        // Special-case: handles dates that don't start at midnight
+        date = new Date(remapYears ? y + 400 : y, m, d);
+    } else {
+        date = new Date(remapYears ? y + 400 : y, m, d, h, M, s, ms);
+    }
 
-    // the date constructor remaps years 0-99 to 1900-1999
-    if (y < 100 && y >= 0 && isFinite(date.getFullYear())) {
+    if (remapYears && isFinite(date.getFullYear())) {
         date.setFullYear(y);
     }
+
     return date;
 }
 
 export function createUTCDate (y) {
-    var date = new Date(Date.UTC.apply(null, arguments));
-
-    // the Date.UTC function remaps years 0-99 to 1900-1999
-    if (y < 100 && y >= 0 && isFinite(date.getUTCFullYear())) {
-        date.setUTCFullYear(y);
+    var date;
+    // the date constructor remaps years 0-99 to 1900-1999
+    if (y < 100 && y >= 0) {
+        var args = Array.prototype.slice.call(arguments);
+        args[0] = y + 400;
+        date = new Date(Date.UTC.apply(null, args));
+        if (isFinite(date.getUTCFullYear())) {
+            date.setUTCFullYear(y);
+        }
+    } else {
+        date = new Date(Date.UTC.apply(null, arguments));
     }
+
     return date;
 }

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -4,8 +4,7 @@ import { hooks } from '../utils/hooks';
 var MS_PER_SECOND = 1000;
 var MS_PER_MINUTE = 60 * MS_PER_SECOND;
 var MS_PER_HOUR = 60 * MS_PER_MINUTE;
-var MS_PER_DAY = 24 * MS_PER_HOUR;
-var MS_PER_400_YEARS = (365 * 400 + 97) * MS_PER_DAY;
+var MS_PER_400_YEARS = (365 * 400 + 97) * 24 * MS_PER_HOUR;
 
 // actual modulo - handles negative numbers (for dates before 1970):
 function mod(dividend, divisor) {

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -4,8 +4,8 @@ import { hooks } from '../utils/hooks';
 var MS_PER_SECOND = 1000;
 var MS_PER_MINUTE = 60 * MS_PER_SECOND;
 var MS_PER_HOUR = 60 * MS_PER_MINUTE;
-var MS_PER_24_HOUR_DAY = 24 * MS_PER_HOUR;
-var MS_PER_400_YEARS = (365 * 400 + 97) * MS_PER_24_HOUR_DAY;
+var MS_PER_DAY = 24 * MS_PER_HOUR;
+var MS_PER_400_YEARS = (365 * 400 + 97) * MS_PER_DAY;
 
 // actual modulo - handles negative numbers (for dates before 1970):
 function mod(dividend, divisor) {

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -17,7 +17,7 @@ function localStartOfDate(y, m, d) {
     if (0 <= y && y <= 99) {
         return new Date(y + 400, m, d) - MS_PER_400_YEARS;
     } else {
-        return new Date(y, m, d).getTime();
+        return new Date(y, m, d).valueOf();
     }
 }
 
@@ -62,7 +62,6 @@ export function startOf (units) {
         case 'hour':
             time = this._d.valueOf();
             time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR));
-            // FIXME: Special case: handle fractional DST changes:
             break;
         case 'minute':
             time = this._d.valueOf();
@@ -111,7 +110,6 @@ export function endOf (units) {
         case 'hour':
             time = this._d.valueOf();
             time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR) + MS_PER_HOUR - 1);
-            // FIXME: Special case: handle fractional DST changes:
             break;
         case 'minute':
             time = this._d.valueOf();

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -5,10 +5,29 @@ var MS_PER_SECOND = 1000;
 var MS_PER_MINUTE = 60 * MS_PER_SECOND;
 var MS_PER_HOUR = 60 * MS_PER_MINUTE;
 var MS_PER_24_HOUR_DAY = 24 * MS_PER_HOUR;
+var MS_PER_400_YEARS = (365 * 400 + 97) * MS_PER_24_HOUR_DAY;
 
 // actual modulo - handles negative numbers (for dates before 1970):
 function mod(dividend, divisor) {
     return (dividend % divisor + divisor) % divisor;
+}
+
+function localStartOfDate(y, m, d) {
+    // the date constructor remaps years 0-99 to 1900-1999
+    if (0 <= y && y <= 99) {
+        return new Date(y + 400, m, d) - MS_PER_400_YEARS;
+    } else {
+        return new Date(y, m, d).getTime();
+    }
+}
+
+function utcStartOfDate(y, m, d) {
+    // Date.UTC remaps years 0-99 to 1900-1999
+    if (0 <= y && y <= 99) {
+        return Date.UTC(y + 400, m, d) - MS_PER_400_YEARS;
+    } else {
+        return Date.UTC(y, m, d);
+    }
 }
 
 export function startOf (units) {
@@ -18,56 +37,32 @@ export function startOf (units) {
         return this;
     }
 
+    var startOfDate = this._isUTC ? utcStartOfDate : localStartOfDate;
+
     switch (units) {
         case 'year':
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), 0) :
-                    new Date(this.year(), 0).valueOf())
-            );
+            time = startOfDate(this.year(), 0, 1);
             break;
         case 'quarter':
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), this.month() - this.month() % 3) :
-                    new Date(this.year(), this.month() - this.month() % 3).valueOf())
-            );
+            time = startOfDate(this.year(), this.month() - this.month() % 3, 1);
             break;
         case 'month':
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), this.month()) :
-                    new Date(this.year(), this.month()).valueOf())
-            );
+            time = startOfDate(this.year(), this.month(), 1);
             break;
         case 'week':
-            // start of week should be: this.date() - this.weekday():
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), this.month(), this.date() - this.weekday()) :
-                    new Date(this.year(), this.month(), this.date() - this.weekday()).valueOf())
-            );
+            time = startOfDate(this.year(), this.month(), this.date() - this.weekday());
             break;
         case 'isoWeek':
-            // start of iso week should be: this.date() - (this.isoWeekday - 1):
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), this.month(), this.date() - (this.isoWeekday() - 1)) :
-                    new Date(this.year(), this.month(), this.date() - (this.isoWeekday() - 1)).valueOf())
-            );
+            time = startOfDate(this.year(), this.month(), this.date() - (this.isoWeekday() - 1));
             break;
         case 'day':
         case 'date':
-            time = this._d.valueOf();
-            time = (
-                (this._isUTC ?
-                    time - mod(time, MS_PER_24_HOUR_DAY) :
-                    new Date(this.year(), this.month(), this.date()).valueOf())
-            );
+            time = startOfDate(this.year(), this.month(), this.date());
             break;
         case 'hour':
             time = this._d.valueOf();
             time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR));
+            // FIXME: Special case: handle fractional DST changes:
             break;
         case 'minute':
             time = this._d.valueOf();
@@ -91,56 +86,32 @@ export function endOf (units) {
         return this;
     }
 
+    var startOfDate = this._isUTC ? utcStartOfDate : localStartOfDate;
+
     switch (units) {
         case 'year':
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year() + 1, 0) :
-                    new Date(this.year() + 1, 0).valueOf()) - 1
-            );
+            time = startOfDate(this.year() + 1, 0, 1) - 1;
             break;
         case 'quarter':
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), 3 + this.month() - this.month() % 3) :
-                    new Date(this.year(), 3 + this.month() - this.month() % 3).valueOf()) - 1
-            );
+            time = startOfDate(this.year(), this.month() - this.month() % 3 + 3, 1) - 1;
             break;
         case 'month':
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), 1 + this.month()) :
-                    new Date(this.year(), 1 + this.month()).valueOf()) - 1
-            );
+            time = startOfDate(this.year(), this.month() + 1, 1) - 1;
             break;
         case 'week':
-            // start of week should be: this.date() - this.weekday(), so end of week would be: this.date() - this.weekday() + 7
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), this.month(), this.date() + 7 - this.weekday()) :
-                    new Date(this.year(), this.month(), this.date() + 7 - this.weekday()).valueOf()) - 1
-            );
+            time = startOfDate(this.year(), this.month(), this.date() - this.weekday() + 7) - 1;
             break;
         case 'isoWeek':
-            // start of iso week should be: this.date() - (this.isoWeekday - 1), so end would be: this.date() - (this.isoWeekday() - 1) + 7
-            time = (
-                (this._isUTC ?
-                    Date.UTC(this.year(), this.month(), this.date() + 7 - (this.isoWeekday() - 1)) :
-                    new Date(this.year(), this.month(), this.date() + 7 - (this.isoWeekday() - 1)).valueOf()) - 1
-            );
+            time = startOfDate(this.year(), this.month(), this.date() - (this.isoWeekday() - 1) + 7) - 1;
             break;
         case 'day':
         case 'date':
-            time = this._d.valueOf();
-            time = (
-                (this._isUTC ?
-                    time - mod(time, MS_PER_24_HOUR_DAY) + MS_PER_24_HOUR_DAY :
-                    new Date(this.year(), this.month(), this.date() + 1).valueOf()) - 1
-            );
+            time = startOfDate(this.year(), this.month(), this.date() + 1) - 1;
             break;
         case 'hour':
             time = this._d.valueOf();
             time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR) + MS_PER_HOUR - 1);
+            // FIXME: Special case: handle fractional DST changes:
             break;
         case 'minute':
             time = this._d.valueOf();

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -1,6 +1,18 @@
 import { normalizeUnits } from '../units/aliases';
+import { hooks } from '../utils/hooks';
+
+var MS_PER_SECOND = 1000;
+var MS_PER_MINUTE = 60 * MS_PER_SECOND;
+var MS_PER_HOUR = 60 * MS_PER_MINUTE;
+var MS_PER_24_HOUR_DAY = 24 * MS_PER_HOUR;
+
+// actual modulo - handles negative numbers (for dates before 1970):
+function mod(dividend, divisor) {
+    return (dividend % divisor + divisor) % divisor;
+}
 
 export function startOf (units) {
+    var time;
     units = normalizeUnits(units);
     // the following switch intentionally omits break keywords
     // to utilize falling through the cases.
@@ -16,16 +28,36 @@ export function startOf (units) {
         case 'isoWeek':
         case 'day':
         case 'date':
-            this.hours(0);
-            /* falls through */
+            if (this.isValid()) {
+                if (this._isUTC) {
+                    time = this._d.valueOf();
+                    this._d.setTime(time - mod(time, MS_PER_24_HOUR_DAY));
+                } else {
+                    this._d.setTime(new Date(this.year(), this.month(), this.date()).valueOf());
+                }
+                hooks.updateOffset(this, true);
+            }
+            break;
         case 'hour':
-            this.minutes(0);
-            /* falls through */
+            if (this.isValid()) {
+                var offset = this._isUTC ? 0 : this.utcOffset();
+                time = this._d.valueOf();
+                this._d.setTime(time - mod(time + offset * MS_PER_MINUTE, MS_PER_HOUR));
+                hooks.updateOffset(this, true);
+            }
+            break;
         case 'minute':
-            this.seconds(0);
-            /* falls through */
+            if (this.isValid()) {
+                time = this._d.valueOf();
+                this._d.setTime(time - mod(time, MS_PER_MINUTE));
+            }
+            break;
         case 'second':
-            this.milliseconds(0);
+            if (this.isValid()) {
+                time = this._d.valueOf();
+                this._d.setTime(time - mod(time, MS_PER_SECOND));
+            }
+            break;
     }
 
     // weeks are a special case
@@ -53,6 +85,19 @@ export function endOf (units) {
     // 'date' is an alias for 'day', so it should be considered as such.
     if (units === 'date') {
         units = 'day';
+    }
+
+    if (units === 'day') {
+        if (this.isValid()) {
+            if (this._isUTC) {
+                var time = this._d.valueOf();
+                this._d.setTime(time - mod(time, MS_PER_24_HOUR_DAY) + MS_PER_24_HOUR_DAY - 1);
+            } else {
+                this._d.setTime(new Date(this.year(), this.month(), this.date() + 1).valueOf() - 1);
+            }
+            hooks.updateOffset(this, true);
+        }
+        return this;
     }
 
     return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -18,91 +18,69 @@ export function startOf (units) {
         return this;
     }
 
-    if (this._isUTC) {
-        switch (units) {
-            case 'year':
-                this._d.setTime(Date.UTC(this.year(), 0));
-                hooks.updateOffset(this, true);
-                break;
-            case 'quarter':
-                this._d.setTime(Date.UTC(this.year(), this.month() - (this.month() % 3)));
-                hooks.updateOffset(this, true);
-                break;
-            case 'month':
-                this._d.setTime(Date.UTC(this.year(), this.month()));
-                hooks.updateOffset(this, true);
-                break;
-            case 'week':
-            case 'isoWeek':
-            case 'day':
-            case 'date':
-                time = this._d.valueOf();
-                this._d.setTime(time - mod(time, MS_PER_24_HOUR_DAY));
-                hooks.updateOffset(this, true);
-                // Note: there may be a better/faster way of doing this with UTC...
-                if (units === 'week') {
-                    this.weekday(0);
-                } else if (units === 'isoWeek') {
-                    this.isoWeekday(1);
-                }
-                break;
-            case 'hour':
-                time = this._d.valueOf();
-                this._d.setTime(time - mod(time, MS_PER_HOUR));
-                hooks.updateOffset(this, true);
-                break;
-            case 'minute':
-                time = this._d.valueOf();
-                this._d.setTime(time - mod(time, MS_PER_MINUTE));
-                break;
-            case 'second':
-                time = this._d.valueOf();
-                this._d.setTime(time - mod(time, MS_PER_SECOND));
-                break;
-        }
-    } else {
-        switch (units) {
-            case 'year':
-                this._d.setTime(new Date(this.year(), 0).valueOf());
-                hooks.updateOffset(this, true);
-                break;
-            case 'quarter':
-                this._d.setTime(new Date(this.year(), this.month() - (this.month() % 3)).valueOf());
-                hooks.updateOffset(this, true);
-                break;
-            case 'month':
-                this._d.setTime(new Date(this.year(), this.month()).valueOf());
-                hooks.updateOffset(this, true);
-                break;
-            case 'week':
-            case 'isoWeek':
-            case 'day':
-            case 'date':
-                this._d.setTime(new Date(this.year(), this.month(), this.date()).valueOf());
-                hooks.updateOffset(this, true);
-                // weeks are a special case
-                if (units === 'week') {
-                    this.weekday(0);
-                } else if (units === 'isoWeek') {
-                    this.isoWeekday(1);
-                }
-                break;
-            case 'hour':
-                time = this._d.valueOf();
-                this._d.setTime(time - mod(time + this.utcOffset() * MS_PER_MINUTE, MS_PER_HOUR));
-                hooks.updateOffset(this, true);
-                break;
-            case 'minute':
-                time = this._d.valueOf();
-                this._d.setTime(time - mod(time, MS_PER_MINUTE));
-                break;
-            case 'second':
-                time = this._d.valueOf();
-                this._d.setTime(time - mod(time, MS_PER_SECOND));
-                break;
-        }
+    switch (units) {
+        case 'year':
+            time = (
+                (this._isUTC ?
+                    Date.UTC(this.year(), 0) :
+                    new Date(this.year(), 0).valueOf())
+            );
+            break;
+        case 'quarter':
+            time = (
+                (this._isUTC ?
+                    Date.UTC(this.year(), this.month() - this.month() % 3) :
+                    new Date(this.year(), this.month() - this.month() % 3).valueOf())
+            );
+            break;
+        case 'month':
+            time = (
+                (this._isUTC ?
+                    Date.UTC(this.year(), this.month()) :
+                    new Date(this.year(), this.month()).valueOf())
+            );
+            break;
+        case 'week':
+            // start of week should be: this.date() - this.weekday():
+            time = (
+                (this._isUTC ?
+                    Date.UTC(this.year(), this.month(), this.date() - this.weekday()) :
+                    new Date(this.year(), this.month(), this.date() - this.weekday()).valueOf())
+            );
+            break;
+        case 'isoWeek':
+            // start of iso week should be: this.date() - (this.isoWeekday - 1):
+            time = (
+                (this._isUTC ?
+                    Date.UTC(this.year(), this.month(), this.date() - (this.isoWeekday() - 1)) :
+                    new Date(this.year(), this.month(), this.date() - (this.isoWeekday() - 1)).valueOf())
+            );
+            break;
+        case 'day':
+        case 'date':
+            time = this._d.valueOf();
+            time = (
+                (this._isUTC ?
+                    time - mod(time, MS_PER_24_HOUR_DAY) :
+                    new Date(this.year(), this.month(), this.date()).valueOf())
+            );
+            break;
+        case 'hour':
+            time = this._d.valueOf();
+            time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR));
+            break;
+        case 'minute':
+            time = this._d.valueOf();
+            this._d.setTime(time - mod(time, MS_PER_MINUTE));
+            return this;
+        case 'second':
+            time = this._d.valueOf();
+            this._d.setTime(time - mod(time, MS_PER_SECOND));
+            return this;
     }
 
+    this._d.setTime(time);
+    hooks.updateOffset(this, true);
     return this;
 }
 
@@ -115,67 +93,66 @@ export function endOf (units) {
 
     switch (units) {
         case 'year':
-            this._d.setTime((this._isUTC ? Date.UTC(this.year() + 1, 0) : new Date(this.year() + 1, 0).valueOf()) - 1);
-            hooks.updateOffset(this, true);
+            time = (
+                (this._isUTC ?
+                    Date.UTC(this.year() + 1, 0) :
+                    new Date(this.year() + 1, 0).valueOf()) - 1
+            );
             break;
         case 'quarter':
-            this._d.setTime(
+            time = (
                 (this._isUTC ?
                     Date.UTC(this.year(), 3 + this.month() - this.month() % 3) :
                     new Date(this.year(), 3 + this.month() - this.month() % 3).valueOf()) - 1
             );
-            hooks.updateOffset(this, true);
             break;
         case 'month':
-            this._d.setTime(
+            time = (
                 (this._isUTC ?
                     Date.UTC(this.year(), 1 + this.month()) :
                     new Date(this.year(), 1 + this.month()).valueOf()) - 1
             );
-            hooks.updateOffset(this, true);
             break;
         case 'week':
             // start of week should be: this.date() - this.weekday(), so end of week would be: this.date() - this.weekday() + 7
-            this._d.setTime(
+            time = (
                 (this._isUTC ?
                     Date.UTC(this.year(), this.month(), this.date() + 7 - this.weekday()) :
                     new Date(this.year(), this.month(), this.date() + 7 - this.weekday()).valueOf()) - 1
             );
-            hooks.updateOffset(this, true);
             break;
         case 'isoWeek':
             // start of iso week should be: this.date() - (this.isoWeekday - 1), so end would be: this.date() - (this.isoWeekday() - 1) + 7
-            this._d.setTime(
+            time = (
                 (this._isUTC ?
                     Date.UTC(this.year(), this.month(), this.date() + 7 - (this.isoWeekday() - 1)) :
                     new Date(this.year(), this.month(), this.date() + 7 - (this.isoWeekday() - 1)).valueOf()) - 1
             );
-            hooks.updateOffset(this, true);
             break;
         case 'day':
         case 'date':
             time = this._d.valueOf();
-            this._d.setTime(
+            time = (
                 (this._isUTC ?
                     time - mod(time, MS_PER_24_HOUR_DAY) + MS_PER_24_HOUR_DAY :
                     new Date(this.year(), this.month(), this.date() + 1).valueOf()) - 1
             );
-            hooks.updateOffset(this, true);
             break;
         case 'hour':
             time = this._d.valueOf();
-            this._d.setTime(time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR) + MS_PER_HOUR - 1);
-            hooks.updateOffset(this, true);
+            time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR) + MS_PER_HOUR - 1);
             break;
         case 'minute':
             time = this._d.valueOf();
             this._d.setTime(time - mod(time, MS_PER_MINUTE) + MS_PER_MINUTE - 1);
-            break;
+            return this;
         case 'second':
             time = this._d.valueOf();
             this._d.setTime(time - mod(time, MS_PER_SECOND) + MS_PER_SECOND - 1);
-            break;
+            return this;
     }
 
+    this._d.setTime(time);
+    hooks.updateOffset(this, true);
     return this;
 }

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -14,91 +14,168 @@ function mod(dividend, divisor) {
 export function startOf (units) {
     var time;
     units = normalizeUnits(units);
-    // the following switch intentionally omits break keywords
-    // to utilize falling through the cases.
-    switch (units) {
-        case 'year':
-            this.month(0);
-            /* falls through */
-        case 'quarter':
-        case 'month':
-            this.date(1);
-            /* falls through */
-        case 'week':
-        case 'isoWeek':
-        case 'day':
-        case 'date':
-            if (this.isValid()) {
-                if (this._isUTC) {
-                    time = this._d.valueOf();
-                    this._d.setTime(time - mod(time, MS_PER_24_HOUR_DAY));
-                } else {
-                    this._d.setTime(new Date(this.year(), this.month(), this.date()).valueOf());
-                }
+    if (units === undefined || units === 'millisecond' || !this.isValid()) {
+        return this;
+    }
+
+    if (this._isUTC) {
+        switch (units) {
+            case 'year':
+                this._d.setTime(Date.UTC(this.year(), 0));
                 hooks.updateOffset(this, true);
-            }
-            break;
-        case 'hour':
-            if (this.isValid()) {
-                var offset = this._isUTC ? 0 : this.utcOffset();
+                break;
+            case 'quarter':
+                this._d.setTime(Date.UTC(this.year(), this.month() - (this.month() % 3)));
+                hooks.updateOffset(this, true);
+                break;
+            case 'month':
+                this._d.setTime(Date.UTC(this.year(), this.month()));
+                hooks.updateOffset(this, true);
+                break;
+            case 'week':
+            case 'isoWeek':
+            case 'day':
+            case 'date':
                 time = this._d.valueOf();
-                this._d.setTime(time - mod(time + offset * MS_PER_MINUTE, MS_PER_HOUR));
+                this._d.setTime(time - mod(time, MS_PER_24_HOUR_DAY));
                 hooks.updateOffset(this, true);
-            }
-            break;
-        case 'minute':
-            if (this.isValid()) {
+                // Note: there may be a better/faster way of doing this with UTC...
+                if (units === 'week') {
+                    this.weekday(0);
+                } else if (units === 'isoWeek') {
+                    this.isoWeekday(1);
+                }
+                break;
+            case 'hour':
+                time = this._d.valueOf();
+                this._d.setTime(time - mod(time, MS_PER_HOUR));
+                hooks.updateOffset(this, true);
+                break;
+            case 'minute':
                 time = this._d.valueOf();
                 this._d.setTime(time - mod(time, MS_PER_MINUTE));
-            }
-            break;
-        case 'second':
-            if (this.isValid()) {
+                break;
+            case 'second':
                 time = this._d.valueOf();
                 this._d.setTime(time - mod(time, MS_PER_SECOND));
-            }
-            break;
-    }
-
-    // weeks are a special case
-    if (units === 'week') {
-        this.weekday(0);
-    }
-    if (units === 'isoWeek') {
-        this.isoWeekday(1);
-    }
-
-    // quarters are also special
-    if (units === 'quarter') {
-        this.month(Math.floor(this.month() / 3) * 3);
+                break;
+        }
+    } else {
+        switch (units) {
+            case 'year':
+                this._d.setTime(new Date(this.year(), 0).valueOf());
+                hooks.updateOffset(this, true);
+                break;
+            case 'quarter':
+                this._d.setTime(new Date(this.year(), this.month() - (this.month() % 3)).valueOf());
+                hooks.updateOffset(this, true);
+                break;
+            case 'month':
+                this._d.setTime(new Date(this.year(), this.month()).valueOf());
+                hooks.updateOffset(this, true);
+                break;
+            case 'week':
+            case 'isoWeek':
+            case 'day':
+            case 'date':
+                this._d.setTime(new Date(this.year(), this.month(), this.date()).valueOf());
+                hooks.updateOffset(this, true);
+                // weeks are a special case
+                if (units === 'week') {
+                    this.weekday(0);
+                } else if (units === 'isoWeek') {
+                    this.isoWeekday(1);
+                }
+                break;
+            case 'hour':
+                time = this._d.valueOf();
+                this._d.setTime(time - mod(time + this.utcOffset() * MS_PER_MINUTE, MS_PER_HOUR));
+                hooks.updateOffset(this, true);
+                break;
+            case 'minute':
+                time = this._d.valueOf();
+                this._d.setTime(time - mod(time, MS_PER_MINUTE));
+                break;
+            case 'second':
+                time = this._d.valueOf();
+                this._d.setTime(time - mod(time, MS_PER_SECOND));
+                break;
+        }
     }
 
     return this;
 }
 
 export function endOf (units) {
+    var time;
     units = normalizeUnits(units);
-    if (units === undefined || units === 'millisecond') {
+    if (units === undefined || units === 'millisecond' || !this.isValid()) {
         return this;
     }
 
-    // 'date' is an alias for 'day', so it should be considered as such.
-    if (units === 'date') {
-        units = 'day';
-    }
-
-    if (units === 'day') {
-        if (this.isValid()) {
-            if (this._isUTC) {
-                var time = this._d.valueOf();
-                this._d.setTime(time - mod(time, MS_PER_24_HOUR_DAY) + MS_PER_24_HOUR_DAY - 1);
-            } else {
-                this._d.setTime(new Date(this.year(), this.month(), this.date() + 1).valueOf() - 1);
-            }
+    switch (units) {
+        case 'year':
+            this._d.setTime((this._isUTC ? Date.UTC(this.year() + 1, 0) : new Date(this.year() + 1, 0).valueOf()) - 1);
             hooks.updateOffset(this, true);
-        }
-        return this;
+            break;
+        case 'quarter':
+            this._d.setTime(
+                (this._isUTC ?
+                    Date.UTC(this.year(), 3 + this.month() - this.month() % 3) :
+                    new Date(this.year(), 3 + this.month() - this.month() % 3).valueOf()) - 1
+            );
+            hooks.updateOffset(this, true);
+            break;
+        case 'month':
+            this._d.setTime(
+                (this._isUTC ?
+                    Date.UTC(this.year(), 1 + this.month()) :
+                    new Date(this.year(), 1 + this.month()).valueOf()) - 1
+            );
+            hooks.updateOffset(this, true);
+            break;
+        case 'week':
+            // start of week should be: this.date() - this.weekday(), so end of week would be: this.date() - this.weekday() + 7
+            this._d.setTime(
+                (this._isUTC ?
+                    Date.UTC(this.year(), this.month(), this.date() + 7 - this.weekday()) :
+                    new Date(this.year(), this.month(), this.date() + 7 - this.weekday()).valueOf()) - 1
+            );
+            hooks.updateOffset(this, true);
+            break;
+        case 'isoWeek':
+            // start of iso week should be: this.date() - (this.isoWeekday - 1), so end would be: this.date() - (this.isoWeekday() - 1) + 7
+            this._d.setTime(
+                (this._isUTC ?
+                    Date.UTC(this.year(), this.month(), this.date() + 7 - (this.isoWeekday() - 1)) :
+                    new Date(this.year(), this.month(), this.date() + 7 - (this.isoWeekday() - 1)).valueOf()) - 1
+            );
+            hooks.updateOffset(this, true);
+            break;
+        case 'day':
+        case 'date':
+            time = this._d.valueOf();
+            this._d.setTime(
+                (this._isUTC ?
+                    time - mod(time, MS_PER_24_HOUR_DAY) + MS_PER_24_HOUR_DAY :
+                    new Date(this.year(), this.month(), this.date() + 1).valueOf()) - 1
+            );
+            hooks.updateOffset(this, true);
+            break;
+        case 'hour':
+            time = this._d.valueOf();
+            this._d.setTime(time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR) + MS_PER_HOUR - 1);
+            hooks.updateOffset(this, true);
+            break;
+        case 'minute':
+            time = this._d.valueOf();
+            this._d.setTime(time - mod(time, MS_PER_MINUTE) + MS_PER_MINUTE - 1);
+            break;
+        case 'second':
+            time = this._d.valueOf();
+            this._d.setTime(time - mod(time, MS_PER_SECOND) + MS_PER_SECOND - 1);
+            break;
     }
 
-    return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
+    return this;
 }

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -61,16 +61,16 @@ export function startOf (units) {
             break;
         case 'hour':
             time = this._d.valueOf();
-            time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR));
+            time -= mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR);
             break;
         case 'minute':
             time = this._d.valueOf();
-            this._d.setTime(time - mod(time, MS_PER_MINUTE));
-            return this;
+            time -= mod(time, MS_PER_MINUTE);
+            break;
         case 'second':
             time = this._d.valueOf();
-            this._d.setTime(time - mod(time, MS_PER_SECOND));
-            return this;
+            time -= mod(time, MS_PER_SECOND);
+            break;
     }
 
     this._d.setTime(time);
@@ -109,16 +109,16 @@ export function endOf (units) {
             break;
         case 'hour':
             time = this._d.valueOf();
-            time = (time - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR) + MS_PER_HOUR - 1);
+            time += MS_PER_HOUR - mod(time + (this._isUTC ? 0 : this.utcOffset() * MS_PER_MINUTE), MS_PER_HOUR) - 1;
             break;
         case 'minute':
             time = this._d.valueOf();
-            this._d.setTime(time - mod(time, MS_PER_MINUTE) + MS_PER_MINUTE - 1);
-            return this;
+            time += MS_PER_MINUTE - mod(time, MS_PER_MINUTE) - 1;
+            break;
         case 'second':
             time = this._d.valueOf();
-            this._d.setTime(time - mod(time, MS_PER_SECOND) + MS_PER_SECOND - 1);
-            return this;
+            time += MS_PER_SECOND - mod(time, MS_PER_SECOND) - 1;
+            break;
     }
 
     this._d.setTime(time);

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -13,7 +13,8 @@ function mod(dividend, divisor) {
 
 function localStartOfDate(y, m, d) {
     // the date constructor remaps years 0-99 to 1900-1999
-    if (0 <= y && y <= 99) {
+    if (y < 100 && y >= 0) {
+        // preserve leap years using a full 400 year cycle, then reset
         return new Date(y + 400, m, d) - MS_PER_400_YEARS;
     } else {
         return new Date(y, m, d).valueOf();
@@ -22,7 +23,8 @@ function localStartOfDate(y, m, d) {
 
 function utcStartOfDate(y, m, d) {
     // Date.UTC remaps years 0-99 to 1900-1999
-    if (0 <= y && y <= 99) {
+    if (y < 100 && y >= 0) {
+        // preserve leap years using a full 400 year cycle, then reset
         return Date.UTC(y + 400, m, d) - MS_PER_400_YEARS;
     } else {
         return Date.UTC(y, m, d);

--- a/src/test/moment/start_end_of.js
+++ b/src/test/moment/start_end_of.js
@@ -393,3 +393,27 @@ test('endOf millisecond and no-arg', function (assert) {
     assert.equal(+m, +m.clone().endOf('millisecond'), 'endOf with millisecond argument should change time');
     assert.equal(+m, +m.clone().endOf('milliseconds'), 'endOf with milliseconds argument should change time');
 });
+
+test('startOf for year zero', function (assert) {
+    var m = moment('0000-02-29T12:34:56.789Z').parseZone();
+    assert.equal(m.clone().startOf('ms').toISOString(), '0000-02-29T12:34:56.789Z',  'startOf millisecond should preserver year');
+    assert.equal(m.clone().startOf('s').toISOString(), '0000-02-29T12:34:56.000Z', 'startOf second should preserver year');
+    assert.equal(m.clone().startOf('m').toISOString(), '0000-02-29T12:34:00.000Z', 'startOf minute should preserver year');
+    assert.equal(m.clone().startOf('h').toISOString(), '0000-02-29T12:00:00.000Z', 'startOf hour should preserver year');
+    assert.equal(m.clone().startOf('d').toISOString(), '0000-02-29T00:00:00.000Z', 'startOf day should preserver year');
+    assert.equal(m.clone().startOf('M').toISOString(), '0000-02-01T00:00:00.000Z', 'startOf month should preserver year');
+    assert.equal(m.clone().startOf('Q').toISOString(), '0000-01-01T00:00:00.000Z', 'startOf quarter should preserver year');
+    assert.equal(m.clone().startOf('y').toISOString(), '0000-01-01T00:00:00.000Z', 'startOf year should preserver year');
+});
+
+test('endOf for year zero', function (assert) {
+    var m = moment('0000-02-29T12:34:56.789Z').parseZone();
+    assert.equal(m.clone().endOf('ms').toISOString(), '0000-02-29T12:34:56.789Z',  'endOf millisecond should preserver year');
+    assert.equal(m.clone().endOf('s').toISOString(), '0000-02-29T12:34:56.999Z', 'endOf second should preserver year');
+    assert.equal(m.clone().endOf('m').toISOString(), '0000-02-29T12:34:59.999Z', 'endOf minute should preserver year');
+    assert.equal(m.clone().endOf('h').toISOString(), '0000-02-29T12:59:59.999Z', 'endOf hour should preserver year');
+    assert.equal(m.clone().endOf('d').toISOString(), '0000-02-29T23:59:59.999Z', 'endOf day should preserver year');
+    assert.equal(m.clone().endOf('M').toISOString(), '0000-02-29T23:59:59.999Z', 'endOf month should preserver year');
+    assert.equal(m.clone().endOf('Q').toISOString(), '0000-03-31T23:59:59.999Z', 'endOf quarter should preserver year');
+    assert.equal(m.clone().endOf('y').toISOString(), '0000-12-31T23:59:59.999Z', 'endOf year should preserver year');
+});

--- a/src/test/moment/start_end_of.js
+++ b/src/test/moment/start_end_of.js
@@ -396,24 +396,24 @@ test('endOf millisecond and no-arg', function (assert) {
 
 test('startOf for year zero', function (assert) {
     var m = moment('0000-02-29T12:34:56.789Z').parseZone();
-    assert.equal(m.clone().startOf('ms').toISOString(), '0000-02-29T12:34:56.789Z',  'startOf millisecond should preserver year');
-    assert.equal(m.clone().startOf('s').toISOString(), '0000-02-29T12:34:56.000Z', 'startOf second should preserver year');
-    assert.equal(m.clone().startOf('m').toISOString(), '0000-02-29T12:34:00.000Z', 'startOf minute should preserver year');
-    assert.equal(m.clone().startOf('h').toISOString(), '0000-02-29T12:00:00.000Z', 'startOf hour should preserver year');
-    assert.equal(m.clone().startOf('d').toISOString(), '0000-02-29T00:00:00.000Z', 'startOf day should preserver year');
-    assert.equal(m.clone().startOf('M').toISOString(), '0000-02-01T00:00:00.000Z', 'startOf month should preserver year');
-    assert.equal(m.clone().startOf('Q').toISOString(), '0000-01-01T00:00:00.000Z', 'startOf quarter should preserver year');
-    assert.equal(m.clone().startOf('y').toISOString(), '0000-01-01T00:00:00.000Z', 'startOf year should preserver year');
+    assert.equal(m.clone().startOf('ms').toISOString(), '0000-02-29T12:34:56.789Z',  'startOf millisecond should preserve year');
+    assert.equal(m.clone().startOf('s').toISOString(), '0000-02-29T12:34:56.000Z', 'startOf second should preserve year');
+    assert.equal(m.clone().startOf('m').toISOString(), '0000-02-29T12:34:00.000Z', 'startOf minute should preserve year');
+    assert.equal(m.clone().startOf('h').toISOString(), '0000-02-29T12:00:00.000Z', 'startOf hour should preserve year');
+    assert.equal(m.clone().startOf('d').toISOString(), '0000-02-29T00:00:00.000Z', 'startOf day should preserve year');
+    assert.equal(m.clone().startOf('M').toISOString(), '0000-02-01T00:00:00.000Z', 'startOf month should preserve year');
+    assert.equal(m.clone().startOf('Q').toISOString(), '0000-01-01T00:00:00.000Z', 'startOf quarter should preserve year');
+    assert.equal(m.clone().startOf('y').toISOString(), '0000-01-01T00:00:00.000Z', 'startOf year should preserve year');
 });
 
 test('endOf for year zero', function (assert) {
     var m = moment('0000-02-29T12:34:56.789Z').parseZone();
-    assert.equal(m.clone().endOf('ms').toISOString(), '0000-02-29T12:34:56.789Z',  'endOf millisecond should preserver year');
-    assert.equal(m.clone().endOf('s').toISOString(), '0000-02-29T12:34:56.999Z', 'endOf second should preserver year');
-    assert.equal(m.clone().endOf('m').toISOString(), '0000-02-29T12:34:59.999Z', 'endOf minute should preserver year');
-    assert.equal(m.clone().endOf('h').toISOString(), '0000-02-29T12:59:59.999Z', 'endOf hour should preserver year');
-    assert.equal(m.clone().endOf('d').toISOString(), '0000-02-29T23:59:59.999Z', 'endOf day should preserver year');
-    assert.equal(m.clone().endOf('M').toISOString(), '0000-02-29T23:59:59.999Z', 'endOf month should preserver year');
-    assert.equal(m.clone().endOf('Q').toISOString(), '0000-03-31T23:59:59.999Z', 'endOf quarter should preserver year');
-    assert.equal(m.clone().endOf('y').toISOString(), '0000-12-31T23:59:59.999Z', 'endOf year should preserver year');
+    assert.equal(m.clone().endOf('ms').toISOString(), '0000-02-29T12:34:56.789Z',  'endOf millisecond should preserve year');
+    assert.equal(m.clone().endOf('s').toISOString(), '0000-02-29T12:34:56.999Z', 'endOf second should preserve year');
+    assert.equal(m.clone().endOf('m').toISOString(), '0000-02-29T12:34:59.999Z', 'endOf minute should preserve year');
+    assert.equal(m.clone().endOf('h').toISOString(), '0000-02-29T12:59:59.999Z', 'endOf hour should preserve year');
+    assert.equal(m.clone().endOf('d').toISOString(), '0000-02-29T23:59:59.999Z', 'endOf day should preserve year');
+    assert.equal(m.clone().endOf('M').toISOString(), '0000-02-29T23:59:59.999Z', 'endOf month should preserve year');
+    assert.equal(m.clone().endOf('Q').toISOString(), '0000-03-31T23:59:59.999Z', 'endOf quarter should preserve year');
+    assert.equal(m.clone().endOf('y').toISOString(), '0000-12-31T23:59:59.999Z', 'endOf year should preserve year');
 });


### PR DESCRIPTION
These changes to `startOf` and `endOf` fix several DST-related issues:
- avoid using setHours/setMinutes/setSeconds - fixes #1990, fixes #2749, fixes #3580
- use `Date.UTC` / `new Date` for units bigger than hours - fixes #3132, fixes #4152

Additionally, the changes supersede these pull requests: #3620, #4164 and #4254 

Benchmark results

| Benchmark | moment 2.19.3 | this PR | improvement |
| --- | --- | --- | --- |
| startOf second | 2,598,171 ops/sec ±1.24% | 5,322,216 ops/sec ±1.56% | 2.0x |
| startOf minute | 1,606,046 ops/sec ±0.98% | 7,397,801 ops/sec ±0.92% | 4.6x |
| startOf hour | 1,069,176 ops/sec ±0.96% | 5,015,984 ops/sec ±0.91%   | 4.6x |
| startOf date | 811,815 ops/sec ±1.08% | 1,162,031 ops/sec ±0.89%     | 1.4x |
| startOf day | 827,911 ops/sec ±0.83% | 1,170,806 ops/sec ±1.25%      | 1.4x |
| startOf isoWeek | 274,302 ops/sec ±1.06% | 973,431 ops/sec ±1.09%    | 3.5x |
| startOf week | 298,240 ops/sec ±1.00% | 1,188,010 ops/sec ±0.94%     | 3.9x |
| startOf month | 653,227 ops/sec ±0.85% | 1,447,224 ops/sec ±0.76%    | 2.2x |
| startOf quarter | 381,496 ops/sec ±0.85% | 1,221,562 ops/sec ±0.93%  | 3.2x |
| startOf year | 425,796 ops/sec ±0.98% | 2,047,534 ops/sec ±1.02%     | 4.8x |
| endOf second | 200,544 ops/sec ±0.92% | 5,496,719 ops/sec ±1.00%     | 27.4x |
| endOf minute | 190,097 ops/sec ±1.02% | 6,600,219 ops/sec ±0.94%     | 34.7x |
| endOf hour | 331,129 ops/sec ±0.86% | 4,612,042 ops/sec ±0.88%       | 13.9x |
| endOf date | 249,577 ops/sec ±1.10% | 1,239,091 ops/sec ±0.96%       | 4.9x  |
| endOf day | 251,496 ops/sec ±1.01% | 1,240,042 ops/sec ±1.35%        | 4.9x  |
| endOf isoWeek | 160,238 ops/sec ±1.73% | 917,050 ops/sec ±0.85%      | 5.7x  |
| endOf week | 174,334 ops/sec ±2.02% | 1,216,138 ops/sec ±0.88%       | 6.9x  |
| endOf month | 200,123 ops/sec ±1.24% | 1,480,412 ops/sec ±2.05%      | 7.3x  |
| endOf quarter | 159,346 ops/sec ±0.99% | 1,165,512 ops/sec ±1.02%    | 7.3x  |
| endOf year | 165,736 ops/sec ±1.70% | 2,026,810 ops/sec ±1.67%       | 12.2x |

Additionally, fixed one more bug: `moment('0000-02-29')` was created in year 1900 then reverted to year 0.  Unfortunately Feb 29th doesn't exist in 1900, so the moment ended up as `0000-03-01` instead.

New tests have been added to `start_end_of.js` that would have failed in earlier releases.