### PR TITLE
[locale] pt-br: Lowercase weekday names

### DIFF
--- a/locale/pt-br.js
+++ b/locale/pt-br.js
@@ -11,9 +11,9 @@
     var ptBr = moment.defineLocale('pt-br', {
         months : 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
         monthsShort : 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
-        weekdays : 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
-        weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
-        weekdaysMin : 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),
+        weekdays : 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
+        weekdaysShort : 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
+        weekdaysMin : 'do_2ª_3ª_4ª_5ª_6ª_sá'.split('_'),
         weekdaysParseExact : true,
         longDateFormat : {
             LT : 'HH:mm',


### PR DESCRIPTION
The weekdays were in capital letters (which is grammatically incorrect).

Sources: (In Portuguese)
https://www.soportugues.com.br/secoes/fono/fono24.php
https://www.recantodasletras.com.br/gramatica/2687620 
http://acordo-ortografico.blogspot.com/2012/10/em-portugues-atual-domingo-ou-domingo.html
https://www.flip.pt/Duvidas-Linguisticas/Duvida-Linguistica/DID/4800
https://www.normaculta.com.br/maiuscula/