### PR TITLE
[misc] Remove unused variable defaults

### DIFF
--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -90,7 +90,7 @@ function parseIso (inp, sign) {
 }
 
 function positiveMomentsDifference(base, other) {
-    var res = {milliseconds: 0, months: 0};
+    var res = {};
 
     res.months = other.month() - base.month() +
         (other.year() - base.year()) * 12;


### PR DESCRIPTION
The default values of the initialized fields are overwritten in the following lines. This means that the code never relies on the variable defaults.
Removing the unused defaults makes the code easier to read.