### PR TITLE
[misc] Update downloads badge to point to graph of downloads 📈

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Join the chat at https://gitter.im/moment/moment](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/moment/moment?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![NPM version][npm-version-image]][npm-url] [![NPM downloads][npm-downloads-image]][npm-url] [![MIT License][license-image]][license-url] [![Build Status][travis-image]][travis-url]
+[![NPM version][npm-version-image]][npm-url] [![NPM downloads][npm-downloads-image]][downloads-url] [![MIT License][license-image]][license-url] [![Build Status][travis-image]][travis-url]
 [![Coverage Status](https://coveralls.io/repos/moment/moment/badge.svg?branch=develop)](https://coveralls.io/r/moment/moment?branch=develop)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fmoment.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fmoment?ref=badge_shield)
 
@@ -56,6 +56,7 @@ Moment.js is freely distributable under the terms of the [MIT license](https://g
 [npm-url]: https://npmjs.org/package/moment
 [npm-version-image]: http://img.shields.io/npm/v/moment.svg?style=flat
 [npm-downloads-image]: http://img.shields.io/npm/dm/moment.svg?style=flat
+[downloads-url]: https://npmcharts.com/compare/moment?minimal=true
 
 [travis-url]: http://travis-ci.org/moment/moment
 [travis-image]: http://img.shields.io/travis/moment/moment/develop.svg?style=flat


### PR DESCRIPTION
👋😃

Noticed that your "npm" badge and "downloads" badge currently both point to the same page on npmjs.org  

I was wondering if you might prefer having the download badge point to a download chart instead?

If not, feel free to close and apologies for the drive-by PR 😄