### PR TITLE
[bugfix] Avoid using trim()

### DIFF
--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -128,7 +128,7 @@ function untruncateYear(yearStr) {
 
 function preprocessRFC2822(s) {
     // Remove comments and folding whitespace and replace multiple-spaces with a single space
-    return s.replace(/\([^)]*\)|[\n\t]/g, ' ').replace(/(\s\s+)/g, ' ').trim();
+    return s.replace(/\([^)]*\)|[\n\t]/g, ' ').replace(/(\s\s+)/g, ' ').replace(/^\s\s*/, '').replace(/\s\s*$/, '');
 }
 
 function checkWeekday(weekdayStr, parsedInput, config) {


### PR DESCRIPTION
Fixes #4547 - trim() isn't available in old IE / compatibility modes, and moment docs still claim support for IE 8.