### PR TITLE
[locale] Extend cs locale with name of the months in genitive

### DIFF
--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -5,6 +5,7 @@
 import moment from '../moment';
 
 var months = 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split('_'),
+    monthsGenitive = 'ledna_února_března_dubna_května_června_července_srpna_září_října_listopadu_prosince'.split('_'),
     monthsShort = 'led_úno_bře_dub_kvě_čvn_čvc_srp_zář_říj_lis_pro'.split('_');
 function plural(n) {
     return (n > 1) && (n < 5) && (~~(n / 10) !== 1);
@@ -71,12 +72,13 @@ function translate(number, withoutSuffix, key, isFuture) {
 
 export default moment.defineLocale('cs', {
     months : months,
+    monthsGenitive: monthsGenitive,
     monthsShort : monthsShort,
     monthsParse : (function (months, monthsShort) {
         var i, _monthsParse = [];
         for (i = 0; i < 12; i++) {
             // use custom parser to solve problem with July (červenec)
-            _monthsParse[i] = new RegExp('^' + months[i] + '$|^' + monthsShort[i] + '$', 'i');
+            _monthsParse[i] = new RegExp('^' + months[i] + '$|^' + monthsGenitive[i] + '$|^' + monthsShort[i] + '$', 'i');
         }
         return _monthsParse;
     }(months, monthsShort)),
@@ -90,7 +92,7 @@ export default moment.defineLocale('cs', {
     longMonthsParse : (function (months) {
         var i, _longMonthsParse = [];
         for (i = 0; i < 12; i++) {
-            _longMonthsParse[i] = new RegExp('^' + months[i] + '$', 'i');
+            _longMonthsParse[i] = new RegExp('^' + months[i] + '$|^' + monthsGenitive[i] + '$', 'i');
         }
         return _longMonthsParse;
     }(months)),

--- a/src/test/locale/cs.js
+++ b/src/test/locale/cs.js
@@ -4,7 +4,7 @@ import moment from '../../moment';
 localeModule('cs');
 
 test('parse', function (assert) {
-    var tests = 'leden led_únor úno_březen bře_duben dub_květen kvě_červen čvn_červenec čvc_srpen srp_září zář_říjen říj_listopad lis_prosinec pro'.split('_'), i;
+    var tests = 'leden led ledna_únor úno února_březen bře března_duben dub dubna_květen kvě května_červen čvn června_červenec čvc července_srpen srp srpna_září zář září_říjen říj října_listopad lis listopadu_prosinec pro prosince'.split('_'), i;
     function equalTest(input, mmm, monthIndex) {
         assert.equal(moment(input, mmm).month(), monthIndex, input + ' ' + mmm + ' should be month ' + (monthIndex + 1));
     }
@@ -15,12 +15,16 @@ test('parse', function (assert) {
         tests[i] = tests[i].split(' ');
         equalTest(tests[i][0], 'MMM', i);
         equalTest(tests[i][1], 'MMM', i);
+        equalTest(tests[i][2], 'MMM', i);
         equalTest(tests[i][0], 'MMMM', i);
         equalTest(tests[i][1], 'MMMM', i);
+        equalTest(tests[i][2], 'MMMM', i);
         equalTest(tests[i][0].toLocaleLowerCase(), 'MMMM', i);
         equalTest(tests[i][1].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i][2].toLocaleLowerCase(), 'MMMM', i);
         equalTest(tests[i][0].toLocaleUpperCase(), 'MMMM', i);
         equalTest(tests[i][1].toLocaleUpperCase(), 'MMMM', i);
+        equalTest(tests[i][2].toLocaleUpperCase(), 'MMMM', i);
 
         equalTestStrict(tests[i][1], 'MMM', i);
         equalTestStrict(tests[i][0], 'MMMM', i);
@@ -28,6 +32,8 @@ test('parse', function (assert) {
         equalTestStrict(tests[i][1].toLocaleUpperCase(), 'MMM', i);
         equalTestStrict(tests[i][0].toLocaleLowerCase(), 'MMMM', i);
         equalTestStrict(tests[i][0].toLocaleUpperCase(), 'MMMM', i);
+        equalTestStrict(tests[i][2].toLocaleLowerCase(), 'MMMM', i);
+        equalTestStrict(tests[i][2].toLocaleUpperCase(), 'MMMM', i);
     }
 });
 


### PR DESCRIPTION
In Czech, it is possible to use also declined form of the month name instead of the nominative case.
This commit adds those declined names of the months.

@radekdostal @saxicek - please verify this patch as locales have to be verified by native speakers.