### PR TITLE
[misc] fix deprecated rollup options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "node"
+  - "8"
   - "7"
   - "6"
   - "5"

--- a/tasks/transpile.js
+++ b/tasks/transpile.js
@@ -47,13 +47,13 @@ module.exports = function (grunt) {
         // entry, umdName, skipMoment
 
         var rollupOpts = {
-            entry: opts.entry,
+            input: opts.entry,
             plugins: [
                 // babel({})
             ]
         }, bundleOpts = {
             format: 'umd',
-            moduleName: opts.umdName != null ? opts.umdName : 'not_used'
+            name: opts.umdName != null ? opts.umdName : 'not_used'
         };
 
         if (opts.skipMoment) {


### PR DESCRIPTION
The test fails due to we have used deprecated rollup options for a long time and recently rollup 0.53.0 will [throw on unknown options](https://github.com/rollup/rollup/commit/afd30df8a368cec475b9c0265ff1b8812c07891f). Since we always use the latest rollup, the error is thrown as-is.

This PR fixes the issue according to the deprecated warning on the older rollup options.

fixes https://github.com/moment/moment/issues/4373