### PR TITLE
[feature] Support strings repr numbers in duration constructor

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -18,6 +18,7 @@ var isoRegex = /^(-|\+)?P(?:([-+]?[0-9,.]*)Y)?(?:([-+]?[0-9,.]*)M)?(?:([-+]?[0-9
 
 export function createDuration (input, key) {
     var duration = input,
+        numericInput = typeof input === 'string' && !isNaN(input) ? +input : input,
         // matching against regexp is expensive, do it on demand
         match = null,
         sign,
@@ -30,12 +31,12 @@ export function createDuration (input, key) {
             d  : input._days,
             M  : input._months
         };
-    } else if (isNumber(input)) {
+    } else if (isNumber(numericInput)) {
         duration = {};
         if (key) {
-            duration[key] = input;
+            duration[key] = numericInput;
         } else {
-            duration.milliseconds = input;
+            duration.milliseconds = numericInput;
         }
     } else if (!!(match = aspNetRegex.exec(input))) {
         sign = (match[1] === '-') ? -1 : 1;

--- a/src/lib/moment/add-subtract.js
+++ b/src/lib/moment/add-subtract.js
@@ -17,7 +17,6 @@ function createAdder(direction, name) {
             tmp = val; val = period; period = tmp;
         }
 
-        val = typeof val === 'string' ? +val : val;
         dur = createDuration(val, period);
         addSubtract(this, dur, direction);
         return this;

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -52,6 +52,11 @@ test('milliseconds instantiation', function (assert) {
     assert.equal(moment.duration(72).humanize(), 'a few seconds', 'Duration should be valid');
 });
 
+test('milliseconds instantiation with string', function (assert) {
+    assert.equal(moment.duration('72').milliseconds(), 72, 'milliseconds');
+    assert.equal(moment.duration('72').humanize(), 'a few seconds', 'Duration should be valid');
+});
+
 test('undefined instantiation', function (assert) {
     assert.equal(moment.duration(undefined).milliseconds(), 0, 'milliseconds');
     assert.equal(moment.duration(undefined).isValid(), true, '_isValid');
@@ -87,6 +92,25 @@ test('instantiation by type', function (assert) {
     assert.equal(moment.duration(7, 's').seconds(),                   7, 's');
     assert.equal(moment.duration(8, 'milliseconds').milliseconds(),   8, 'milliseconds');
     assert.equal(moment.duration(8, 'ms').milliseconds(),             8, 'ms');
+});
+
+test('instantiation by type with string', function (assert) {
+    assert.equal(moment.duration('1', 'years').years(),                 1, 'years');
+    assert.equal(moment.duration('1', 'y').years(),                     1, 'y');
+    assert.equal(moment.duration('2', 'months').months(),               2, 'months');
+    assert.equal(moment.duration('2', 'M').months(),                    2, 'M');
+    assert.equal(moment.duration('3', 'weeks').weeks(),                 3, 'weeks');
+    assert.equal(moment.duration('3', 'w').weeks(),                     3, 'weeks');
+    assert.equal(moment.duration('4', 'days').days(),                   4, 'days');
+    assert.equal(moment.duration('4', 'd').days(),                      4, 'd');
+    assert.equal(moment.duration('5', 'hours').hours(),                 5, 'hours');
+    assert.equal(moment.duration('5', 'h').hours(),                     5, 'h');
+    assert.equal(moment.duration('6', 'minutes').minutes(),             6, 'minutes');
+    assert.equal(moment.duration('6', 'm').minutes(),                   6, 'm');
+    assert.equal(moment.duration('7', 'seconds').seconds(),             7, 'seconds');
+    assert.equal(moment.duration('7', 's').seconds(),                   7, 's');
+    assert.equal(moment.duration('8', 'milliseconds').milliseconds(),   8, 'milliseconds');
+    assert.equal(moment.duration('8', 'ms').milliseconds(),             8, 'ms');
 });
 
 test('shortcuts', function (assert) {


### PR DESCRIPTION
Previous behavior:

```javascript
moment.duration(5, 'days').days();   // 5
moment.duration(5).milliseconds();   // 5
moment.duration('5', 'days').days(); // 0
moment.duration('5').milliseconds(); // 0
```

New behavior:

```javascript
moment.duration('5', 'days').days(); // 5
moment.duration('5').milliseconds(); // 5
```

This is consistent with how similar methods allow this signature, like `moment().add('5', 'days')`