### PR TITLE
[bugfix] Treat periods as periods, not regex-anything period, for weekday parsing in strict mode.

### DIFF
--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -200,9 +200,9 @@ export function localeWeekdaysParse (weekdayName, format, strict) {
 
         mom = createUTC([2000, 1]).day(i);
         if (strict && !this._fullWeekdaysParse[i]) {
-            this._fullWeekdaysParse[i] = new RegExp('^' + this.weekdays(mom, '').replace('.', '\.?') + '$', 'i');
+            this._fullWeekdaysParse[i] = new RegExp('^' + this.weekdays(mom, '').replace('.', '\\.?') + '$', 'i');
             this._shortWeekdaysParse[i] = new RegExp('^' + this.weekdaysShort(mom, '').replace('.', '\\.?') + '$', 'i');
-            this._minWeekdaysParse[i] = new RegExp('^' + this.weekdaysMin(mom, '').replace('.', '\.?') + '$', 'i');
+            this._minWeekdaysParse[i] = new RegExp('^' + this.weekdaysMin(mom, '').replace('.', '\\.?') + '$', 'i');
         }
         if (!this._weekdaysParse[i]) {
             regex = '^' + this.weekdays(mom, '') + '|^' + this.weekdaysShort(mom, '') + '|^' + this.weekdaysMin(mom, '');

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -201,7 +201,7 @@ export function localeWeekdaysParse (weekdayName, format, strict) {
         mom = createUTC([2000, 1]).day(i);
         if (strict && !this._fullWeekdaysParse[i]) {
             this._fullWeekdaysParse[i] = new RegExp('^' + this.weekdays(mom, '').replace('.', '\.?') + '$', 'i');
-            this._shortWeekdaysParse[i] = new RegExp('^' + this.weekdaysShort(mom, '').replace('.', '\.?') + '$', 'i');
+            this._shortWeekdaysParse[i] = new RegExp('^' + this.weekdaysShort(mom, '').replace('.', '\\.?') + '$', 'i');
             this._minWeekdaysParse[i] = new RegExp('^' + this.weekdaysMin(mom, '').replace('.', '\.?') + '$', 'i');
         }
         if (!this._weekdaysParse[i]) {

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -471,16 +471,37 @@ test('moment().lang with missing key doesn\'t change locale', function (assert) 
             'preserve global locale in case of bad locale id');
 });
 
-test('in strict mode, regex day of week parsing treats periods literally, not as the regex-period', function(assert) {
-    moment.defineLocale('periods', {
-        weekdays : 'Mondee_Tuesdee_Wednsee_Thursee_Fridee_Saturdee_Sundee'.split('_'),
-        weekdaysShort : 'mon_tu.s_wed_tuas_fri_sat_sun'.split('_'),
-        weekdaysMin : 'ZA_ZB_ZC_ZD_ZE_ZF_ZG'.split('_'),
+test('when in strict mode with inexact parsing, treat periods in short weekdays literally, not as the regex-period', function(assert) {
+    moment.defineLocale('periods-in-short-weekdays', {
+        weekdays : 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
+        weekdaysShort : 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),
         weekdaysParseExact : false,
     });
 
-    moment().locale('periods');
-    assert.equal(moment('tuas', 'ddd', true).format('dddd'), 'Thursee');
+    moment().locale('periods-in-short-weekdays');
+    assert.equal(moment('thurs', 'ddd', true).format('dddd'), 'Thursday');
+});
+
+test('when in strict mode with inexact parsing, treat periods in full weekdays literally, not as the regex-period', function(assert) {
+    moment.defineLocale('periods-in-full-weekdays', {
+        weekdays : 'Monday_T....day_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
+        weekdaysShort : 'mon_tues_wed_thurs_fri_sat_sun'.split('_'),
+        weekdaysParseExact : false,
+    });
+
+    moment().locale('periods-in-full-weekdays');
+    assert.equal(moment('Thursday', 'dddd', true).format('ddd'), 'thurs');
+});
+
+test('when in strict mode with inexact parsing, treat periods in min-weekdays literally, not as the regex-period', function(assert) {
+    moment.defineLocale('periods-in-min-weekdays', {
+        weekdays : 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
+        weekdaysMin : 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),
+        weekdaysParseExact : false,
+    });
+
+    moment().locale('periods-in-min-weekdays');
+    assert.equal(moment('thurs', 'dd', true).format('dddd'), 'Thursday');
 });
 
 

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -471,7 +471,7 @@ test('moment().lang with missing key doesn\'t change locale', function (assert) 
             'preserve global locale in case of bad locale id');
 });
 
-test('when in strict mode with inexact parsing, treat periods in short weekdays literally, not as the regex-period', function(assert) {
+test('when in strict mode with inexact parsing, treat periods in short weekdays literally, not as the regex-period', function (assert) {
     moment.defineLocale('periods-in-short-weekdays', {
         weekdays : 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
         weekdaysShort : 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),
@@ -482,7 +482,7 @@ test('when in strict mode with inexact parsing, treat periods in short weekdays 
     assert.equal(moment('thurs', 'ddd', true).format('dddd'), 'Thursday');
 });
 
-test('when in strict mode with inexact parsing, treat periods in full weekdays literally, not as the regex-period', function(assert) {
+test('when in strict mode with inexact parsing, treat periods in full weekdays literally, not as the regex-period', function (assert) {
     moment.defineLocale('periods-in-full-weekdays', {
         weekdays : 'Monday_T....day_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
         weekdaysShort : 'mon_tues_wed_thurs_fri_sat_sun'.split('_'),
@@ -493,7 +493,7 @@ test('when in strict mode with inexact parsing, treat periods in full weekdays l
     assert.equal(moment('Thursday', 'dddd', true).format('ddd'), 'thurs');
 });
 
-test('when in strict mode with inexact parsing, treat periods in min-weekdays literally, not as the regex-period', function(assert) {
+test('when in strict mode with inexact parsing, treat periods in min-weekdays literally, not as the regex-period', function (assert) {
     moment.defineLocale('periods-in-min-weekdays', {
         weekdays : 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
         weekdaysMin : 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -471,6 +471,18 @@ test('moment().lang with missing key doesn\'t change locale', function (assert) 
             'preserve global locale in case of bad locale id');
 });
 
+test('in strict mode, regex day of week parsing treats periods literally, not as the regex-period', function(assert) {
+    moment.defineLocale('periods', {
+        weekdays : 'Mondee_Tuesdee_Wednsee_Thursee_Fridee_Saturdee_Sundee'.split('_'),
+        weekdaysShort : 'mon_tu.s_wed_tuas_fri_sat_sun'.split('_'),
+        weekdaysMin : 'ZA_ZB_ZC_ZD_ZE_ZF_ZG'.split('_'),
+        weekdaysParseExact : false,
+    });
+
+    moment().locale('periods');
+    assert.equal(moment('tuas', 'ddd', true).format('dddd'), 'Thursee');
+});
+
 
 // TODO: Enable this after fixing pl months parse hack hack
 // test('monthsParseExact', function (assert) {

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -475,7 +475,7 @@ test('when in strict mode with inexact parsing, treat periods in short weekdays 
     moment.defineLocale('periods-in-short-weekdays', {
         weekdays : 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
         weekdaysShort : 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),
-        weekdaysParseExact : false,
+        weekdaysParseExact : false
     });
 
     moment().locale('periods-in-short-weekdays');
@@ -486,7 +486,7 @@ test('when in strict mode with inexact parsing, treat periods in full weekdays l
     moment.defineLocale('periods-in-full-weekdays', {
         weekdays : 'Monday_T....day_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
         weekdaysShort : 'mon_tues_wed_thurs_fri_sat_sun'.split('_'),
-        weekdaysParseExact : false,
+        weekdaysParseExact : false
     });
 
     moment().locale('periods-in-full-weekdays');
@@ -497,7 +497,7 @@ test('when in strict mode with inexact parsing, treat periods in min-weekdays li
     moment.defineLocale('periods-in-min-weekdays', {
         weekdays : 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
         weekdaysMin : 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),
-        weekdaysParseExact : false,
+        weekdaysParseExact : false
     });
 
     moment().locale('periods-in-min-weekdays');


### PR DESCRIPTION
Closes #4347 
This can close #4350 too because this is that change, but with the required unit tests.