### PR TITLE
[bugfix] from()/to() wrong days calculation around a month #4127

### DIFF
--- a/src/lib/duration/as.js
+++ b/src/lib/duration/as.js
@@ -2,38 +2,31 @@ import { daysToMonths, monthsToDays } from './bubble';
 import { normalizeUnits } from '../units/aliases';
 import toInt from '../utils/to-int';
 
-export function as (units) {
+export function as(units) {
     if (!this.isValid()) {
         return NaN;
     }
     var days;
     var months;
-    var milliseconds = this._milliseconds;
 
     units = normalizeUnits(units);
 
-    if (units === 'month' || units === 'year') {
-        days   = this._days   + milliseconds / 864e5;
-        months = this._months + daysToMonths(days);
-        return units === 'month' ? months : months / 12;
-    } else {
-        // handle milliseconds separately because of floating point math errors (issue #1867)
-        days = this._days + Math.round(monthsToDays(this._months));
-        switch (units) {
-            case 'week'   : return days / 7     + milliseconds / 6048e5;
-            case 'day'    : return days         + milliseconds / 864e5;
-            case 'hour'   : return days * 24    + milliseconds / 36e5;
-            case 'minute' : return days * 1440  + milliseconds / 6e4;
-            case 'second' : return days * 86400 + milliseconds / 1000;
-            // Math.floor prevents floating point math errors here
-            case 'millisecond': return Math.floor(days * 864e5) + milliseconds;
-            default: throw new Error('Unknown unit ' + units);
-        }
+    switch (units) {
+        case 'year': return daysToMonths(this._milliseconds / 1000 / 60 / 60 / 24) / 12;
+        case 'month': return daysToMonths(this._milliseconds / 1000 / 60 / 60 / 24);
+        case 'week': return this._milliseconds / 1000 / 60 / 60 / 24 / 7;
+        case 'day': return this._milliseconds / 1000 / 60 / 60 / 24;
+        case 'hour': return this._milliseconds / 1000 / 60 / 60;
+        case 'minute': return this._milliseconds / 1000 / 60;
+        case 'second': return this._milliseconds / 1000;
+        // Math.floor prevents floating point math errors here
+        case 'millisecond': return this._milliseconds;
+        default: throw new Error('Unknown unit ' + units);
     }
 }
 
 // TODO: Use this.as('ms')?
-export function valueOf () {
+export function valueOf() {
     if (!this.isValid()) {
         return NaN;
     }
@@ -45,17 +38,17 @@ export function valueOf () {
     );
 }
 
-function makeAs (alias) {
+function makeAs(alias) {
     return function () {
         return this.as(alias);
     };
 }
 
 export var asMilliseconds = makeAs('ms');
-export var asSeconds      = makeAs('s');
-export var asMinutes      = makeAs('m');
-export var asHours        = makeAs('h');
-export var asDays         = makeAs('d');
-export var asWeeks        = makeAs('w');
-export var asMonths       = makeAs('M');
-export var asYears        = makeAs('y');
+export var asSeconds = makeAs('s');
+export var asMinutes = makeAs('m');
+export var asHours = makeAs('h');
+export var asDays = makeAs('d');
+export var asWeeks = makeAs('w');
+export var asMonths = makeAs('M');
+export var asYears = makeAs('y');

--- a/src/lib/duration/bubble.js
+++ b/src/lib/duration/bubble.js
@@ -2,60 +2,46 @@ import absFloor from '../utils/abs-floor';
 import absCeil from '../utils/abs-ceil';
 import { createUTCDate } from '../create/date-from-array';
 
-export function bubble () {
+export function bubble() {
     var milliseconds = this._milliseconds;
-    var days         = this._days;
-    var months       = this._months;
-    var data         = this._data;
+    var days;
+    var months;
+    var data = this._data;
     var seconds, minutes, hours, years, monthsFromDays;
-
-    // if we have a mix of positive and negative values, bubble down first
-    // check: https://github.com/moment/moment/issues/2166
-    if (!((milliseconds >= 0 && days >= 0 && months >= 0) ||
-            (milliseconds <= 0 && days <= 0 && months <= 0))) {
-        milliseconds += absCeil(monthsToDays(months) + days) * 864e5;
-        days = 0;
-        months = 0;
-    }
 
     // The following code bubbles up values, see the tests for
     // examples of what that means.
     data.milliseconds = milliseconds % 1000;
 
-    seconds           = absFloor(milliseconds / 1000);
-    data.seconds      = seconds % 60;
+    seconds = milliseconds / 1000;
+    data.seconds = seconds % 60;
 
-    minutes           = absFloor(seconds / 60);
-    data.minutes      = minutes % 60;
+    minutes = seconds / 60;
+    data.minutes = minutes % 60;
 
-    hours             = absFloor(minutes / 60);
-    data.hours        = hours % 24;
+    hours = minutes / 60;
+    data.hours = hours % 24;
 
-    days += absFloor(hours / 24);
-
+    days = hours / 24;
     // convert days to months
-    monthsFromDays = absFloor(daysToMonths(days));
-    months += monthsFromDays;
-    days -= absCeil(monthsToDays(monthsFromDays));
+    months = daysToMonths(days);
+
+    data.days = days - monthsToDays(months);
 
     // 12 months -> 1 year
-    years = absFloor(months / 12);
-    months %= 12;
-
-    data.days   = days;
-    data.months = months;
-    data.years  = years;
+    data.years = months / 12;
+    data.months = months % 12;
 
     return this;
 }
 
-export function daysToMonths (days) {
+export function daysToMonths(days) {
     // 400 years have 146097 days (taking into account leap year rules)
     // 400 years have 12 months === 4800
     return days * 4800 / 146097;
 }
 
-export function monthsToDays (months) {
+export function monthsToDays(months) {
     // the reverse of daysToMonths
     return months * 146097 / 4800;
 }

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -2,7 +2,7 @@ import { normalizeObjectUnits } from '../units/aliases';
 import { getLocale } from '../locale/locales';
 import isDurationValid from './valid.js';
 
-export function Duration (duration) {
+export function Duration(duration) {
     var normalizedInput = normalizeObjectUnits(duration),
         years = normalizedInput.year || 0,
         quarters = normalizedInput.quarter || 0,
@@ -17,20 +17,7 @@ export function Duration (duration) {
     this._isValid = isDurationValid(normalizedInput);
 
     // representation for dateAddRemove
-    this._milliseconds = +milliseconds +
-        seconds * 1e3 + // 1000
-        minutes * 6e4 + // 1000 * 60
-        hours * 1000 * 60 * 60; //using 1000 * 60 * 60 instead of 36e5 to avoid floating point rounding errors https://github.com/moment/moment/issues/2978
-    // Because of dateAddRemove treats 24 hours as different from a
-    // day when working around DST, we need to store them separately
-    this._days = +days +
-        weeks * 7;
-    // It is impossible to translate months into days without knowing
-    // which months you are are talking about, so we have to store
-    // it separately.
-    this._months = +months +
-        quarters * 3 +
-        years * 12;
+    this._milliseconds = +milliseconds;
 
     this._data = {};
 
@@ -39,6 +26,6 @@ export function Duration (duration) {
     this._bubble();
 }
 
-export function isDuration (obj) {
+export function isDuration(obj) {
     return obj instanceof Duration;
 }

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -16,7 +16,7 @@ var aspNetRegex = /^(\-|\+)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)(\.\d*)?)?$/;
 // and further modified to allow for strings containing both week and day
 var isoRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)W)?(?:([-+]?[0-9,.]*)D)?(?:T(?:([-+]?[0-9,.]*)H)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9,.]*)S)?)?$/;
 
-export function createDuration (input, key) {
+export function createDuration(input, key) {
     var duration = input,
         // matching against regexp is expensive, do it on demand
         match = null,
@@ -26,9 +26,9 @@ export function createDuration (input, key) {
 
     if (isDuration(input)) {
         duration = {
-            ms : input._milliseconds,
-            d  : input._days,
-            M  : input._months
+            ms: input._milliseconds,
+            d: input._days,
+            M: input._months
         };
     } else if (isNumber(input)) {
         duration = {};
@@ -40,23 +40,23 @@ export function createDuration (input, key) {
     } else if (!!(match = aspNetRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : 1;
         duration = {
-            y  : 0,
-            d  : toInt(match[DATE])                         * sign,
-            h  : toInt(match[HOUR])                         * sign,
-            m  : toInt(match[MINUTE])                       * sign,
-            s  : toInt(match[SECOND])                       * sign,
-            ms : toInt(absRound(match[MILLISECOND] * 1000)) * sign // the millisecond decimal point is included in the match
+            y: 0,
+            d: toInt(match[DATE]) * sign,
+            h: toInt(match[HOUR]) * sign,
+            m: toInt(match[MINUTE]) * sign,
+            s: toInt(match[SECOND]) * sign,
+            ms: toInt(absRound(match[MILLISECOND] * 1000)) * sign // the millisecond decimal point is included in the match
         };
     } else if (!!(match = isoRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : (match[1] === '+') ? 1 : 1;
         duration = {
-            y : parseIso(match[2], sign),
-            M : parseIso(match[3], sign),
-            w : parseIso(match[4], sign),
-            d : parseIso(match[5], sign),
-            h : parseIso(match[6], sign),
-            m : parseIso(match[7], sign),
-            s : parseIso(match[8], sign)
+            y: parseIso(match[2], sign),
+            M: parseIso(match[3], sign),
+            w: parseIso(match[4], sign),
+            d: parseIso(match[5], sign),
+            h: parseIso(match[6], sign),
+            m: parseIso(match[7], sign),
+            s: parseIso(match[8], sign)
         };
     } else if (duration == null) {// checks for null or undefined
         duration = {};
@@ -65,7 +65,6 @@ export function createDuration (input, key) {
 
         duration = {};
         duration.ms = diffRes.milliseconds;
-        duration.M = diffRes.months;
     }
 
     ret = new Duration(duration);
@@ -80,7 +79,7 @@ export function createDuration (input, key) {
 createDuration.fn = Duration.prototype;
 createDuration.invalid = invalid;
 
-function parseIso (inp, sign) {
+function parseIso(inp, sign) {
     // We'd normally use ~~inp for this, but unfortunately it also
     // converts floats to ints.
     // inp may be undefined, so careful calling replace on it.
@@ -90,15 +89,9 @@ function parseIso (inp, sign) {
 }
 
 function positiveMomentsDifference(base, other) {
-    var res = {milliseconds: 0, months: 0};
+    var res = {milliseconds: 0};
 
-    res.months = other.month() - base.month() +
-        (other.year() - base.year()) * 12;
-    if (base.clone().add(res.months, 'M').isAfter(other)) {
-        --res.months;
-    }
-
-    res.milliseconds = +other - +(base.clone().add(res.months, 'M'));
+    res.milliseconds = +other._d.getTime() - +base._d.getTime();
 
     return res;
 }
@@ -115,7 +108,6 @@ function momentsDifference(base, other) {
     } else {
         res = positiveMomentsDifference(other, base);
         res.milliseconds = -res.milliseconds;
-        res.months = -res.months;
     }
 
     return res;


### PR DESCRIPTION
Issue for the bug was that were calculating the time difference by finding the difference months and millisecond. While calculating the difference of months it was ignoring the decimal value which important when we are converting the months to days.
For example - for passing "1" value to monthstodays function will give 30. But passing "1.XX" value to monthstodays function will give 31.

Fix - I have removed the calculation of month difference. Just calculation the overall millisecond difference and calculating the duration based on that.