### PR TITLE
[locale] (en-sg) Rename locale en-SG to en-sg

### DIFF
--- a/src/locale/en-sg.js
+++ b/src/locale/en-sg.js
@@ -1,10 +1,10 @@
 //! moment.js locale configuration
-//! locale : English (Singapore) [en-SG]
+//! locale : English (Singapore) [en-sg]
 //! author : Matthew Castrillon-Madrigal : https://github.com/techdimension
 
 import moment from '../moment';
 
-export default moment.defineLocale('en-SG', {
+export default moment.defineLocale('en-sg', {
     months : 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_'),
     monthsShort : 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
     weekdays : 'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),

--- a/src/test/locale/en-sg.js
+++ b/src/test/locale/en-sg.js
@@ -1,7 +1,7 @@
 import {test} from '../qunit';
 import {localeModule} from '../qunit-locale';
 import moment from '../../moment';
-localeModule('en-SG');
+localeModule('en-sg');
 
 test('parse', function (assert) {
     var tests = 'January Jan_February Feb_March Mar_April Apr_May May_June Jun_July Jul_August Aug_September Sep_October Oct_November Nov_December Dec'.split('_'), i;


### PR DESCRIPTION
@TechDimension added the locale `en-SG` (#4951). However, it uses a different capitalization from all other locales.

This PR simply renames `en-SG` to `en-sg`. It does not change the actual locale content.

See #5024 