### PR TITLE
[feature] Add localeSort param to Locale weekday methods

### DIFF
--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -96,25 +96,28 @@ function parseIsoWeekday(input, locale) {
 }
 
 // LOCALES
+function shiftWeekdays (ws, n) {
+    return ws.slice(n, 7).concat(ws.slice(0, n));
+}
 
 export var defaultLocaleWeekdays = 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_');
 export function localeWeekdays (m, format) {
-    if (!m) {
-        return isArray(this._weekdays) ? this._weekdays :
-            this._weekdays['standalone'];
-    }
-    return isArray(this._weekdays) ? this._weekdays[m.day()] :
-        this._weekdays[this._weekdays.isFormat.test(format) ? 'format' : 'standalone'][m.day()];
+    var weekdays = isArray(this._weekdays) ? this._weekdays :
+        this._weekdays[(m && m !== true && this._weekdays.isFormat.test(format)) ? 'format' : 'standalone'];
+    return (m === true) ? shiftWeekdays(weekdays, this._week.dow)
+        : (m) ? weekdays[m.day()] : weekdays;
 }
 
 export var defaultLocaleWeekdaysShort = 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_');
 export function localeWeekdaysShort (m) {
-    return (m) ? this._weekdaysShort[m.day()] : this._weekdaysShort;
+    return (m === true) ? shiftWeekdays(this._weekdaysShort, this._week.dow)
+        : (m) ? this._weekdaysShort[m.day()] : this._weekdaysShort;
 }
 
 export var defaultLocaleWeekdaysMin = 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_');
 export function localeWeekdaysMin (m) {
-    return (m) ? this._weekdaysMin[m.day()] : this._weekdaysMin;
+    return (m === true) ? shiftWeekdays(this._weekdaysMin, this._week.dow)
+        : (m) ? this._weekdaysMin[m.day()] : this._weekdaysMin;
 }
 
 function handleStrictParse(weekdayName, format, strict) {

--- a/src/locale/en-au.js
+++ b/src/locale/en-au.js
@@ -56,4 +56,3 @@ export default moment.defineLocale('en-au', {
         doy : 4  // The week that contains Jan 4th is the first week of the year.
     }
 });
-

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -35,6 +35,9 @@ function weekdaysCaseReplace(m, format) {
         'genitive': 'неділі_понеділка_вівторка_середи_четверга_п’ятниці_суботи'.split('_')
     };
 
+    if (m === true) {
+      return weekdays['nominative'].slice(1, 7).concat(weekdays['nominative'].slice(0, 1));
+    }
     if (!m) {
         return weekdays['nominative'];
     }
@@ -141,4 +144,3 @@ export default moment.defineLocale('uk', {
         doy : 7  // The week that contains Jan 1st is the first week of the year.
     }
 });
-

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -36,7 +36,7 @@ function weekdaysCaseReplace(m, format) {
     };
 
     if (m === true) {
-      return weekdays['nominative'].slice(1, 7).concat(weekdays['nominative'].slice(0, 1));
+        return weekdays['nominative'].slice(1, 7).concat(weekdays['nominative'].slice(0, 1));
     }
     if (!m) {
         return weekdays['nominative'];

--- a/src/test/helpers/common-locale.js
+++ b/src/test/helpers/common-locale.js
@@ -145,5 +145,23 @@ export function defineCommonLocaleTests(locale, options) {
         assert.equal(moment().localeData().weekdaysShort().length, 7, 'weekdaysShort should return 7 days');
         assert.equal(moment().localeData().weekdaysMin().length, 7, 'monthsShort should return 7 days');
     });
-}
 
+    test('localeData weekdays can localeSort', function (assert) {
+        var weekdays = moment().localeData().weekdays();
+        var weekdaysShort = moment().localeData().weekdaysShort();
+        var weekdaysMin = moment().localeData().weekdaysMin();
+        var shift = moment().localeData()._week.dow;
+        assert.deepEqual(
+            moment().localeData().weekdays(true),
+            weekdays.slice(shift, 7).concat(weekdays.slice(0, shift)),
+            'weekdays should localeSort');
+        assert.deepEqual(
+            moment().localeData().weekdaysShort(true),
+            weekdaysShort.slice(shift, 7).concat(weekdaysShort.slice(0, shift)),
+            'weekdaysShort should localeSort');
+        assert.deepEqual(
+            moment().localeData().weekdaysMin(true),
+            weekdaysMin.slice(shift, 7).concat(weekdaysMin.slice(0, shift)),
+            'weekdaysMin should localeSort');
+    });
+}

--- a/src/test/locale/en-au.js
+++ b/src/test/locale/en-au.js
@@ -208,3 +208,31 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0,  9]).format('w ww wo'),   '2 02 2nd', 'Jan  9 2012 should be week 2');
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2nd', 'Jan 15 2012 should be week 2');
 });
+
+// Concrete test for Locale#weekdaysMin
+test('Weekdays sort by locale', function (assert) {
+    assert.deepEqual(
+        moment().localeData('en-au').weekdays(),
+        'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
+        'weekdays start on Sunday');
+    assert.deepEqual(
+        moment().localeData('en-au').weekdays(true),
+        'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
+        'locale-sorted weekdays start on Monday');
+    assert.deepEqual(
+        moment().localeData('en-au').weekdaysShort(),
+        'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
+        'weekdaysShort start on Sunday');
+    assert.deepEqual(
+        moment().localeData('en-au').weekdaysShort(true),
+        'Mon_Tue_Wed_Thu_Fri_Sat_Sun'.split('_'),
+        'locale-sorted weekdaysShort start on Monday');
+    assert.deepEqual(
+        moment().localeData('en-au').weekdaysMin(),
+        'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
+        'weekdaysMin start on Sunday');
+    assert.deepEqual(
+        moment().localeData('en-au').weekdaysMin(true),
+        'Mo_Tu_We_Th_Fr_Sa_Su'.split('_'),
+        'locale-sorted weekdaysMin start on Monday');
+});

--- a/src/test/locale/en-gb.js
+++ b/src/test/locale/en-gb.js
@@ -208,4 +208,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0,  9]).format('w ww wo'),   '2 02 2nd', 'Jan  9 2012 should be week 2');
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2nd', 'Jan 15 2012 should be week 2');
 });
-


### PR DESCRIPTION
fixes https://github.com/moment/moment/issues/4066

This adds `Locale#weekdays(true)` to sort weekdays by locale (as `moment.weekdays(true)` does if it is the current locale). Same for `#weekdaysShort`, `#weekdaysMin`. 

I added some tests for all locales, and a concrete one for `en-au`.
Example:
```
moment.localeData('en-gb').weekdays(true) 
```