### PR TITLE
[locale] lastWeek Romanian translation

### DIFF
--- a/locale/ro.js
+++ b/locale/ro.js
@@ -44,7 +44,7 @@
             nextDay: '[mâine la] LT',
             nextWeek: 'dddd [la] LT',
             lastDay: '[ieri la] LT',
-            lastWeek: '[fosta] dddd [la] LT',
+            lastWeek: '[săptămăna trecută] dddd [la] LT',
             sameElse: 'L'
         },
         relativeTime : {


### PR DESCRIPTION
More accurate way of saying last week.
Source: romanian friend