### PR TITLE
[locale] fix comment about "doy"

### DIFF
--- a/src/lib/units/week.js
+++ b/src/lib/units/week.js
@@ -43,7 +43,7 @@ export function localeWeek (mom) {
 
 export var defaultLocaleWeek = {
     dow : 0, // Sunday is the first day of the week.
-    doy : 6  // The week that contains Jan 1st is the first week of the year.
+    doy : 6  // The week that contains Jan 6th is the first week of the year.
 };
 
 export function localeFirstDayOfWeek () {

--- a/src/locale/ar-dz.js
+++ b/src/locale/ar-dz.js
@@ -45,7 +45,7 @@ export default moment.defineLocale('ar-dz', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 4  // The week that contains Jan 1st is the first week of the year.
+        doy : 4  // The week that contains Jan 4th is the first week of the year.
     }
 });
 

--- a/src/locale/ar-kw.js
+++ b/src/locale/ar-kw.js
@@ -45,6 +45,6 @@ export default moment.defineLocale('ar-kw', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 12  // The week that contains Jan 1st is the first week of the year.
+        doy : 12  // The week that contains Jan 12th is the first week of the year.
     }
 });

--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -108,6 +108,6 @@ export default moment.defineLocale('ar-ly', {
     },
     week : {
         dow : 6, // Saturday is the first day of the week.
-        doy : 12  // The week that contains Jan 1st is the first week of the year.
+        doy : 12  // The week that contains Jan 12th is the first week of the year.
     }
 });

--- a/src/locale/ar-ma.js
+++ b/src/locale/ar-ma.js
@@ -46,7 +46,7 @@ export default moment.defineLocale('ar-ma', {
     },
     week : {
         dow : 6, // Saturday is the first day of the week.
-        doy : 12  // The week that contains Jan 1st is the first week of the year.
+        doy : 12  // The week that contains Jan 12th is the first week of the year.
     }
 });
 

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -90,7 +90,7 @@ export default moment.defineLocale('ar-sa', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
 

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -123,6 +123,6 @@ export default moment.defineLocale('ar', {
     },
     week : {
         dow : 6, // Saturday is the first day of the week.
-        doy : 12  // The week that contains Jan 1st is the first week of the year.
+        doy : 12  // The week that contains Jan 12th is the first week of the year.
     }
 });

