### PR TITLE
[misc] Update typing for diff function

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -518,6 +518,7 @@ declare namespace moment {
     isoWeekday(d: number|string): Moment;
     weekYear(): number;
     weekYear(d: number): Moment;
+    isoWeekYear(): number;
     isoWeekYear(d: number): Moment;
     week(): number;
     week(d: number): Moment;

--- a/moment.d.ts
+++ b/moment.d.ts
@@ -518,7 +518,6 @@ declare namespace moment {
     isoWeekday(d: number|string): Moment;
     weekYear(): number;
     weekYear(d: number): Moment;
-    isoWeekYear(): number;
     isoWeekYear(d: number): Moment;
     week(): number;
     week(d: number): Moment;
@@ -538,7 +537,7 @@ declare namespace moment {
     fromNow(withoutSuffix?: boolean): string;
     toNow(withoutPrefix?: boolean): string;
 
-    diff(b: MomentInput, unitOfTime?: unitOfTime.Diff, precise?: boolean): number;
+    diff(b: any, unitOfTime?: unitOfTime.Diff, precise?: boolean): number;
 
     toArray(): number[];
     toDate(): Date;


### PR DESCRIPTION
This might be the intended typing, but it's not accurate. No error is thrown by passing anything other than a `MomentInput` and the function still returns a `number` type as `NaN` is categorised as a `number`. Either the implementation needs to change such that this throws without a `MomentInput` or this typing needs to change, as `Nan` is a valid return value.