### PR TITLE
[locale] it: Improve relative time

### DIFF
--- a/locale/it.js
+++ b/locale/it.js
@@ -23,16 +23,24 @@
             LLLL : 'dddd D MMMM YYYY HH:mm'
         },
         calendar : {
-            sameDay: '[Oggi alle] LT',
-            nextDay: '[Domani alle] LT',
-            nextWeek: 'dddd [alle] LT',
-            lastDay: '[Ieri alle] LT',
+            sameDay: function () {
+                return '[Oggi a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+            },
+            nextDay: function () {
+                return '[Domani a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+            },
+            nextWeek: function () {
+                return 'dddd [a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+            },
+            lastDay: function () {
+                return '[Ieri a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+            },
             lastWeek: function () {
                 switch (this.day()) {
                     case 0:
-                        return '[la scorsa] dddd [alle] LT';
+                        return '[La scorsa] dddd [a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
                     default:
-                        return '[lo scorso] dddd [alle] LT';
+                        return '[Lo scorso] dddd [a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
                 }
             },
             sameElse: 'L'

--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -2,6 +2,7 @@
 //! locale : Italian [it]
 //! author : Lorenzo : https://github.com/aliem
 //! author: Mattia Larentis: https://github.com/nostalgiaz
+//! author: Marco : https://github.com/Manfre98
 
 import moment from '../moment';
 
@@ -20,16 +21,24 @@ export default moment.defineLocale('it', {
         LLLL : 'dddd D MMMM YYYY HH:mm'
     },
     calendar : {
-        sameDay: '[Oggi alle] LT',
-        nextDay: '[Domani alle] LT',
-        nextWeek: 'dddd [alle] LT',
-        lastDay: '[Ieri alle] LT',
+        sameDay: function () {
+            return '[Oggi a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+        },
+        nextDay: function () {
+            return '[Domani a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+        },
+        nextWeek: function () {
+            return 'dddd [a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+        },
+        lastDay: function () {
+            return '[Ieri a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
+        },
         lastWeek: function () {
             switch (this.day()) {
                 case 0:
-                    return '[la scorsa] dddd [alle] LT';
+                    return '[La scorsa] dddd [a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
                 default:
-                    return '[lo scorso] dddd [alle] LT';
+                    return '[Lo scorso] dddd [a' + ((this.hours() > 1) ? 'lle ' : (this.hours() === 0) ? ' ' : 'll\'') + ']LT';
             }
         },
         sameElse: 'L'

--- a/src/test/locale/it.js
+++ b/src/test/locale/it.js
@@ -150,23 +150,24 @@ test('fromNow', function (assert) {
 test('calendar day', function (assert) {
     var a = moment().hours(12).minutes(0).seconds(0);
 
-    assert.equal(moment(a).calendar(),                   'Oggi alle 12:00',     'today at the same time');
-    assert.equal(moment(a).add({m: 25}).calendar(),      'Oggi alle 12:25',     'Now plus 25 min');
-    assert.equal(moment(a).add({h: 1}).calendar(),       'Oggi alle 13:00',     'Now plus 1 hour');
-    assert.equal(moment(a).add({d: 1}).calendar(),       'Domani alle 12:00',   'tomorrow at the same time');
-    assert.equal(moment(a).subtract({h: 1}).calendar(),  'Oggi alle 11:00',     'Now minus 1 hour');
-    assert.equal(moment(a).subtract({d: 1}).calendar(),  'Ieri alle 12:00',     'yesterday at the same time');
+    assert.equal(moment(a).calendar(),                       'Oggi alle 12:00',     'today at the same time');
+    assert.equal(moment(a).add({m: 25}).calendar(),          'Oggi alle 12:25',     'Now plus 25 min');
+    assert.equal(moment(a).add({h: 1}).calendar(),           'Oggi alle 13:00',     'Now plus 1 hour');
+    assert.equal(moment(a).add({d: 1}).calendar(),           'Domani alle 12:00',   'tomorrow at the same time');
+    assert.equal(moment(a).add({d: 1, h : -1}).calendar(),   'Domani alle 11:00',  'tomorrow minus 1 hour');
+    assert.equal(moment(a).subtract({h: 1}).calendar(),      'Oggi alle 11:00',     'Now minus 1 hour');
+    assert.equal(moment(a).subtract({d: 1}).calendar(),      'Ieri alle 12:00',     'yesterday at the same time');
 });
 
 test('calendar next week', function (assert) {
     var i, m;
     for (i = 2; i < 7; i++) {
         m = moment().add({d: i});
-        assert.equal(m.calendar(),       m.format('dddd [alle] LT'),  'Today + ' + i + ' days current time');
+        assert.equal(m.calendar(),       m.format('dddd [a' + ((m.hours() > 1) ? 'lle ' : (m.hours() === 0) ? ' ' : 'll\'') + ']LT'),  'Today + ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),       m.format('dddd [alle] LT'),  'Today + ' + i + ' days beginning of day');
+        assert.equal(m.calendar(),       m.format('dddd [a' + ((m.hours() > 1) ? 'lle ' : (m.hours() === 0) ? ' ' : 'll\'') + ']LT'),  'Today + ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),       m.format('dddd [alle] LT'),  'Today + ' + i + ' days end of day');
+        assert.equal(m.calendar(),       m.format('dddd [a' + ((m.hours() > 1) ? 'lle ' : (m.hours() === 0) ? ' ' : 'll\'') + ']LT'),  'Today + ' + i + ' days end of day');
     }
 });
 
@@ -176,7 +177,7 @@ test('calendar last week', function (assert) {
         m = moment().subtract({d: i});
         // Different date string
         weekday = parseInt(m.format('d'), 10);
-        datestring = (weekday === 0) ? '[la scorsa] dddd [alle] LT' : '[lo scorso] dddd [alle] LT';
+        datestring = (weekday === 0) ? '[La scorsa] dddd [a' + ((m.hours() > 1) ? 'lle ' : (m.hours() === 0) ? ' ' : 'll\'') + ']LT' : '[Lo scorso] dddd [a' + ((m.hours() > 1) ? 'lle ' : (m.hours() === 0) ? ' ' : 'll\'') + ']LT';
         assert.equal(m.calendar(), m.format(datestring), 'Today - ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
         assert.equal(m.calendar(), m.format(datestring), 'Today - ' + i + ' days beginning of day');


### PR DESCRIPTION
Source (in Italian): http://www.accademiadellacrusca.it/it/lingua-italiana/consulenza-linguistica/domande-risposte/larticolo-date-cifre
Examples:
«Today at 00:30 AM», before changes «Oggi alle 00:30», after changes «Oggi a 00:30».
«Today at 01:30 AM», before changes «Oggi alle 01:30», after changes «Oggi all'01:30».
«Today at 02:30 AM», before changes «Oggi alle 02:30», after changes «Oggi alle 02:30».

The hour that starts with 1 needs to have «all'{time}» instead of «alle {time}», the hour that starts with 0 needs to have «a {time}» instead of «alle {time}», all the other numbers needs to have «alle {time}».