--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -91,7 +91,7 @@ export default moment.defineLocale('az', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/be.js
+++ b/src/locale/be.js
@@ -120,7 +120,7 @@ export default moment.defineLocale('be', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -76,7 +76,7 @@ export default moment.defineLocale('bg', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/bn.js
+++ b/src/locale/bn.js
@@ -105,6 +105,6 @@ export default moment.defineLocale('bn', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });

--- a/src/locale/bo.js
+++ b/src/locale/bo.js
@@ -105,7 +105,7 @@ export default moment.defineLocale('bo', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
 

--- a/src/locale/bs.js
+++ b/src/locale/bs.js
@@ -138,6 +138,6 @@ export default moment.defineLocale('bs', {
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/cv.js
+++ b/src/locale/cv.js
@@ -49,6 +49,6 @@ export default moment.defineLocale('cv', {
     ordinal : '%d-мӗш',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/dv.js
+++ b/src/locale/dv.js
@@ -85,6 +85,6 @@ export default moment.defineLocale('dv', {
     },
     week : {
         dow : 7,  // Sunday is the first day of the week.
-        doy : 12  // The week that contains Jan 1st is the first week of the year.
+        doy : 12  // The week that contains Jan 12th is the first week of the year.
     }
 });

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -59,7 +59,7 @@ export default moment.defineLocale('eo', {
     ordinal : '%da',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/es-us.js
+++ b/src/locale/es-us.js
@@ -69,6 +69,6 @@ export default moment.defineLocale('es-us', {
     ordinal : '%dº',
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });

--- a/src/locale/eu.js
+++ b/src/locale/eu.js
@@ -52,7 +52,7 @@ export default moment.defineLocale('eu', {
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/fa.js
+++ b/src/locale/fa.js
@@ -92,7 +92,7 @@ export default moment.defineLocale('fa', {
     ordinal : '%dم',
     week : {
         dow : 6, // Saturday is the first day of the week.
-        doy : 12 // The week that contains Jan 1st is the first week of the year.
+        doy : 12 // The week that contains Jan 12th is the first week of the year.
     }
 });
 

--- a/src/locale/gu.js
+++ b/src/locale/gu.js
@@ -110,6 +110,6 @@ export default moment.defineLocale('gu', {
     },
     week: {
         dow: 0, // Sunday is the first day of the week.
-        doy: 6 // The week that contains Jan 1st is the first week of the year.
+        doy: 6 // The week that contains Jan 6th is the first week of the year.
     }
 });

--- a/src/locale/hi.js
+++ b/src/locale/hi.js
@@ -110,7 +110,7 @@ export default moment.defineLocale('hi', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
 

--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -140,6 +140,6 @@ export default moment.defineLocale('hr', {
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/hy-am.js
+++ b/src/locale/hy-am.js
@@ -81,7 +81,7 @@ export default moment.defineLocale('hy-am', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -69,6 +69,6 @@ export default moment.defineLocale('id', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/jv.js
+++ b/src/locale/jv.js
@@ -69,6 +69,6 @@ export default moment.defineLocale('jv', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/kk.js
+++ b/src/locale/kk.js
@@ -73,6 +73,6 @@ export default moment.defineLocale('kk', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/kn.js
+++ b/src/locale/kn.js
@@ -112,6 +112,6 @@ export default moment.defineLocale('kn', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });

--- a/src/locale/ky.js
+++ b/src/locale/ky.js
@@ -74,6 +74,6 @@ export default moment.defineLocale('ky', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/me.js
+++ b/src/locale/me.js
@@ -98,6 +98,6 @@ export default moment.defineLocale('me', {
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/mk.js
+++ b/src/locale/mk.js
@@ -76,7 +76,7 @@ export default moment.defineLocale('mk', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/mr.js
+++ b/src/locale/mr.js
@@ -147,7 +147,7 @@ export default moment.defineLocale('mr', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
 

--- a/src/locale/ms-my.js
+++ b/src/locale/ms-my.js
@@ -69,7 +69,7 @@ export default moment.defineLocale('ms-my', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/ms.js
+++ b/src/locale/ms.js
@@ -68,7 +68,7 @@ export default moment.defineLocale('ms', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/my.js
+++ b/src/locale/my.js
@@ -81,7 +81,7 @@ export default moment.defineLocale('my', {
     },
     week: {
         dow: 1, // Monday is the first day of the week.
-        doy: 4 // The week that contains Jan 1st is the first week of the year.
+        doy: 4 // The week that contains Jan 4th is the first week of the year.
     }
 });
 

--- a/src/locale/ne.js
+++ b/src/locale/ne.js
@@ -109,7 +109,7 @@ export default moment.defineLocale('ne', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
 

--- a/src/locale/pa-in.js
+++ b/src/locale/pa-in.js
@@ -110,7 +110,7 @@ export default moment.defineLocale('pa-in', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
 

--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -62,7 +62,7 @@ export default moment.defineLocale('ro', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -159,6 +159,6 @@ export default moment.defineLocale('sl', {
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/sr-cyrl.js
+++ b/src/locale/sr-cyrl.js
@@ -97,6 +97,6 @@ export default moment.defineLocale('sr-cyrl', {
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -97,6 +97,6 @@ export default moment.defineLocale('sr', {
     ordinal : '%d.',
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });

--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -45,7 +45,7 @@ export default moment.defineLocale('sw', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/ta.js
+++ b/src/locale/ta.js
@@ -115,7 +115,7 @@ export default moment.defineLocale('ta', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
 

--- a/src/locale/te.js
+++ b/src/locale/te.js
@@ -75,6 +75,6 @@ export default moment.defineLocale('te', {
     },
     week : {
         dow : 0, // Sunday is the first day of the week.
-        doy : 6  // The week that contains Jan 1st is the first week of the year.
+        doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });

--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -84,7 +84,7 @@ export default moment.defineLocale('tr', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/tzm-latn.js
+++ b/src/locale/tzm-latn.js
@@ -44,7 +44,7 @@ export default moment.defineLocale('tzm-latn', {
     },
     week : {
         dow : 6, // Saturday is the first day of the week.
-        doy : 12  // The week that contains Jan 1st is the first week of the year.
+        doy : 12  // The week that contains Jan 12th is the first week of the year.
     }
 });
 

--- a/src/locale/tzm.js
+++ b/src/locale/tzm.js
@@ -44,7 +44,7 @@ export default moment.defineLocale('tzm', {
     },
     week : {
         dow : 6, // Saturday is the first day of the week.
-        doy : 12  // The week that contains Jan 1st is the first week of the year.
+        doy : 12  // The week that contains Jan 12th is the first week of the year.
     }
 });
 

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -138,7 +138,7 @@ export default moment.defineLocale('uk', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 

--- a/src/locale/uz-latn.js
+++ b/src/locale/uz-latn.js
@@ -44,7 +44,7 @@ export default moment.defineLocale('uz-latn', {
     },
     week : {
         dow : 1, // Monday is the first day of the week.
-        doy : 7  // The week that contains Jan 1st is the first week of the year.
+        doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
 


### PR DESCRIPTION
Hi, I'm not absolutely certain about this change, but based on what I've read, I think I'm right...

The docs show:
http://momentjs.com/docs/#/i18n/
```js
    week : {
        dow : 1, // Monday is the first day of the week.
        doy : 4  // The week that contains Jan 4th is the first week of the year.
    }
```

which, afaict means that the `4` as value for `doy` should correspond to the commented `Jan 4th`.

A significant portion of the locales get this right.
Sadly, the file that feels like a template doesn't match the documentation and a handful of locales kept that.

If you agree that the template like file is incorrect, I'm happy to `@ mention` the locale owners to get confirmation about fixing their comments. OTOH, if I'm absolutely wrong about what the comment means, I'd sooner not disturb your localizers.