### PR TITLE
[locale] es-us: Update month parsing to be dot lenient

### DIFF
--- a/src/locale/es-us.js
+++ b/src/locale/es-us.js
@@ -1,6 +1,7 @@
 //! moment.js locale configuration
 //! locale : Spanish (United States) [es-us]
 //! author : bustta : https://github.com/bustta
+//! author : chrisrodz : https://github.com/chrisrodz
 
 import moment from '../moment';
 

--- a/src/locale/es-us.js
+++ b/src/locale/es-us.js
@@ -7,6 +7,9 @@ import moment from '../moment';
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split('_'),
     monthsShort = 'ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic'.split('_');
 
+var monthsParse = [/^ene/i, /^feb/i, /^mar/i, /^abr/i, /^may/i, /^jun/i, /^jul/i, /^ago/i, /^sep/i, /^oct/i, /^nov/i, /^dic/i];
+var monthsRegex = /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene\.?|feb\.?|mar\.?|abr\.?|may\.?|jun\.?|jul\.?|ago\.?|sep\.?|oct\.?|nov\.?|dic\.?)/i;
+
 export default moment.defineLocale('es-us', {
     months : 'enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre'.split('_'),
     monthsShort : function (m, format) {
@@ -18,7 +21,13 @@ export default moment.defineLocale('es-us', {
             return monthsShortDot[m.month()];
         }
     },
-    monthsParseExact : true,
+    monthsRegex: monthsRegex,
+    monthsShortRegex: monthsRegex,
+    monthsStrictRegex: /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)/i,
+    monthsShortStrictRegex: /^(ene\.?|feb\.?|mar\.?|abr\.?|may\.?|jun\.?|jul\.?|ago\.?|sep\.?|oct\.?|nov\.?|dic\.?)/i,
+    monthsParse: monthsParse,
+    longMonthsParse: monthsParse,
+    shortMonthsParse: monthsParse,
     weekdays : 'domingo_lunes_martes_miércoles_jueves_viernes_sábado'.split('_'),
     weekdaysShort : 'dom._lun._mar._mié._jue._vie._sáb.'.split('_'),
     weekdaysMin : 'do_lu_ma_mi_ju_vi_sá'.split('_'),

--- a/src/test/locale/es-us.js
+++ b/src/test/locale/es-us.js
@@ -217,3 +217,10 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0, 14]).format('w ww wo'),   '2 02 2º', 'Jan 14 2012 should be week 2');
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '3 03 3º', 'Jan 15 2012 should be week 3');
 });
+
+test('test short months proper', function (assert) {
+    var str = '02-ago-2016'; // "02-ago-2016"
+    assert.equal(moment(str, 'DD-MMM-YYYY').month(), 7, '02-ago-2016 month should be 7');
+    assert.equal(moment(str, 'DD-MMM-YYYY', true).month(), 7, '02-ago-2016 strict parse month should be 7');
+});
+

--- a/src/test/locale/es-us.js
+++ b/src/test/locale/es-us.js
@@ -224,3 +224,6 @@ test('test short months proper', function (assert) {
     assert.equal(moment(str, 'DD-MMM-YYYY', true).month(), 7, '02-ago-2016 strict parse month should be 7');
 });
 
+test('test lenient month parsing', function (assert) {
+    assert.ok(moment('nov 01, 2015', 'MMM D, YYYY', true).isValid(), 'nov 01, 2015 should parse correctly');
+});


### PR DESCRIPTION
This is the same PR as https://github.com/moment/moment/pull/3894/files, except for the `es-us` locale.

fixes #4162