### PR TITLE
[locale] ky: Fix spelling typos

### DIFF
--- a/src/locale/ky.js
+++ b/src/locale/ky.js
@@ -46,8 +46,8 @@ export default moment.defineLocale('ky', {
         sameDay : '[Бүгүн саат] LT',
         nextDay : '[Эртең саат] LT',
         nextWeek : 'dddd [саат] LT',
-        lastDay : '[Кече саат] LT',
-        lastWeek : '[Өткен аптанын] dddd [күнү] [саат] LT',
+        lastDay : '[Кечээ саат] LT',
+        lastWeek : '[Өткөн аптанын] dddd [күнү] [саат] LT',
         sameElse : 'L'
     },
     relativeTime : {

--- a/src/test/locale/ky.js
+++ b/src/test/locale/ky.js
@@ -159,7 +159,7 @@ test('calendar day', function (assert) {
     assert.equal(moment(a).add({h: 1}).calendar(),       'Бүгүн саат 13:00',  'Now plus 1 hour');
     assert.equal(moment(a).add({d: 1}).calendar(),       'Эртең саат 12:00',  'tomorrow at the same time');
     assert.equal(moment(a).subtract({h: 1}).calendar(),  'Бүгүн саат 11:00',  'Now minus 1 hour');
-    assert.equal(moment(a).subtract({d: 1}).calendar(),  'Кече саат 12:00',   'yesterday at the same time');
+    assert.equal(moment(a).subtract({d: 1}).calendar(),  'Кечээ саат 12:00',   'yesterday at the same time');
 });
 
 test('calendar next week', function (assert) {
@@ -179,11 +179,11 @@ test('calendar last week', function (assert) {
 
     for (i = 2; i < 7; i++) {
         m = moment().subtract({d: i});
-        assert.equal(m.calendar(),       m.format('[Өткен аптанын] dddd [күнү] [саат] LT'),  'Today - ' + i + ' days current time');
+        assert.equal(m.calendar(),       m.format('[Өткөн аптанын] dddd [күнү] [саат] LT'),  'Today - ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),       m.format('[Өткен аптанын] dddd [күнү] [саат] LT'),  'Today - ' + i + ' days beginning of day');
+        assert.equal(m.calendar(),       m.format('[Өткөн аптанын] dddd [күнү] [саат] LT'),  'Today - ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),       m.format('[Өткен аптанын] dddd [күнү] [саат] LT'),  'Today - ' + i + ' days end of day');
+        assert.equal(m.calendar(),       m.format('[Өткөн аптанын] dddd [күнү] [саат] LT'),  'Today - ' + i + ' days end of day');
     }
 });
 


### PR DESCRIPTION
@ichernev @marwahaha 

Fixed small spelling errors in Kyrgyz locale.

[This](https://translate.google.com/#view=home&op=translate&sl=en&tl=ky&text=Yesterday%20morning) and [this](https://translate.google.com/#view=home&op=translate&sl=en&tl=ky&text=Last%20month) are the references from Google Translate for proof :)