### PR TITLE
Fix endOf day on brazilian DST start being the next day

### DIFF
--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -55,5 +55,5 @@ export function endOf (units) {
         units = 'day';
     }
 
-    return this.startOf(units).add(1, (units === 'isoWeek' ? 'week' : units)).subtract(1, 'ms');
+    return this.add(1, (units === 'isoWeek' ? 'week' : units)).startOf(units).subtract(1, 'ms');
 }

--- a/src/test/moment/start_end_of.js
+++ b/src/test/moment/start_end_of.js
@@ -347,6 +347,27 @@ test('startOf across DST +1', function (assert) {
     moment.updateOffset = oldUpdateOffset;
 });
 
+test('endOf across DST +1', function (assert) {
+    var oldUpdateOffset = moment.updateOffset,
+        // Based on a real story somewhere in America/Sao_Paulo
+        dstAt = moment('2018-11-04T00:00:00-03:00').parseZone(),
+        m;
+
+    moment.updateOffset = function (mom, keepTime) {
+        if (mom.isBefore(dstAt)) {
+            mom.utcOffset(-3, keepTime);
+        } else {
+            mom.utcOffset(-2, keepTime);
+        }
+    };
+
+    m = moment('2018-11-04T09:00:00-02:00').parseZone();
+    m.endOf('d');
+    assert.equal(m.format(), '2018-11-04T23:59:59-02:00', 'endOf(\'d\') across +1');
+
+    moment.updateOffset = oldUpdateOffset;
+});
+
 test('startOf across DST -1', function (assert) {
     var oldUpdateOffset = moment.updateOffset,
         // Based on a real story somewhere in America/Los_Angeles


### PR DESCRIPTION
I discovered that the order of the computation of the end of day is resulting in:

```
moment('2018-11-04T09:00:00-02:00').endOf('day').toString();
// Mon Nov 05 2018 00:59:59 GMT-0200
```

And this simple change in the order of the operations results in:

```
moment('2018-11-04T09:00:00-02:00').endOf('day').toString();
// Sun Nov 04 2018 23:59:59 GMT-0200
```

Is this a good enough solution?