### PR TITLE
[bugfix] Fix #4698: Use ISO WeekYear for HTML5_FMT.WEEK

### DIFF
--- a/src/moment.js
+++ b/src/moment.js
@@ -88,7 +88,7 @@ moment.HTML5_FMT = {
     TIME: 'HH:mm',                                  // <input type="time" />
     TIME_SECONDS: 'HH:mm:ss',                       // <input type="time" step="1" />
     TIME_MS: 'HH:mm:ss.SSS',                        // <input type="time" step="0.001" />
-    WEEK: 'YYYY-[W]WW',                             // <input type="week" />
+    WEEK: 'GGGG-[W]WW',                             // <input type="week" />
     MONTH: 'YYYY-MM'                                // <input type="month" />
 };
 

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -5,16 +5,16 @@ import moment from '../../moment';
 module('format');
 
 test('format using constants', function (assert) {
-    var m = moment('2017-09-01T23:40:40.678');
-    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL), '2017-09-01T23:40', 'datetime local format constant');
-    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS), '2017-09-01T23:40:40', 'datetime local format constant');
-    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL_MS), '2017-09-01T23:40:40.678', 'datetime local format constant with seconds and millis');
-    assert.equal(m.format(moment.HTML5_FMT.DATE), '2017-09-01', 'date format constant');
+    var m = moment('2016-01-02T23:40:40.678');
+    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL), '2016-01-02T23:40', 'datetime local format constant');
+    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS), '2016-01-02T23:40:40', 'datetime local format constant');
+    assert.equal(m.format(moment.HTML5_FMT.DATETIME_LOCAL_MS), '2016-01-02T23:40:40.678', 'datetime local format constant with seconds and millis');
+    assert.equal(m.format(moment.HTML5_FMT.DATE), '2016-01-02', 'date format constant');
     assert.equal(m.format(moment.HTML5_FMT.TIME), '23:40', 'time format constant');
     assert.equal(m.format(moment.HTML5_FMT.TIME_SECONDS), '23:40:40', 'time format constant with seconds');
     assert.equal(m.format(moment.HTML5_FMT.TIME_MS), '23:40:40.678', 'time format constant with seconds and millis');
-    assert.equal(m.format(moment.HTML5_FMT.WEEK), '2017-W35', 'week format constant');
-    assert.equal(m.format(moment.HTML5_FMT.MONTH), '2017-09', 'month format constant');
+    assert.equal(m.format(moment.HTML5_FMT.WEEK), '2015-W53', 'week format constant');
+    assert.equal(m.format(moment.HTML5_FMT.MONTH), '2016-01', 'month format constant');
 });
 
 test('format YY', function (assert) {

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -536,3 +536,8 @@ test('Y token', function (assert) {
     assert.equal(moment('9999-01-01', 'Y-MM-DD', true).format('Y'), '9999', 'format 9999 with Y');
     assert.equal(moment('10000-01-01', 'Y-MM-DD', true).format('Y'), '+10000', 'format 10000 with Y');
 });
+
+test('HTML5_FMT.WEEK', function (assert) {
+    assert.equal(moment('2004-W01', moment.HTML5_FMT.WEEK).format(moment.HTML5_FMT.WEEK), '2004-W01', 'issue #4698 regression');
+    assert.equal(moment('2019-W01').format(moment.HTML5_FMT.WEEK), '2019-W01', 'issue #4833 regression');
+});


### PR DESCRIPTION
Use the ISO WeekYear `GGGG` in HTML5_FMT.WEEK constant.

Updated test cases for the formatting constants to use a date/time that fails with the old `YYYY` format, to prevent regressions.

Fixes #4698 
Fixes #4833 