### PR TITLE
[bugfix] double declared property in strict mode

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -90,7 +90,7 @@ function parseIso (inp, sign) {
 }
 
 function positiveMomentsDifference(base, other) {
-    var res = {milliseconds: 0, months: 0};
+    var res = {milliseconds: 0};
 
     res.months = other.month() - base.month() +
         (other.year() - base.year()) * 12;


### PR DESCRIPTION
this change fixes errors in IE 11 that properties are not allowed to be declared multiple times in strict mode