### PR TITLE
[locale] mr (Marathi)

### DIFF
--- a/src/locale/mr.js
+++ b/src/locale/mr.js
@@ -117,25 +117,21 @@ export default moment.defineLocale('mr', {
             return symbolMap[match];
         });
     },
-    meridiemParse: /रात्री|सकाळी|दुपारी|सायंकाळी/,
-    meridiemHour : function (hour, meridiem) {
+    meridiemParse: /पहाटे|सकाळी|दुपारी|सायंकाळी|रात्री/,
+    meridiemHour: function (hour, meridiem) {
         if (hour === 12) {
             hour = 0;
         }
-        if (meridiem === 'रात्री') {
-            return hour < 4 ? hour : hour + 12;
-        } else if (meridiem === 'सकाळी') {
+        if (meridiem === 'पहाटे' || meridiem === 'सकाळी') {
             return hour;
-        } else if (meridiem === 'दुपारी') {
-            return hour >= 10 ? hour : hour + 12;
-        } else if (meridiem === 'सायंकाळी') {
-            return hour + 12;
+        } else if (meridiem === 'दुपारी' || meridiem === 'सायंकाळी' || meridiem === 'रात्री') {
+            return hour >= 12 ? hour : hour + 12;
         }
     },
     meridiem: function (hour, minute, isLower) {
-        if (hour < 4) {
-            return 'रात्री';
-        } else if (hour < 10) {
+        if (hour >= 0 && hour < 6) {
+            return 'पहाटे';
+        } else if (hour < 12) {
             return 'सकाळी';
         } else if (hour < 17) {
             return 'दुपारी';
@@ -150,4 +146,3 @@ export default moment.defineLocale('mr', {
         doy : 6  // The week that contains Jan 6th is the first week of the year.
     }
 });
-

--- a/src/test/locale/mr.js
+++ b/src/test/locale/mr.js
@@ -157,7 +157,7 @@ test('calendar day', function (assert) {
     assert.equal(moment(a).add({m: 25}).calendar(),      'आज दुपारी १२:२५ वाजता',    'Now plus 25 min');
     assert.equal(moment(a).add({h: 3}).calendar(),       'आज दुपारी ३:०० वाजता',     'Now plus 3 hours');
     assert.equal(moment(a).add({d: 1}).calendar(),       'उद्या दुपारी १२:०० वाजता', 'tomorrow at the same time');
-    assert.equal(moment(a).subtract({h: 1}).calendar(),  'आज दुपारी ११:०० वाजता',    'Now minus 1 hour');
+    assert.equal(moment(a).subtract({h: 1}).calendar(),  'आज सकाळी ११:०० वाजता',    'Now minus 1 hour');
     assert.equal(moment(a).subtract({d: 1}).calendar(),  'काल दुपारी १२:०० वाजता',   'yesterday at the same time');
 });
 
@@ -201,14 +201,14 @@ test('calendar all else', function (assert) {
 });
 
 test('meridiem', function (assert) {
-    assert.equal(moment([2011, 2, 23,  2, 30]).format('a'), 'रात्री', 'before dawn');
+    assert.equal(moment([2011, 2, 23,  2, 30]).format('a'), 'पहाटे', 'before dawn');
     assert.equal(moment([2011, 2, 23,  9, 30]).format('a'), 'सकाळी', 'morning');
     assert.equal(moment([2011, 2, 23, 14, 30]).format('a'), 'दुपारी', 'during day');
     assert.equal(moment([2011, 2, 23, 17, 30]).format('a'), 'सायंकाळी', 'evening');
     assert.equal(moment([2011, 2, 23, 19, 30]).format('a'), 'सायंकाळी', 'late evening');
     assert.equal(moment([2011, 2, 23, 21, 20]).format('a'), 'रात्री', 'night');
 
-    assert.equal(moment([2011, 2, 23,  2, 30]).format('A'), 'रात्री', 'before dawn');
+    assert.equal(moment([2011, 2, 23,  2, 30]).format('A'), 'पहाटे', 'before dawn');
     assert.equal(moment([2011, 2, 23,  9, 30]).format('A'), 'सकाळी', 'morning');
     assert.equal(moment([2011, 2, 23, 14, 30]).format('A'), 'दुपारी', ' during day');
     assert.equal(moment([2011, 2, 23, 17, 30]).format('A'), 'सायंकाळी', 'evening');


### PR DESCRIPTION
We Marathi people follow standards mentioned below, to label timespans.

Label | Time Span 
------------ | -------------
पहाटे (post midnight, pre-sunrise) |    >= 12am to < 6am 
सकाळी (post sunrise, pre-noon) |    >= 6am to < 12pm
दुपारी (afternoon) |    >= 12pm to < 5pm
सायंकाळी (evening) |    >= 5pm to < 8pm
रात्री (night) |    >= 8pm to < 12am

Actually, 12am is confusing in Marathi tradition. In modern clock system, Moment 12am is considered in arriving date as 0am. And in Marathi tradition it is referred to as final moment of the previous date (Sort of, 0:01 is starting minute of the arriving date) . To comply with modern clock system, I propose to refer to 0am as पहाटे , so that it is considered as moment in the arriving date. Hope this discription itself is not confusing :)

Another point is about range of पहाटे, ie. >= 0am to < 6am. Though conventionally, upto 2 am, we refer to the time as रात्री or पहाटे, both alternatively, I want to specifically call पहाटे for early times in the arriving date and रात्री for late times in the departing date, to make it more specific and well-defined, avoiding confusion about date of the time.