### PR TITLE
[bugfix] Correct min/max TypeScript signatures

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -684,8 +684,8 @@ declare namespace moment {
   export function weekdaysMin(localeSorted: boolean, format: string): string[];
   export function weekdaysMin(localeSorted: boolean, format: string, index: number): string;
 
-  export function min(...moments: MomentInput[]): Moment;
-  export function max(...moments: MomentInput[]): Moment;
+  export function min(...moments: Moment[]): Moment;
+  export function max(...moments: Moment[]): Moment;
 
   /**
    * Returns unix time in milliseconds. Overwrite for profit.

--- a/moment.d.ts
+++ b/moment.d.ts
@@ -684,7 +684,9 @@ declare namespace moment {
   export function weekdaysMin(localeSorted: boolean, format: string): string[];
   export function weekdaysMin(localeSorted: boolean, format: string, index: number): string;
 
+  export function min(moments: Moment[]): Moment;
   export function min(...moments: Moment[]): Moment;
+  export function max(moments: Moment[]): Moment;
   export function max(...moments: Moment[]): Moment;
 
   /**

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -200,6 +200,9 @@ a8.diff(b8, 'days');
 a8.diff(b8, 'years')
 a8.diff(b8, 'years', true);
 
+moment.min(a8, b8);
+moment.max(a8, b8);
+
 moment([2007, 0, 29]).toDate();
 moment([2007, 1, 23]).toISOString();
 moment(1318874398806).valueOf();

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -200,7 +200,9 @@ a8.diff(b8, 'days');
 a8.diff(b8, 'years')
 a8.diff(b8, 'years', true);
 
+moment.min([a8, b8]);
 moment.min(a8, b8);
+moment.max([a8, b8]);
 moment.max(a8, b8);
 
 moment([2007, 0, 29]).toDate();


### PR DESCRIPTION
`min` and `max` only work with moment instances (not Dates, strings, numbers etc.)

Fixes #4316 