### PR TITLE
[locale] it: Added italian grammar rule

### DIFF
--- a/locale/it.js
+++ b/locale/it.js
@@ -23,16 +23,24 @@
             LLLL : 'dddd D MMMM YYYY HH:mm'
         },
         calendar : {
-            sameDay: '[Oggi alle] LT',
-            nextDay: '[Domani alle] LT',
-            nextWeek: 'dddd [alle] LT',
-            lastDay: '[Ieri alle] LT',
+            sameDay: function () {
+                return '[Oggi all' + ((this.hours() !== 1) ? 'e ' : '\'') + ']LT';
+            },
+            nextDay: function () {
+                return '[Domani all' + ((this.hours() !== 1) ? 'e ' : '\'') + ']LT';
+            },
+            nextWeek: function () {
+                return 'dddd [all' + ((this.hours() !== 1) ? 'e ' : '\'') + ']LT';
+            },
+            lastDay: function () {
+                return '[Ieri all' + ((this.hours() !== 1) ? 'e ' : '\'') + ']LT';
+            },
             lastWeek: function () {
                 switch (this.day()) {
                     case 0:
-                        return '[la scorsa] dddd [alle] LT';
+                        return '[La scorsa] dddd [all' + ((this.hours() !== 1) ? 'e ' : '\'') + ']LT';
                     default:
-                        return '[lo scorso] dddd [alle] LT';
+                        return '[Lo scorso] dddd [all' + ((this.hours() !== 1) ? 'e ' : '\'') + ']LT';
                 }
             },
             sameElse: 'L'


### PR DESCRIPTION
Source (in Italian): http://www.accademiadellacrusca.it/it/lingua-italiana/consulenza-linguistica/domande-risposte/larticolo-date-cifre
Examples:
«Today at 01:30 AM», before changes «Oggi alle 01:30», after changes «Oggi all'01:30».
«Today at 02:30 AM», before changes «Oggi alle 02:30», after changes «Oggi alle 02:30».
The hour that starts with 1 needs to have «all'{time}» instead of «alle {time}», all the other numbers needs to have «alle {time}».