### PR TITLE
[locale] Fix inconsistent output on new year

### DIFF
--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -37,7 +37,7 @@ export default moment.defineLocale('ja', {
         sameDay : '[今日] LT',
         nextDay : '[明日] LT',
         nextWeek : function (now) {
-            if (now.week() < this.week()) {
+            if (this.week() !== now.week()) {
                 return '[来週]dddd LT';
             } else {
                 return 'dddd LT';
@@ -45,7 +45,7 @@ export default moment.defineLocale('ja', {
         },
         lastDay : '[昨日] LT',
         lastWeek : function (now) {
-            if (this.week() < now.week()) {
+            if (this.week() !== now.week()) {
                 return '[先週]dddd LT';
             } else {
                 return 'dddd LT';

--- a/src/test/locale/ja.js
+++ b/src/test/locale/ja.js
@@ -194,8 +194,8 @@ test('parse with japanese parentheses', function (assert) {
 });
 
 test('calendar return on year overlap', function (assert) {
-    assert.equal(moment('2018-01-06').locale('ja').calendar(moment('2018-01-09')), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日');
-    assert.equal(moment('2017-12-31').locale('ja').calendar(moment('2018-01-03')), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日 even on year overlap');
-    assert.equal(moment('2018-01-09').locale('ja').calendar(moment('2018-01-06')), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日');
-    assert.equal(moment('2018-01-03').locale('ja').calendar(moment('2017-12-31')), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日 even on year overlap');
+    assert.equal(moment([2018,  0,  6]).calendar(moment([2018,  0,  9])), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日');
+    assert.equal(moment([2017, 11, 31]).calendar(moment([2018,  0,  3])), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日 even on year overlap');
+    assert.equal(moment([2018,  0,  9]).calendar(moment([2018,  0,  6])), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日');
+    assert.equal(moment([2018,  0,  3]).calendar(moment([2017, 11, 31])), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日 even on year overlap');
 });

--- a/src/test/locale/ja.js
+++ b/src/test/locale/ja.js
@@ -195,7 +195,7 @@ test('parse with japanese parentheses', function (assert) {
 
 test('calendar return on year overlap', function (assert) {
     assert.equal(moment([2018,  0,  6]).calendar(moment([2018,  0,  9])), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日');
-    assert.equal(moment([2017, 11, 31]).calendar(moment([2018,  0,  3])), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日 even on year overlap');
+    assert.equal(moment([2017, 11, 30]).calendar(moment([2018,  0,  2])), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日 even on year overlap');
     assert.equal(moment([2018,  0,  9]).calendar(moment([2018,  0,  6])), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日');
-    assert.equal(moment([2018,  0,  3]).calendar(moment([2017, 11, 31])), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日 even on year overlap');
+    assert.equal(moment([2018,  0,  2]).calendar(moment([2017, 11, 30])), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日 even on year overlap');
 });

--- a/src/test/locale/ja.js
+++ b/src/test/locale/ja.js
@@ -192,3 +192,10 @@ test('weeks year starting sunday format', function (assert) {
 test('parse with japanese parentheses', function (assert) {
     assert.ok(moment('2016年5月18日（水）', 'YYYY年M月D日（dd）', true).isValid(), 'parse with japanese parentheses');
 });
+
+test('calendar return on year overlap', function (assert) {
+    assert.equal(moment('2018-01-06').locale('ja').calendar(moment('2018-01-09')), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日');
+    assert.equal(moment('2017-12-31').locale('ja').calendar(moment('2018-01-03')), '先週土曜日 00:00', 'calendar() with next week should be 先週土曜日 even on year overlap');
+    assert.equal(moment('2018-01-09').locale('ja').calendar(moment('2018-01-06')), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日');
+    assert.equal(moment('2018-01-03').locale('ja').calendar(moment('2017-12-31')), '来週火曜日 00:00', 'calendar() with previous week should be 来週火曜日 even on year overlap');
+});


### PR DESCRIPTION
Comparing last week of year N and first week of year N+1 produced wrong result.

Fix #4719