### PR TITLE
#4323 Check for isNaN when checking for number

### DIFF
--- a/moment.js
+++ b/moment.js
@@ -3021,7 +3021,7 @@
                 d  : input._days,
                 M  : input._months
             };
-        } else if (isNumber(input)) {
+        } else if (isNumber(input) && !isNaN(input)) {
             duration = {};
             if (key) {
                 duration[key] = input;


### PR DESCRIPTION
NaN passes the isNumber check which then uses this to set valid and makes it false, but milliseconds gets set to 0 so when cloned it becomes valid. This will make NaN fail the number check which makes it a valid duration just like it does when undefined or null is passed in. 