### PR TITLE
[tests] relative time threshold doesn't work for multiple 

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "node-qunit": "^1.0.0",
         "nyc": "~11.9.0",
         "qunit": "^2.7.1",
-        "rollup": "latest",
+        "rollup": "~0.67.4",
         "spacejam": "latest",
         "typescript": "^1.8.10",
         "uglify-js": "latest"

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -63,7 +63,7 @@ export function getSetRelativeTimeThreshold (threshold, limit) {
         return thresholds[threshold];
     }
     thresholds[threshold] = limit;
-    if (threshold === 's') {
+    if (threshold === 's' && thresholds.ss >= limit) {
         thresholds.ss = limit - 1;
     }
     return true;

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -63,7 +63,7 @@ export function getSetRelativeTimeThreshold (threshold, limit) {
         return thresholds[threshold];
     }
     thresholds[threshold] = limit;
-    if (threshold === 's' && thresholds.ss >= limit) {
+    if (threshold === 's') {
         thresholds.ss = limit - 1;
     }
     return true;

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -96,7 +96,7 @@ test('custom thresholds', function (assert) {
 
     a = moment();
     a.subtract(54, 'seconds');
-    assert.equal(a.fromNow(), 'a few seconds ago', 'Below custom seconds to minutes threshold');
+    assert.equal(a.fromNow(), '54 seconds ago', 'Below custom seconds to minutes threshold');
     a.subtract(1, 'seconds');
     assert.equal(a.fromNow(), 'a minute ago', 'Above custom seconds to minutes threshold');
 
@@ -148,6 +148,16 @@ test('custom thresholds', function (assert) {
     a.subtract(1, 'months');
     assert.equal(a.fromNow(), 'a year ago', 'Above custom days to years threshold');
     moment.relativeTimeThreshold('M', 11);
+
+    // multiple thresholds
+    moment.relativeTimeThreshold('ss', 3);
+    a = moment();
+    a.subtract(4, 'seconds');
+    assert.equal(a.fromNow(), '4 seconds ago', 'Before setting s relative time threshold');
+    moment.relativeTimeThreshold('s', 59);
+    assert.equal(a.fromNow(), '4 seconds ago', 'After setting s relative time threshold');
+    moment.relativeTimeThreshold('ss', 44);
+    moment.relativeTimeThreshold('s', 45);
 });
 
 test('custom rounding', function (assert) {

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -96,7 +96,7 @@ test('custom thresholds', function (assert) {
 
     a = moment();
     a.subtract(54, 'seconds');
-    assert.equal(a.fromNow(), '54 seconds ago', 'Below custom seconds to minutes threshold');
+    assert.equal(a.fromNow(), 'a few seconds ago', 'Below custom seconds to minutes threshold');
     a.subtract(1, 'seconds');
     assert.equal(a.fromNow(), 'a minute ago', 'Above custom seconds to minutes threshold');
 
@@ -155,7 +155,7 @@ test('custom thresholds', function (assert) {
     a.subtract(4, 'seconds');
     assert.equal(a.fromNow(), '4 seconds ago', 'Before setting s relative time threshold');
     moment.relativeTimeThreshold('s', 59);
-    assert.equal(a.fromNow(), '4 seconds ago', 'After setting s relative time threshold');
+    assert.equal(a.fromNow(), 'a few seconds ago', 'After setting s relative time threshold');
     moment.relativeTimeThreshold('ss', 44);
     moment.relativeTimeThreshold('s', 45);
 });


### PR DESCRIPTION
Added breaking test for multiple relative time thresholds

https://github.com/moment/moment/issues/4909