### PR TITLE
[misc] Update DurationInputArg1 types

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -398,7 +398,7 @@ declare namespace moment {
   }
 
   type MomentInput = Moment | Date | string | number | (number | string)[] | MomentInputObject | void; // null | undefined
-  type DurationInputArg1 = Duration | number | string | FromTo | DurationInputObject | void; // null | undefined
+  type DurationInputArg1 = Duration | number | FromTo | DurationInputObject | void; // null | undefined
   type DurationInputArg2 = unitOfTime.DurationConstructor;
   type LocaleSpecifier = string | Moment | Duration | string[] | boolean;
 


### PR DESCRIPTION
Hey guys,
I think that DurationInput1 doesn't works well with string.

As a proof. I tried to run the following two scrits on https://npm.runkit.com/moment

```javascript
var moment = require("moment")

// format the current date
moment.duration("5", "seconds").as("milliseconds")
```

and this

```javascript
var moment = require("moment")

// format the current date
moment.duration(5, "seconds").as("milliseconds")
```

With number we got the correct result. But with string got 0

* Notice that one is `"5"`, and the other is `5`