### PR TITLE
[bugfix] Issue 4323

### DIFF
--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -4,15 +4,15 @@ import isDurationValid from './valid.js';
 
 export function Duration (duration) {
     var normalizedInput = normalizeObjectUnits(duration),
-        years = normalizedInput.year || 0,
-        quarters = normalizedInput.quarter || 0,
-        months = normalizedInput.month || 0,
-        weeks = normalizedInput.week || 0,
-        days = normalizedInput.day || 0,
-        hours = normalizedInput.hour || 0,
-        minutes = normalizedInput.minute || 0,
-        seconds = normalizedInput.second || 0,
-        milliseconds = normalizedInput.millisecond || 0;
+        years = normalizedInput.year || null,
+        quarters = normalizedInput.quarter || null,
+        months = normalizedInput.month || null,
+        weeks = normalizedInput.week || null,
+        days = normalizedInput.day || null,
+        hours = normalizedInput.hour || null,
+        minutes = normalizedInput.minute || null,
+        seconds = normalizedInput.second || null,
+        milliseconds = normalizedInput.millisecond || null;
 
     this._isValid = isDurationValid(normalizedInput);
 

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -7,7 +7,7 @@ var ordering = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'se
 
 export default function isDurationValid(m) {
     for (var key in m) {
-        if (!(indexOf.call(ordering, key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
+        if (!(indexOf.call(ordering, key) !== -1 && !(m[key] == null || isNaN(m[key])))) {
             return false;
         }
     }

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -9,10 +9,10 @@ test('invalid duration', function (assert) {
     assert.ok(isNaN(m.valueOf()));
 });
 
-test('valid duration', function (assert) {
-    var m = moment.duration({d: null}); // should be valid, for now
-    assert.equal(m.isValid(), true);
-    assert.equal(m.valueOf(), 0);
+test('invalid duration - with null value', function (assert) {
+    var m = moment.duration({d: null});
+    assert.equal(m.isValid(), false);
+    assert.ok(isNaN(m.valueOf()));
 });
 
 test('invalid duration - only smallest unit can have decimal', function (assert) {


### PR DESCRIPTION
Fix of Issue 4323.
The main concern that I've considered that duration created with `null` value (e.g. m.duration({d: null}) will make duration invalid - before it was valid).
But it fixes [issue](https://github.com/moment/moment/issues/4323) for now.