### PR TITLE
Making weekdaysShort relevant for Norwegian

### DIFF
--- a/locale/nb.js
+++ b/locale/nb.js
@@ -13,7 +13,7 @@
         monthsShort : 'jan._feb._mars_april_mai_juni_juli_aug._sep._okt._nov._des.'.split('_'),
         monthsParseExact : true,
         weekdays : 'søndag_mandag_tirsdag_onsdag_torsdag_fredag_lørdag'.split('_'),
-        weekdaysShort : 'sø._ma._ti._on._to._fr._lø.'.split('_'),
+        weekdaysShort : 'søn_man_tir_ons_tor_fre_lør'.split('_'),
         weekdaysMin : 'sø_ma_ti_on_to_fr_lø'.split('_'),
         weekdaysParseExact : true,
         longDateFormat : {

--- a/src/locale/pa-in.js
+++ b/src/locale/pa-in.js
@@ -47,7 +47,7 @@ export default moment.defineLocale('pa-in', {
     calendar : {
         sameDay : '[ਅਜ] LT',
         nextDay : '[ਕਲ] LT',
-        nextWeek : 'dddd, LT',
+        nextWeek : '[ਅਗਲਾ] dddd, LT',
         lastDay : '[ਕਲ] LT',
         lastWeek : '[ਪਿਛਲੇ] dddd, LT',
         sameElse : 'L'

--- a/src/test/locale/pa-in.js
+++ b/src/test/locale/pa-in.js
@@ -165,11 +165,11 @@ test('calendar next week', function (assert) {
     var i, m;
     for (i = 2; i < 7; i++) {
         m = moment().add({d: i});
-        assert.equal(m.calendar(),       m.format('dddd[,] LT'),  'Today + ' + i + ' days current time');
+        assert.equal(m.calendar(),       m.format('[ਅਗਲਾ] dddd[,] LT'),  'Today + ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),       m.format('dddd[,] LT'),  'Today + ' + i + ' days beginning of day');
+        assert.equal(m.calendar(),       m.format('[ਅਗਲਾ] dddd[,] LT'),  'Today + ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),       m.format('dddd[,] LT'),  'Today + ' + i + ' days end of day');
+        assert.equal(m.calendar(),       m.format('[ਅਗਲਾ] dddd[,] LT'),  'Today + ' + i + ' days end of day');
     }
 });
 

--- a/src/test/moment/start_end_of.js
+++ b/src/test/moment/start_end_of.js
@@ -289,7 +289,7 @@ test('start of second', function (assert) {
     assert.equal(m.date(), 2, 'keep the day');
     assert.equal(m.hours(), 3, 'keep the hours');
     assert.equal(m.minutes(), 4, 'keep the minutes');
-    assert.equal(m.seconds(), 5, 'keep the the seconds');
+    assert.equal(m.seconds(), 5, 'keep the seconds');
     assert.equal(m.milliseconds(), 0, 'strip out the milliseconds');
 });
 


### PR DESCRIPTION
Current translation is never used in Norwegian, making it relevant/useful to use "weekdaysShort".