### PR TITLE
[feature] Add weeksInWeekYear to return the weeks in a given week year (fixes #3942)

### DIFF
--- a/src/lib/moment/prototype.js
+++ b/src/lib/moment/prototype.js
@@ -63,7 +63,10 @@ proto.year       = getSetYear;
 proto.isLeapYear = getIsLeapYear;
 
 // Week Year
-import { getSetWeekYear, getSetISOWeekYear, getWeeksInYear, getISOWeeksInYear } from '../units/week-year';
+import {
+    getSetWeekYear, getSetISOWeekYear, getWeeksInYear, getISOWeeksInYear,
+    getWeeksInWeekYear
+} from '../units/week-year';
 proto.weekYear    = getSetWeekYear;
 proto.isoWeekYear = getSetISOWeekYear;
 
@@ -81,6 +84,7 @@ import { getSetWeek, getSetISOWeek } from '../units/week';
 proto.week           = proto.weeks        = getSetWeek;
 proto.isoWeek        = proto.isoWeeks     = getSetISOWeek;
 proto.weeksInYear    = getWeeksInYear;
+proto.weeksInWeekYear = getWeeksInWeekYear;
 proto.isoWeeksInYear = getISOWeeksInYear;
 
 // Day

--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -79,8 +79,16 @@ export function getISOWeeksInYear () {
 }
 
 export function getWeeksInYear () {
-    var weekInfo = this.localeData()._week;
-    return weeksInYear(this.year(), weekInfo.dow, weekInfo.doy);
+    return getWeeksInGivenYear.call(this, this.year());
+}
+
+export function getWeeksInWeekYear () {
+    return getWeeksInGivenYear.call(this, this.weekYear());
+}
+
+function getWeeksInGivenYear(year) {
+    let weekInfo = this.localeData()._week;
+    return weeksInYear(year, weekInfo.dow, weekInfo.doy);
 }
 
 function getSetWeekYearHelper(input, week, weekday, dow, doy) {

--- a/src/test/moment/weeks_in_year.js
+++ b/src/test/moment/weeks_in_year.js
@@ -1,4 +1,4 @@
-import { module, test } from '../qunit';
+import {module, test} from '../qunit';
 import moment from '../../moment';
 
 module('weeks in year');
@@ -22,10 +22,10 @@ test('weeksInYear doy/dow = 1/4', function (assert) {
     moment.locale('1/4', {week: {dow: 1, doy: 4}});
 
     assert.equal(moment([2004]).weeksInYear(), 53, '2004 has 53 weeks');
-    assert.equal(moment([2005]).weeksInYear(), 52, '2005 has 53 weeks');
-    assert.equal(moment([2006]).weeksInYear(), 52, '2006 has 53 weeks');
+    assert.equal(moment([2005]).weeksInYear(), 52, '2005 has 52 weeks');
+    assert.equal(moment([2006]).weeksInYear(), 52, '2006 has 52 weeks');
     assert.equal(moment([2007]).weeksInYear(), 52, '2007 has 52 weeks');
-    assert.equal(moment([2008]).weeksInYear(), 52, '2008 has 53 weeks');
+    assert.equal(moment([2008]).weeksInYear(), 52, '2008 has 52 weeks');
     assert.equal(moment([2009]).weeksInYear(), 53, '2009 has 53 weeks');
     assert.equal(moment([2010]).weeksInYear(), 52, '2010 has 52 weeks');
     assert.equal(moment([2011]).weeksInYear(), 52, '2011 has 52 weeks');
@@ -33,40 +33,76 @@ test('weeksInYear doy/dow = 1/4', function (assert) {
     assert.equal(moment([2013]).weeksInYear(), 52, '2013 has 52 weeks');
     assert.equal(moment([2014]).weeksInYear(), 52, '2014 has 52 weeks');
     assert.equal(moment([2015]).weeksInYear(), 53, '2015 has 53 weeks');
+    assert.equal(moment([2016]).weeksInYear(), 52, '2016 has 52 weeks');
+});
+
+
+test('weeksInWeekYear doy/dow = 1/4', function (assert) {
+    assert.equal(moment([2004]).weeksInWeekYear(), 52, '2004 has 52 weeks in week year');
+    assert.equal(moment([2005]).weeksInWeekYear(), 53, '2005 has 53 weeks in week year');
+    assert.equal(moment([2006]).weeksInWeekYear(), 52, '2006 has 53 weeks in week year');
+    assert.equal(moment([2007]).weeksInWeekYear(), 52, '2007 has 52 weeks in week year');
+    assert.equal(moment([2008]).weeksInWeekYear(), 52, '2008 has 52 weeks in week year');
+    assert.equal(moment([2009]).weeksInWeekYear(), 52, '2009 has 52 weeks in week year');
+    assert.equal(moment([2010]).weeksInWeekYear(), 52, '2010 has 53 weeks in week year');
+    assert.equal(moment([2011]).weeksInWeekYear(), 53, '2011 has 53 weeks in week year');
+    assert.equal(moment([2012]).weeksInWeekYear(), 52, '2012 has 52 weeks in week year');
+    assert.equal(moment([2013]).weeksInWeekYear(), 52, '2013 has 52 weeks in week year');
+    assert.equal(moment([2014]).weeksInWeekYear(), 52, '2014 has 52 weeks in week year');
+    assert.equal(moment([2015]).weeksInWeekYear(), 52, '2015 has 52 weeks in week year');
+    assert.equal(moment([2016]).weeksInWeekYear(), 53, '2016 has 53 weeks in week year');
 });
 
 test('weeksInYear doy/dow = 6/12', function (assert) {
     moment.locale('6/12', {week: {dow: 6, doy: 12}});
 
     assert.equal(moment([2004]).weeksInYear(), 53, '2004 has 53 weeks');
-    assert.equal(moment([2005]).weeksInYear(), 52, '2005 has 53 weeks');
-    assert.equal(moment([2006]).weeksInYear(), 52, '2006 has 53 weeks');
+    assert.equal(moment([2005]).weeksInYear(), 52, '2005 has 52 weeks');
+    assert.equal(moment([2006]).weeksInYear(), 52, '2006 has 52 weeks');
     assert.equal(moment([2007]).weeksInYear(), 52, '2007 has 52 weeks');
-    assert.equal(moment([2008]).weeksInYear(), 52, '2008 has 53 weeks');
-    assert.equal(moment([2009]).weeksInYear(), 52, '2009 has 53 weeks');
-    assert.equal(moment([2010]).weeksInYear(), 53, '2010 has 52 weeks');
+    assert.equal(moment([2008]).weeksInYear(), 52, '2008 has 52 weeks');
+    assert.equal(moment([2009]).weeksInYear(), 52, '2009 has 52 weeks');
+    assert.equal(moment([2010]).weeksInYear(), 53, '2010 has 53 weeks');
     assert.equal(moment([2011]).weeksInYear(), 52, '2011 has 52 weeks');
     assert.equal(moment([2012]).weeksInYear(), 52, '2012 has 52 weeks');
     assert.equal(moment([2013]).weeksInYear(), 52, '2013 has 52 weeks');
     assert.equal(moment([2014]).weeksInYear(), 52, '2014 has 52 weeks');
-    assert.equal(moment([2015]).weeksInYear(), 52, '2015 has 53 weeks');
+    assert.equal(moment([2015]).weeksInYear(), 52, '2015 has 52 weeks');
 });
+
 
 test('weeksInYear doy/dow = 1/7', function (assert) {
     moment.locale('1/7', {week: {dow: 1, doy: 7}});
 
-    assert.equal(moment([2004]).weeksInYear(), 52, '2004 has 53 weeks');
-    assert.equal(moment([2005]).weeksInYear(), 52, '2005 has 53 weeks');
+    assert.equal(moment([2004]).weeksInYear(), 52, '2004 has 52 weeks');
+    assert.equal(moment([2005]).weeksInYear(), 52, '2005 has 52 weeks');
     assert.equal(moment([2006]).weeksInYear(), 53, '2006 has 53 weeks');
     assert.equal(moment([2007]).weeksInYear(), 52, '2007 has 52 weeks');
-    assert.equal(moment([2008]).weeksInYear(), 52, '2008 has 53 weeks');
-    assert.equal(moment([2009]).weeksInYear(), 52, '2009 has 53 weeks');
+    assert.equal(moment([2008]).weeksInYear(), 52, '2008 has 52 weeks');
+    assert.equal(moment([2009]).weeksInYear(), 52, '2009 has 52 weeks');
     assert.equal(moment([2010]).weeksInYear(), 52, '2010 has 52 weeks');
     assert.equal(moment([2011]).weeksInYear(), 52, '2011 has 52 weeks');
-    assert.equal(moment([2012]).weeksInYear(), 53, '2012 has 52 weeks');
+    assert.equal(moment([2012]).weeksInYear(), 53, '2012 has 53 weeks');
     assert.equal(moment([2013]).weeksInYear(), 52, '2013 has 52 weeks');
     assert.equal(moment([2014]).weeksInYear(), 52, '2014 has 52 weeks');
-    assert.equal(moment([2015]).weeksInYear(), 52, '2015 has 53 weeks');
+    assert.equal(moment([2015]).weeksInYear(), 52, '2015 has 52 weeks');
+    assert.equal(moment([2016]).weeksInYear(), 52, '2016 has 52 weeks');
+});
+
+test('weeksInWeekYear doy/dow = 1/7', function (assert) {
+    assert.equal(moment([2004]).weeksInWeekYear(), 52, '2004 has 52 weeks in week year');
+    assert.equal(moment([2005]).weeksInWeekYear(), 53, '2005 has 53 weeks in week year');
+    assert.equal(moment([2006]).weeksInWeekYear(), 52, '2006 has 52 weeks in week year');
+    assert.equal(moment([2007]).weeksInWeekYear(), 52, '2007 has 52 weeks in week year');
+    assert.equal(moment([2008]).weeksInWeekYear(), 52, '2008 has 52 weeks in week year');
+    assert.equal(moment([2009]).weeksInWeekYear(), 52, '2009 has 52 weeks in week year');
+    assert.equal(moment([2010]).weeksInWeekYear(), 52, '2010 has 52 weeks in week year');
+    assert.equal(moment([2011]).weeksInWeekYear(), 53, '2011 has 53 weeks in week year');
+    assert.equal(moment([2012]).weeksInWeekYear(), 52, '2012 has 52 weeks in week year');
+    assert.equal(moment([2013]).weeksInWeekYear(), 52, '2013 has 52 weeks in week year');
+    assert.equal(moment([2014]).weeksInWeekYear(), 52, '2014 has 52 weeks in week year');
+    assert.equal(moment([2015]).weeksInWeekYear(), 52, '2015 has 52 weeks in week year');
+    assert.equal(moment([2016]).weeksInWeekYear(), 53, '2016 has 53 weeks in week year');
 });
 
 test('weeksInYear doy/dow = 0/6', function (assert) {


### PR DESCRIPTION
Added weeksInWeekYear to return the number of week in a given year. This uses the weekYear() and not year().
[Issue Reference](https://github.com/moment/moment/issues/3942)