### PR TITLE
chore(package.json) http -> https

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
     "name": "moment",
     "version": "2.22.2",
     "description": "Parse, validate, manipulate, and display dates",
-    "homepage": "http://momentjs.com",
+    "homepage": "https://momentjs.com",
     "author": "Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)",
     "contributors": [
         "Tim Wood <washwithcare@gmail.com> (http://timwoodcreates.com/)",
         "Rocky Meza (http://rockymeza.com)",
-        "Matt Johnson <mj1856@hotmail.com> (http://codeofmatt.com)",
+        "Matt Johnson <mj1856@hotmail.com> (https://codeofmatt.com)",
         "Isaac Cambron <isaac@isaaccambron.com> (http://isaaccambron.com)",
         "Andre Polykanine <andre@oire.org> (https://github.com/oire)"
     ],


### PR DESCRIPTION
Google Chrome is marking http websites as insecure starting from July 2018

https://momentjs.com as well as https://codeofmatt.com support https, so I don't see any reasons not to switch :)