### PR TITLE
[feature] Declare module for projects that don't use any module system

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -712,4 +712,7 @@ declare namespace moment {
   export var defaultFormatUtc: string;
 }
 
-export = moment;
+declare module "moment" {
+    export = moment;
+}
+


### PR DESCRIPTION
I was working in my project and downloaded moment for the typing and when i started building it threw an error because i don't use RequireJS or AMD. 

Feel free to check if this is the correct path to fix the problem, this fixed the issue for me and it might help others that might be facing the same problem