### PR TITLE
[misc] Add copyright date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) JS Foundation and other contributors
+Copyright (c) 2011-2018 JS Foundation and other contributors
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
moment.js is included in a Debian package. We need to know the copyright date. I guesses it from past commits, feel free to fix it, but please include the date.