### PR TITLE
[bugfix] Fixing RelativeTimeSpec to allow update of a single relativeTime handler

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -79,20 +79,20 @@ declare namespace moment {
   type RelativeTimeFuturePastVal = string | ((relTime: string) => string);
 
   interface RelativeTimeSpec {
-    future: RelativeTimeFuturePastVal;
-    past: RelativeTimeFuturePastVal;
-    s: RelativeTimeSpecVal;
-    ss: RelativeTimeSpecVal;
-    m: RelativeTimeSpecVal;
-    mm: RelativeTimeSpecVal;
-    h: RelativeTimeSpecVal;
-    hh: RelativeTimeSpecVal;
-    d: RelativeTimeSpecVal;
-    dd: RelativeTimeSpecVal;
-    M: RelativeTimeSpecVal;
-    MM: RelativeTimeSpecVal;
-    y: RelativeTimeSpecVal;
-    yy: RelativeTimeSpecVal;
+    future?: RelativeTimeFuturePastVal;
+    past?: RelativeTimeFuturePastVal;
+    s?: RelativeTimeSpecVal;
+    ss?: RelativeTimeSpecVal;
+    m?: RelativeTimeSpecVal;
+    mm?: RelativeTimeSpecVal;
+    h?: RelativeTimeSpecVal;
+    hh?: RelativeTimeSpecVal;
+    d?: RelativeTimeSpecVal;
+    dd?: RelativeTimeSpecVal;
+    M?: RelativeTimeSpecVal;
+    MM?: RelativeTimeSpecVal;
+    y?: RelativeTimeSpecVal;
+    yy?: RelativeTimeSpecVal;
   }
 
   interface LongDateFormatSpec {


### PR DESCRIPTION
We have the ability to update only a single relativeTime handler, but the typescript spec doesn't allow to do so.
Issue ref => https://github.com/moment/moment/issues/4438