### PR TITLE
[locale] lastWeek romanian change

### DIFF
--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('ro', {
         nextDay: '[mâine la] LT',
         nextWeek: 'dddd [la] LT',
         lastDay: '[ieri la] LT',
-        lastWeek: '[fosta] dddd [la] LT',
+        lastWeek: '[săptămâna trecută] dddd [la] LT',
         sameElse: 'L'
     },
     relativeTime : {


### PR DESCRIPTION
More accurate way of saying last week in Romanian.
Source: romanian friend