### PR TITLE
[bugfix] Issue #4323 check for NaN when creating duration

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -30,7 +30,7 @@ export function createDuration (input, key) {
             d  : input._days,
             M  : input._months
         };
-    } else if (isNumber(input)) {
+    } else if (isNumber(input) && !isNaN(input)) {
         duration = {};
         if (key) {
             duration[key] = input;


### PR DESCRIPTION
NaN passes the isNumber check which then uses this to set valid and makes it false, but milliseconds gets set to 0 so when cloned it becomes valid. This will make NaN fail the number check which makes it a valid duration just like it does when undefined or null is passed in.