### PR TITLE
[bugfix] locale/en-ie.js date format

### DIFF
--- a/locale/en-ie.js
+++ b/locale/en-ie.js
@@ -17,7 +17,7 @@
         longDateFormat : {
             LT : 'HH:mm',
             LTS : 'HH:mm:ss',
-            L : 'DD/MM/YYYY',
+            L : 'DD-MM-YYYY',
             LL : 'D MMMM YYYY',
             LLL : 'D MMMM YYYY HH:mm',
             LLLL : 'dddd D MMMM YYYY HH:mm'

--- a/locale/en-ie.js
+++ b/locale/en-ie.js
@@ -17,7 +17,7 @@
         longDateFormat : {
             LT : 'HH:mm',
             LTS : 'HH:mm:ss',
-            L : 'DD-MM-YYYY',
+            L : 'DD/MM/YYYY',
             LL : 'D MMMM YYYY',
             LLL : 'D MMMM YYYY HH:mm',
             LLLL : 'dddd D MMMM YYYY HH:mm'

--- a/src/locale/en-ie.js
+++ b/src/locale/en-ie.js
@@ -13,7 +13,7 @@ export default moment.defineLocale('en-ie', {
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',
-        L : 'DD-MM-YYYY',
+        L : 'DD/MM/YYYY',
         LL : 'D MMMM YYYY',
         LLL : 'D MMMM YYYY HH:mm',
         LLLL : 'dddd D MMMM YYYY HH:mm'

--- a/src/test/locale/en-ie.js
+++ b/src/test/locale/en-ie.js
@@ -38,11 +38,11 @@ test('format', function (assert) {
             ['a A',                                'pm PM'],
             ['[the] DDDo [day of the year]',       'the 45th day of the year'],
             ['LTS',                                '15:25:50'],
-            ['L',                                  '14-02-2010'],
+            ['L',                                  '14/02/2010'],
             ['LL',                                 '14 February 2010'],
             ['LLL',                                '14 February 2010 15:25'],
             ['LLLL',                               'Sunday 14 February 2010 15:25'],
-            ['l',                                  '14-2-2010'],
+            ['l',                                  '14/2/2010'],
             ['ll',                                 '14 Feb 2010'],
             ['lll',                                '14 Feb 2010 15:25'],
             ['llll',                               'Sun 14 Feb 2010 15:25']


### PR DESCRIPTION
Correct to en-IE date locale to match the ICU definition: http://www.localeplanet.com/icu/en-IE/index.html

ICU defines the en-IE date format to be 06/11/2018 rather than 06-11-2018.

fixes https://github.com/moment/moment/issues/4857