### PR TITLE
[bugfix] Use ISO Year for weeksInISOYear instead of calendar year.

### DIFF
--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -9,6 +9,7 @@ import { hooks } from '../utils/hooks';
 import { createLocal } from '../create/local';
 import { createUTCDate } from '../create/date-from-array';
 
+const THURSDAY = 4;
 // FORMATTING
 
 addFormatToken(0, ['gg', 2], 0, function () {
@@ -75,7 +76,7 @@ export function getSetISOWeekYear (input) {
 }
 
 export function getISOWeeksInYear () {
-    return weeksInYear(this.isoWeekday(7).year(), 1, 4);
+    return weeksInYear(this.isoWeekday(THURSDAY).year(), 1, 4);
 }
 
 export function getWeeksInYear () {

--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -75,7 +75,7 @@ export function getSetISOWeekYear (input) {
 }
 
 export function getISOWeeksInYear () {
-    return weeksInYear(this.year(), 1, 4);
+    return weeksInYear(this.isoWeekday(7).year(), 1, 4);
 }
 
 export function getWeeksInYear () {

--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -9,7 +9,10 @@ import { hooks } from '../utils/hooks';
 import { createLocal } from '../create/local';
 import { createUTCDate } from '../create/date-from-array';
 
+// CONSTANTS
+
 const THURSDAY = 4;
+
 // FORMATTING
 
 addFormatToken(0, ['gg', 2], 0, function () {

--- a/src/test/moment/weeks_in_year.js
+++ b/src/test/moment/weeks_in_year.js
@@ -3,24 +3,24 @@ import moment from '../../moment';
 
 module('weeks in year');
 
-test('isoWeeksInYear', function (assert) {
-    assert.equal(moment([2004]).isoWeeksInYear(), 53, '2004 has 53 iso weeks');
-    assert.equal(moment([2005]).isoWeeksInYear(), 52, '2005 has 53 iso weeks');
-    assert.equal(moment([2006]).isoWeeksInYear(), 52, '2006 has 53 iso weeks');
-    assert.equal(moment([2007]).isoWeeksInYear(), 52, '2007 has 52 iso weeks');
-    assert.equal(moment([2008]).isoWeeksInYear(), 52, '2008 has 53 iso weeks');
-    assert.equal(moment([2009]).isoWeeksInYear(), 53, '2009 has 53 iso weeks');
-    assert.equal(moment([2010]).isoWeeksInYear(), 52, '2010 has 52 iso weeks');
-    assert.equal(moment([2011]).isoWeeksInYear(), 52, '2011 has 52 iso weeks');
-    assert.equal(moment([2012]).isoWeeksInYear(), 52, '2012 has 52 iso weeks');
-    assert.equal(moment([2013]).isoWeeksInYear(), 52, '2013 has 52 iso weeks');
-    assert.equal(moment([2014]).isoWeeksInYear(), 52, '2014 has 52 iso weeks');
-    assert.equal(moment([2015]).isoWeeksInYear(), 53, '2015 has 53 iso weeks');
-    assert.equal(moment([2016]).isoWeeksInYear(), 52, '2016 has 52 iso weeks');
-    assert.equal(moment([2017]).isoWeeksInYear(), 52, '2017 has 52 iso weeks');
-    assert.equal(moment([2018]).isoWeeksInYear(), 52, '2018 has 52 iso weeks');
-    assert.equal(moment([2019]).isoWeeksInYear(), 52, '2019 has 52 iso weeks');
-    assert.equal(moment([2020]).isoWeeksInYear(), 53, '2020 has 53 iso weeks');
+test('isoWeeksInYear first day of ISO Year', function (assert) {
+    assert.equal(moment('2003-12-29').isoWeeksInYear(), 53, 'ISO year 2004 has 53 iso weeks');
+    assert.equal(moment('2005-01-03').isoWeeksInYear(), 52, 'ISO year 2005 has 53 iso weeks');
+    assert.equal(moment('2006-01-02').isoWeeksInYear(), 52, 'ISO year 2006 has 53 iso weeks');
+    assert.equal(moment('2007-01-01').isoWeeksInYear(), 52, 'ISO year 2007 has 52 iso weeks');
+    assert.equal(moment('2007-12-31').isoWeeksInYear(), 52, 'ISO year 2008 has 53 iso weeks');
+    assert.equal(moment('2008-12-29').isoWeeksInYear(), 53, 'ISO year 2009 has 53 iso weeks');
+    assert.equal(moment('2010-01-04').isoWeeksInYear(), 52, 'ISO year 2010 has 52 iso weeks');
+    assert.equal(moment('2011-01-03').isoWeeksInYear(), 52, 'ISO year 2011 has 52 iso weeks');
+    assert.equal(moment('2012-01-02').isoWeeksInYear(), 52, 'ISO year 2012 has 52 iso weeks');
+    assert.equal(moment('2012-12-31').isoWeeksInYear(), 52, 'ISO year 2013 has 52 iso weeks');
+    assert.equal(moment('2013-12-30').isoWeeksInYear(), 52, 'ISO year 2014 has 52 iso weeks');
+    assert.equal(moment('2014-12-29').isoWeeksInYear(), 53, 'ISO year 2015 has 53 iso weeks');
+    assert.equal(moment('2016-01-04').isoWeeksInYear(), 52, 'ISO year 2016 has 52 iso weeks');
+    assert.equal(moment('2017-01-02').isoWeeksInYear(), 52, 'ISO year 2017 has 52 iso weeks');
+    assert.equal(moment('2018-01-01').isoWeeksInYear(), 52, 'ISO year 2018 has 52 iso weeks');
+    assert.equal(moment('2018-12-31').isoWeeksInYear(), 52, 'ISO year 2019 has 52 iso weeks');
+    assert.equal(moment('2019-12-30').isoWeeksInYear(), 53, 'ISO year 2020 has 53 iso weeks');
 });
 
 test('weeksInYear doy/dow = 1/4', function (assert) {
@@ -91,7 +91,8 @@ test('weeksInYear doy/dow = 0/6', function (assert) {
     assert.equal(moment([2015]).weeksInYear(), 52, '2015 has 53 weeks');
 });
 
-test('isoWeeksInYear', function (assert) {
+test('isoWeeksInYear calendar year !== ISO year', function (assert) {
     assert.equal(moment('2019-12-31').isoWeeksInYear(), 53, 'December 31, 2019 is in ISO year 2020 and ISO year 2020 has 53 weeks');
-})
+    assert.equal(moment('2020-12-31').isoWeeksInYear(), 53, 'December 31, 2020 is in ISO year 2020 and ISO year 2020 has 53 weeks');
+});
 

--- a/src/test/moment/weeks_in_year.js
+++ b/src/test/moment/weeks_in_year.js
@@ -16,6 +16,11 @@ test('isoWeeksInYear', function (assert) {
     assert.equal(moment([2013]).isoWeeksInYear(), 52, '2013 has 52 iso weeks');
     assert.equal(moment([2014]).isoWeeksInYear(), 52, '2014 has 52 iso weeks');
     assert.equal(moment([2015]).isoWeeksInYear(), 53, '2015 has 53 iso weeks');
+    assert.equal(moment([2016]).isoWeeksInYear(), 52, '2016 has 52 iso weeks');
+    assert.equal(moment([2017]).isoWeeksInYear(), 52, '2017 has 52 iso weeks');
+    assert.equal(moment([2018]).isoWeeksInYear(), 52, '2018 has 52 iso weeks');
+    assert.equal(moment([2019]).isoWeeksInYear(), 52, '2019 has 52 iso weeks');
+    assert.equal(moment([2020]).isoWeeksInYear(), 53, '2020 has 53 iso weeks');
 });
 
 test('weeksInYear doy/dow = 1/4', function (assert) {
@@ -85,3 +90,8 @@ test('weeksInYear doy/dow = 0/6', function (assert) {
     assert.equal(moment([2014]).weeksInYear(), 52, '2014 has 52 weeks');
     assert.equal(moment([2015]).weeksInYear(), 52, '2015 has 53 weeks');
 });
+
+test('isoWeeksInYear', function (assert) {
+    assert.equal(moment('2019-12-31').isoWeeksInYear(), 53, 'December 31, 2019 is in ISO year 2020 and ISO year 2020 has 53 weeks');
+})
+


### PR DESCRIPTION
New Unit Test exemplifies issue in existing version: `weeksInISOYear` assumed that `this.year()` was equal to the moment's ISO year. This is not the case when the new year starts on a Thursday and we are checking the Wednesday (e.g. December 31, 2019 is in ISO year 2020 and ISO year 2020 has 53 weeks)

The Thursday of the week is guaranteed to be in that day's ISO week, so this fix is rather simple.

Closes #3942.