### PR TITLE
Added export as namespace statement

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -1,6 +1,8 @@
 declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, strict?: boolean): moment.Moment;
 declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, language?: string, strict?: boolean): moment.Moment;
 
+export as namespace moment;
+
 declare namespace moment {
   type RelativeTimeKey = 's' | 'ss' | 'm' | 'mm' | 'h' | 'hh' | 'd' | 'dd' | 'M' | 'MM' | 'y' | 'yy';
   type CalendarKey = 'sameDay' | 'nextDay' | 'lastDay' | 'nextWeek' | 'lastWeek' | 'sameElse' | string;


### PR DESCRIPTION
To enable the use of the type definitions in a non-module-based application using moment as a global variable. 

For context of this statement. Search for "UMD modules" in this page:

https://www.typescriptlang.org/docs/handbook/modules.html