### PR TITLE
[bugfix] define amd module to moment 

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -6,7 +6,7 @@
 
 ;(function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-    typeof define === 'function' && define.amd ? define('moment', factory) :
+    typeof define === 'function' && define.amd ? define(factory) :
     global.moment = factory()
 }(this, (function () { 'use strict';
 

--- a/moment.js
+++ b/moment.js
@@ -6,7 +6,7 @@
 
 ;(function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-    typeof define === 'function' && define.amd ? define(factory) :
+    typeof define === 'function' && define.amd ? define('moment', factory) :
     global.moment = factory()
 }(this, (function () { 'use strict';
 

--- a/templates/default.js
+++ b/templates/default.js
@@ -1,5 +1,5 @@
 ;(function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-    typeof define === 'function' && define.amd ? define(factory) :
+    typeof define === 'function' && define.amd ? define('moment', factory) :
     global.moment = factory()
 }(this, (function () { 'use strict';

--- a/templates/locale-header.js
+++ b/templates/locale-header.js
@@ -1,6 +1,6 @@
 ;(function (global, factory) {
    typeof exports === 'object' && typeof module !== 'undefined'
        && typeof require === 'function' ? factory(require('../moment')) :
-   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
+   typeof define === 'function' && define.amd ? define('moment', ['../moment'], factory) :
    factory(global.moment)
 }(this, (function (moment) { 'use strict';


### PR DESCRIPTION
if define.amd is available then currently the moment library is defined as an anonymous factory.
moment needs to be named if it should be used in other modules.