### PR TITLE
[locale] it: Improve future relative time

### DIFF
--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -39,9 +39,7 @@ export default moment.defineLocale('it', {
         sameElse: 'L',
     },
     relativeTime: {
-        future: function (s) {
-            return (/^[0-9].+$/.test(s) ? 'tra' : 'in') + ' ' + s;
-        },
+        future : 'tra %s',
         past: '%s fa',
         s: 'alcuni secondi',
         ss: '%d secondi',

--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -39,7 +39,7 @@ export default moment.defineLocale('it', {
         sameElse: 'L',
     },
     relativeTime: {
-        future : 'tra %s',
+        future: 'tra %s',
         past: '%s fa',
         s: 'alcuni secondi',
         ss: '%d secondi',

--- a/src/test/locale/it.js
+++ b/src/test/locale/it.js
@@ -289,15 +289,15 @@ test('from', function (assert) {
 });
 
 test('suffix', function (assert) {
-    assert.equal(moment(30000).from(0), 'in alcuni secondi', 'prefix');
+    assert.equal(moment(30000).from(0), 'tra alcuni secondi', 'prefix');
     assert.equal(moment(0).from(30000), 'alcuni secondi fa', 'suffix');
 });
 
 test('fromNow', function (assert) {
     assert.equal(
         moment().add({ s: 30 }).fromNow(),
-        'in alcuni secondi',
-        'in seconds'
+        'tra alcuni secondi',
+        'tra seconds'
     );
     assert.equal(moment().add({ d: 5 }).fromNow(), 'tra 5 giorni', 'in 5 days');
 });


### PR DESCRIPTION
I don't know Italian, but this is what my colleague said:

> In Italian, "in" followed by a time expression is translated with "tra", not with "in". 
> There's no difference between "in a day" and "in 1 day" if they are both referred to future plans, they should both be translated with "tra" in Italian.
> "In" in Italian refers to locations. It can also refer to time expressions, but not in the future.
> 
> The current translation is indeed a mistake and it should be changed to
> 
> tra un giorno
> 
> See more info about the use of "in" and "tra" in Italian here (not a complete grammar, of course, but it can give you the idea):
> http://www.italianlanguageguide.com/grammar/prepositions/