### PR TITLE
[Typescript] StartOf can be null

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -300,7 +300,7 @@ declare namespace moment {
 
     type DurationAs = Base;
 
-    type StartOf = Base | _quarter | _isoWeek | _date;
+    type StartOf = Base | _quarter | _isoWeek | _date | null;
 
     type Diff = Base | _quarter;
 


### PR DESCRIPTION
It's seems (cf https://momentjs.com/docs/#/query/is-between/) that the third argument of isBetween() can be **null** but it's was not specified in the type definition.

This pull request allow StartOf to be nullable.