### PR TITLE
[feature] Prevent toISOString converting to UTC (issue #1751)

### DIFF
--- a/src/lib/moment/format.js
+++ b/src/lib/moment/format.js
@@ -9,11 +9,11 @@ export function toString () {
     return this.clone().locale('en').format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ');
 }
 
-export function toISOString(options) {
+export function toISOString(keepOffset) {
     if (!this.isValid()) {
         return null;
     }
-    var utc = !(options && options.utc === false);
+    var utc = !(keepOffset === true);
     var m = utc ? this.clone().utc() : this;
     if (m.year() < 0 || m.year() > 9999) {
         return formatMoment(m, utc ? 'YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]' : 'YYYYYY-MM-DD[T]HH:mm:ss.SSSZ');

--- a/src/lib/moment/format.js
+++ b/src/lib/moment/format.js
@@ -13,7 +13,7 @@ export function toISOString(keepOffset) {
     if (!this.isValid()) {
         return null;
     }
-    var utc = !(keepOffset === true);
+    var utc = keepOffset !== true;
     var m = utc ? this.clone().utc() : this;
     if (m.year() < 0 || m.year() > 9999) {
         return formatMoment(m, utc ? 'YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]' : 'YYYYYY-MM-DD[T]HH:mm:ss.SSSZ');

--- a/src/lib/moment/format.js
+++ b/src/lib/moment/format.js
@@ -9,19 +9,24 @@ export function toString () {
     return this.clone().locale('en').format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ');
 }
 
-export function toISOString() {
+export function toISOString(options) {
     if (!this.isValid()) {
         return null;
     }
-    var m = this.clone().utc();
+    var utc = !(options && options.utc === false);
+    var m = utc ? this.clone().utc() : this;
     if (m.year() < 0 || m.year() > 9999) {
-        return formatMoment(m, 'YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
+        return formatMoment(m, utc ? 'YYYYYY-MM-DD[T]HH:mm:ss.SSS[Z]' : 'YYYYYY-MM-DD[T]HH:mm:ss.SSSZ');
     }
     if (isFunction(Date.prototype.toISOString)) {
         // native implementation is ~50x faster, use it when we can
-        return this.toDate().toISOString();
+        if (utc) {
+            return this.toDate().toISOString();
+        } else {
+            return new Date(this.toDate().getTime() + this.utcOffset() * 6e4).toISOString().slice(0, -1) + formatMoment(m, 'Z');
+        }
     }
-    return formatMoment(m, 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]');
+    return formatMoment(m, utc ? 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]' : 'YYYY-MM-DD[T]HH:mm:ss.SSSZ');
 }
 
 /**

--- a/src/lib/moment/format.js
+++ b/src/lib/moment/format.js
@@ -23,7 +23,7 @@ export function toISOString(options) {
         if (utc) {
             return this.toDate().toISOString();
         } else {
-            return new Date(this.toDate().getTime() + this.utcOffset() * 6e4).toISOString().slice(0, -1) + formatMoment(m, 'Z');
+            return new Date(this._d.valueOf()).toISOString().replace('Z', formatMoment(m, 'Z'));
         }
     }
     return formatMoment(m, utc ? 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]' : 'YYYY-MM-DD[T]HH:mm:ss.SSSZ');

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -154,6 +154,26 @@ test('toISOString', function (assert) {
     assert.equal(date.toISOString(), null, 'An invalid date to iso string is null');
 });
 
+test('toISOString without UTC conversion', function (assert) {
+    var date = moment.utc('2016-12-31T19:53:45.678').utcOffset('+05:30');
+
+    assert.equal(date.toISOString({utc: false}), '2017-01-01T01:23:45.678+05:30', 'should output ISO8601 on moment.fn.toISOString');
+
+    // big years
+    date = moment.utc('+020122-12-31T19:53:45.678').utcOffset('+05:30');
+    assert.equal(date.toISOString({utc: false}), '+020123-01-01T01:23:45.678+05:30', 'ISO8601 format on big positive year');
+    // negative years
+    date = moment.utc('-000002-12-31T19:53:45.678').utcOffset('+05:30');
+    assert.equal(date.toISOString({utc: false}), '-000001-01-01T01:23:45.678+05:30', 'ISO8601 format on negative year');
+    // big negative years
+    date = moment.utc('-020124-12-31T19:53:45.678').utcOffset('+05:30');
+    assert.equal(date.toISOString({utc: false}), '-020123-01-01T01:23:45.678+05:30', 'ISO8601 format on big negative year');
+
+    //invalid dates
+    date = moment.utc('2017-12-32').utcOffset('+05:30');
+    assert.equal(date.toISOString({utc: false}), null, 'An invalid date to iso string is null');
+});
+
 // See https://nodejs.org/dist/latest/docs/api/util.html#util_custom_inspect_function_on_objects
 test('inspect', function (assert) {
     function roundtrip(m) {

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -157,21 +157,21 @@ test('toISOString', function (assert) {
 test('toISOString without UTC conversion', function (assert) {
     var date = moment.utc('2016-12-31T19:53:45.678').utcOffset('+05:30');
 
-    assert.equal(date.toISOString({utc: false}), '2017-01-01T01:23:45.678+05:30', 'should output ISO8601 on moment.fn.toISOString');
+    assert.equal(date.toISOString(true), '2017-01-01T01:23:45.678+05:30', 'should output ISO8601 on moment.fn.toISOString');
 
     // big years
     date = moment.utc('+020122-12-31T19:53:45.678').utcOffset('+05:30');
-    assert.equal(date.toISOString({utc: false}), '+020123-01-01T01:23:45.678+05:30', 'ISO8601 format on big positive year');
+    assert.equal(date.toISOString(true), '+020123-01-01T01:23:45.678+05:30', 'ISO8601 format on big positive year');
     // negative years
     date = moment.utc('-000002-12-31T19:53:45.678').utcOffset('+05:30');
-    assert.equal(date.toISOString({utc: false}), '-000001-01-01T01:23:45.678+05:30', 'ISO8601 format on negative year');
+    assert.equal(date.toISOString(true), '-000001-01-01T01:23:45.678+05:30', 'ISO8601 format on negative year');
     // big negative years
     date = moment.utc('-020124-12-31T19:53:45.678').utcOffset('+05:30');
-    assert.equal(date.toISOString({utc: false}), '-020123-01-01T01:23:45.678+05:30', 'ISO8601 format on big negative year');
+    assert.equal(date.toISOString(true), '-020123-01-01T01:23:45.678+05:30', 'ISO8601 format on big negative year');
 
     //invalid dates
     date = moment.utc('2017-12-32').utcOffset('+05:30');
-    assert.equal(date.toISOString({utc: false}), null, 'An invalid date to iso string is null');
+    assert.equal(date.toISOString(true), null, 'An invalid date to iso string is null');
 });
 
 // See https://nodejs.org/dist/latest/docs/api/util.html#util_custom_inspect_function_on_objects


### PR DESCRIPTION
A minimal effort to allow users to opt-out of UTC conversion when calling `toISOString()`:

```js
moment().toISOString();
moment().toISOString({ utc: false });
```

Example while running in Europe/London timezone:
```js
moment('2017-07-01').toISOString(); // 2017-06-30T23:00:00.000Z
moment('2017-07-01').toISOString({ utc: false }); // 2017-07-01T00:00:00.000+01:00
```

The PR preserves existing behaviour of converting to UTC by default.