### PR TITLE
[locale] ja: fix long month names

### DIFF
--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -5,7 +5,7 @@
 import moment from '../moment';
 
 export default moment.defineLocale('ja', {
-    months : '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),
+    months : '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split('_'),
     monthsShort : '1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月'.split('_'),
     weekdays : '日曜日_月曜日_火曜日_水曜日_木曜日_金曜日_土曜日'.split('_'),
     weekdaysShort : '日_月_火_水_木_金_土'.split('_'),

--- a/src/test/locale/ja.js
+++ b/src/test/locale/ja.js
@@ -23,9 +23,9 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, a h:mm:ss',      '日曜日, 2月 14日 2010, 午後 3:25:50'],
+            ['dddd, MMMM Do YYYY, a h:mm:ss',      '日曜日, 二月 14日 2010, 午後 3:25:50'],
             ['ddd, Ah',                            '日, 午後3'],
-            ['M Mo MM MMMM MMM',                   '2 2 02 2月 2月'],
+            ['M Mo MM MMMM MMM',                   '2 2 02 二月 2月'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14日 14'],
             ['d do dddd ddd dd',                   '0 0日 日曜日 日 日'],
@@ -55,7 +55,7 @@ test('format', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = '1月 1月_2月 2月_3月 3月_4月 4月_5月 5月_6月 6月_7月 7月_8月 8月_9月 9月_10月 10月_11月 11月_12月 12月'.split('_'), i;
+    var expected = '一月 1月_二月 2月_三月 3月_四月 4月_五月 5月_六月 6月_七月 7月_八月 8月_九月 9月_十月 10月_十一月 11月_十二月 12月'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }

--- a/src/test/moment/start_end_of.js
+++ b/src/test/moment/start_end_of.js
@@ -289,7 +289,7 @@ test('start of second', function (assert) {
     assert.equal(m.date(), 2, 'keep the day');
     assert.equal(m.hours(), 3, 'keep the hours');
     assert.equal(m.minutes(), 4, 'keep the minutes');
-    assert.equal(m.seconds(), 5, 'keep the the seconds');
+    assert.equal(m.seconds(), 5, 'keep the seconds');
     assert.equal(m.milliseconds(), 0, 'strip out the milliseconds');
 });
 


### PR DESCRIPTION
@baryon 

I just fixed month names.

### Related Information
http://cldr.unicode.org/translation/date-time-patterns