### PR TITLE
Return separate function for module export

### DIFF
--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -68,7 +68,9 @@ hooks.parseTwoDigitYear = function (input) {
 
 // MOMENTS
 
-export var getSetYear = makeGetSet('FullYear', true);
+export var getSetYear = function () {
+    return makeGetSet('FullYear', true).apply(this, arguments);
+};
 
 export function getIsLeapYear () {
     return isLeapYear(this.year());


### PR DESCRIPTION
To prevent circular dependency issue in some situations, this returns a new function instead of the referenced function from `get-set.js`

Fixes #4756 