### PR TITLE
[locale] Extend cs locale with name of the months in genitive

### DIFF
--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -6,6 +6,12 @@ import moment from '../moment';
 
 var months = 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split('_'),
     monthsShort = 'led_úno_bře_dub_kvě_čvn_čvc_srp_zář_říj_lis_pro'.split('_');
+
+var monthsParse = [/^led/i, /^úno/i, /^bře/i, /^dub/i, /^kvě/i, /^(čvn|červen$|června)/i, /^(čvc|červenec|července)/i, /^srp/i, /^zář/i, /^říj/i, /^lis/i, /^pro/i];
+// NOTE: 'červen' is substring of 'červenec'; therefore 'červenec' must precede 'červen' in the regex to be fully matched.
+// Otherwise parser matches '1. červenec' as '1. červen' + 'ec'.
+var monthsRegex = /^(leden|únor|březen|duben|květen|červenec|července|červen|června|srpen|září|říjen|listopad|prosinec|led|úno|bře|dub|kvě|čvn|čvc|srp|zář|říj|lis|pro)/i;
+
 function plural(n) {
     return (n > 1) && (n < 5) && (~~(n / 10) !== 1);
 }
@@ -72,28 +78,15 @@ function translate(number, withoutSuffix, key, isFuture) {
 export default moment.defineLocale('cs', {
     months : months,
     monthsShort : monthsShort,
-    monthsParse : (function (months, monthsShort) {
-        var i, _monthsParse = [];
-        for (i = 0; i < 12; i++) {
-            // use custom parser to solve problem with July (červenec)
-            _monthsParse[i] = new RegExp('^' + months[i] + '$|^' + monthsShort[i] + '$', 'i');
-        }
-        return _monthsParse;
-    }(months, monthsShort)),
-    shortMonthsParse : (function (monthsShort) {
-        var i, _shortMonthsParse = [];
-        for (i = 0; i < 12; i++) {
-            _shortMonthsParse[i] = new RegExp('^' + monthsShort[i] + '$', 'i');
-        }
-        return _shortMonthsParse;
-    }(monthsShort)),
-    longMonthsParse : (function (months) {
-        var i, _longMonthsParse = [];
-        for (i = 0; i < 12; i++) {
-            _longMonthsParse[i] = new RegExp('^' + months[i] + '$', 'i');
-        }
-        return _longMonthsParse;
-    }(months)),
+    monthsRegex : monthsRegex,
+    monthsShortRegex : monthsRegex,
+    // NOTE: 'červen' is substring of 'červenec'; therefore 'červenec' must precede 'červen' in the regex to be fully matched.
+    // Otherwise parser matches '1. červenec' as '1. červen' + 'ec'.
+    monthsStrictRegex : /^(leden|ledna|února|únor|březen|března|duben|dubna|květen|května|červenec|července|červen|června|srpen|srpna|září|říjen|října|listopadu|listopad|prosinec|prosince)/i,
+    monthsShortStrictRegex : /^(led|úno|bře|dub|kvě|čvn|čvc|srp|zář|říj|lis|pro)/i,
+    monthsParse : monthsParse,
+    longMonthsParse : monthsParse,
+    shortMonthsParse : monthsParse,
     weekdays : 'neděle_pondělí_úterý_středa_čtvrtek_pátek_sobota'.split('_'),
     weekdaysShort : 'ne_po_út_st_čt_pá_so'.split('_'),
     weekdaysMin : 'ne_po_út_st_čt_pá_so'.split('_'),

--- a/src/test/locale/cs.js
+++ b/src/test/locale/cs.js
@@ -4,7 +4,7 @@ import moment from '../../moment';
 localeModule('cs');
 
 test('parse', function (assert) {
-    var tests = 'leden led_únor úno_březen bře_duben dub_květen kvě_červen čvn_červenec čvc_srpen srp_září zář_říjen říj_listopad lis_prosinec pro'.split('_'), i;
+    var tests = 'leden led ledna_únor úno února_březen bře března_duben dub dubna_květen kvě května_červen čvn června_červenec čvc července_srpen srp srpna_září zář září_říjen říj října_listopad lis listopadu_prosinec pro prosince'.split('_'), i;
     function equalTest(input, mmm, monthIndex) {
         assert.equal(moment(input, mmm).month(), monthIndex, input + ' ' + mmm + ' should be month ' + (monthIndex + 1));
     }
@@ -15,19 +15,26 @@ test('parse', function (assert) {
         tests[i] = tests[i].split(' ');
         equalTest(tests[i][0], 'MMM', i);
         equalTest(tests[i][1], 'MMM', i);
+        equalTest(tests[i][2], 'MMM', i);
         equalTest(tests[i][0], 'MMMM', i);
         equalTest(tests[i][1], 'MMMM', i);
+        equalTest(tests[i][2], 'MMMM', i);
         equalTest(tests[i][0].toLocaleLowerCase(), 'MMMM', i);
         equalTest(tests[i][1].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i][2].toLocaleLowerCase(), 'MMMM', i);
         equalTest(tests[i][0].toLocaleUpperCase(), 'MMMM', i);
         equalTest(tests[i][1].toLocaleUpperCase(), 'MMMM', i);
+        equalTest(tests[i][2].toLocaleUpperCase(), 'MMMM', i);
 
         equalTestStrict(tests[i][1], 'MMM', i);
         equalTestStrict(tests[i][0], 'MMMM', i);
+        equalTestStrict(tests[i][2], 'MMMM', i);
         equalTestStrict(tests[i][1].toLocaleLowerCase(), 'MMM', i);
         equalTestStrict(tests[i][1].toLocaleUpperCase(), 'MMM', i);
         equalTestStrict(tests[i][0].toLocaleLowerCase(), 'MMMM', i);
         equalTestStrict(tests[i][0].toLocaleUpperCase(), 'MMMM', i);
+        equalTestStrict(tests[i][2].toLocaleLowerCase(), 'MMMM', i);
+        equalTestStrict(tests[i][2].toLocaleUpperCase(), 'MMMM', i);
     }
 });
 


### PR DESCRIPTION
In Czech, it is possible to use also declined form of the month name instead of the nominative case.
This commit adds those declined names of the months.

@radekdostal @marxsk @petrbela - please verify this patch as locales have to be verified by native speakers.

This PR is meant to replace solution suggested in https://github.com/moment/moment/pull/4765 (and agreed with @marxsk in https://github.com/moment/moment/pull/4765#issuecomment-419863315)

*Discussion:*
Pro of this solution is that is it easier to understand because plain regexes or their arrays are used instead of anonymous function.
Con is that "červenec" must precede "červen" in the `monthsRegex` and `monthsStrictRegex` to match properly.