### PR TITLE
[locale] Tweak bg translation for last week

### DIFF
--- a/locale/bg.js
+++ b/locale/bg.js
@@ -32,12 +32,12 @@
                     case 0:
                     case 3:
                     case 6:
-                        return '[Миналата] dddd [в] LT';
+                        return '[В изминалата] dddd [в] LT';
                     case 1:
                     case 2:
                     case 4:
                     case 5:
-                        return '[Миналия] dddd [в] LT';
+                        return '[В изминалия] dddd [в] LT';
                 }
             },
             sameElse : 'L'

--- a/locale/bg.js
+++ b/locale/bg.js
@@ -32,12 +32,12 @@
                     case 0:
                     case 3:
                     case 6:
-                        return '[В изминалата] dddd [в] LT';
+                        return '[Миналата] dddd [в] LT';
                     case 1:
                     case 2:
                     case 4:
                     case 5:
-                        return '[В изминалия] dddd [в] LT';
+                        return '[Миналия] dddd [в] LT';
                 }
             },
             sameElse : 'L'

--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -28,12 +28,12 @@ export default moment.defineLocale('bg', {
                 case 0:
                 case 3:
                 case 6:
-                    return '[В изминалата] dddd [в] LT';
+                    return '[Миналата] dddd [в] LT';
                 case 1:
                 case 2:
                 case 4:
                 case 5:
-                    return '[В изминалия] dddd [в] LT';
+                    return '[Миналия] dddd [в] LT';
             }
         },
         sameElse : 'L'
@@ -79,4 +79,3 @@ export default moment.defineLocale('bg', {
         doy : 7  // The week that contains Jan 7th is the first week of the year.
     }
 });
-

--- a/src/test/locale/bg.js
+++ b/src/test/locale/bg.js
@@ -183,12 +183,12 @@ test('calendar last week', function (assert) {
             case 0:
             case 3:
             case 6:
-                return '[В изминалата] dddd [в] LT';
+                return '[Миналата] dddd [в] LT';
             case 1:
             case 2:
             case 4:
             case 5:
-                return '[В изминалия] dddd [в] LT';
+                return '[Миналия] dddd [в] LT';
         }
     }
 
@@ -223,4 +223,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012,  0,  8]).format('w ww wo'), '2 02 2-ри', 'Jan  8 2012 should be week 2');
     assert.equal(moment([2012,  0,  9]).format('w ww wo'), '3 03 3-ти', 'Jan  9 2012 should be week 3');
 });
-


### PR DESCRIPTION
The current translation adds a very specific and mostly unnecessary 'at' in the beginning. It just looks/sounds wrong. Maybe there are cases when this might be correct but surely not most of the time. [insert 'change my mind' meme]