### PR TITLE
[bugfix] Fix #4962 updateLocale with null to reset

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -160,6 +160,9 @@ export function updateLocale(name, config) {
         if (locales[name] != null) {
             if (locales[name].parentLocale != null) {
                 locales[name] = locales[name].parentLocale;
+                if (name === getSetGlobalLocale()) {
+                    getSetGlobalLocale(name);
+                }
             } else if (locales[name] != null) {
                 delete locales[name];
             }

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -172,3 +172,13 @@ test('update existing locale', function (assert) {
     assert.equal(moment('2017-02-01').format('YYYY MMM MMMM'), '2017 FEB Februar');
     moment.updateLocale('de', null);
 });
+
+test('reset locale', function (assert) {
+    moment.locale('de');
+    var resultBeforeUpdate = moment('2017-02-01').format('YYYY MMM MMMM');
+    moment.updateLocale('de', {
+        monthsShort: ['JAN', 'FEB', 'MÄR', 'APR', 'MAI', 'JUN', 'JUL', 'AUG', 'SEP', 'OKT', 'NOV', 'DEZ']
+    });
+    moment.updateLocale('de', null);
+    assert.equal(moment('2017-02-01').format('YYYY MMM MMMM'), resultBeforeUpdate);
+});


### PR DESCRIPTION
`updateLocale(abbr, null)` correctly resets a locale to its previous definition; but didn't check if it needed to reset the 'current' locale'.

This PR fixes that so that resetting the current locale takes immediate effect, without having to manually called `moment.locale(moment.locale())`

Fixes #4962 
