### PR TITLE
[misc] improve typings for isBetween methods

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -567,7 +567,7 @@ declare namespace moment {
     isSame(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
     isSameOrAfter(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
     isSameOrBefore(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
-    isBetween(a: MomentInput, b: MomentInput, granularity?: unitOfTime.StartOf, inclusivity?: "()" | "[)" | "(]" | "[]"): boolean;
+    isBetween(a: MomentInput, b: MomentInput, granularity?: unitOfTime.StartOf | null, inclusivity?: "()" | "[)" | "(]" | "[]"): boolean;
 
     /**
      * @deprecated as of 2.8.0, use locale


### PR DESCRIPTION
Based on mentioned supported methods in docs example here: 

<img width="769" alt="screen shot 2018-08-17 at 13 13 47" src="https://user-images.githubusercontent.com/4658636/44263475-6bbc7980-a21f-11e8-8670-78d6c9222419.png">

https://momentjs.com/docs/#/query/is-between/ .  **isBettween** can contains **granularity** value **null**. But this is not mentioned in d.ts file so after adding null as possible value below example will work in typescript as it is. 

`moment('2016-10-30').isBetween('2016-10-30', '2016-12-30', null, '()'); //false
`

