### PR TITLE
[bugfix] Invalid parse against array still picks best format. (#4435)

### DIFF
--- a/src/lib/create/from-string-and-array.js
+++ b/src/lib/create/from-string-and-array.js
@@ -11,7 +11,9 @@ export function configFromStringAndArray(config) {
 
         scoreToBeat,
         i,
-        currentScore;
+        currentScore,
+        validFormatFound,
+        bestFormatIsValid = false;
 
     if (config._f.length === 0) {
         getParsingFlags(config).invalidFormat = true;
@@ -21,6 +23,7 @@ export function configFromStringAndArray(config) {
 
     for (i = 0; i < config._f.length; i++) {
         currentScore = 0;
+        validFormatFound = false;
         tempConfig = copyConfig({}, config);
         if (config._useUTC != null) {
             tempConfig._useUTC = config._useUTC;
@@ -28,8 +31,8 @@ export function configFromStringAndArray(config) {
         tempConfig._f = config._f[i];
         configFromStringAndFormat(tempConfig);
 
-        if (!isValid(tempConfig)) {
-            continue;
+        if (isValid(tempConfig)) {
+            validFormatFound = true;
         }
 
         // if there is any input that was not parsed add a penalty for that format
@@ -40,9 +43,19 @@ export function configFromStringAndArray(config) {
 
         getParsingFlags(tempConfig).score = currentScore;
 
-        if (scoreToBeat == null || currentScore < scoreToBeat) {
-            scoreToBeat = currentScore;
-            bestMoment = tempConfig;
+        if (!bestFormatIsValid) {
+            if (scoreToBeat == null || currentScore < scoreToBeat || validFormatFound) {
+                scoreToBeat = currentScore;
+                bestMoment = tempConfig;
+                if (validFormatFound) {
+                    bestFormatIsValid = true;
+                }
+            }
+        } else {
+            if (currentScore < scoreToBeat) {
+                scoreToBeat = currentScore;
+                bestMoment = tempConfig;
+            }
         }
     }
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -422,6 +422,11 @@ test('string with array of formats + ISO', function (assert) {
     assert.equal(moment('2014-05-05', ['YYYY-MM-DD', moment.ISO_8601]).parsingFlags().iso, false, 'iso: edge case array precedence not iso');
 });
 
+test('strict parsing invalid date against array of formats', function (assert) {
+    var b = moment('2/30/2019 7:00pm', ['M/DD/YYYY h:mma", "MM/DD/YYYY h:mma", "M-D-YYYY h:mma", "MM-D-YYYY h:mma'], true);
+    assert.deepEqual(b.parsingFlags().parsedDateParts, [2019,1,30,7,0], 'strict parsing multiple formats should still select the best format even if the date is invalid');
+});
+
 test('string with format - years', function (assert) {
     assert.equal(moment('67', 'YY').format('YYYY'), '2067', '67 > 2067');
     assert.equal(moment('68', 'YY').format('YYYY'), '2068', '68 > 2068');


### PR DESCRIPTION
Fixes issue in open issue 4435. Test case is based on the example provided there.

https://github.com/moment/moment/issues/4435