### PR TITLE
[locale] Update pt-br.js

### DIFF
--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -1,15 +1,15 @@
 //! moment.js locale configuration
 //! locale : Portuguese (Brazil) [pt-br]
-//! author : Caio Ribeiro Pereira : https://github.com/caio-ribeiro-pereira
+//! author : Diego Ramos : https://github.com/DaDodger
 
 import moment from '../moment';
 
 export default moment.defineLocale('pt-br', {
-    months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-    monthsShort : 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
-    weekdays : 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
-    weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
-    weekdaysMin : 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),
+    months : 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
+    monthsShort : 'jan_fev_mar_abr_maio_jun_jul_ago_set_out_nov_dez'.split('_'),
+    weekdays : 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
+    weekdaysShort : 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
+    weekdaysMin : 'do_2ª_3ª_4ª_5ª_6ª_sá'.split('_'),
     weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',
@@ -50,4 +50,3 @@ export default moment.defineLocale('pt-br', {
     dayOfMonthOrdinalParse: /\d{1,2}º/,
     ordinal : '%dº'
 });
-


### PR DESCRIPTION
I reverted the capitalisation thing for pt-br since Brazilian Portuguese mostly does not capitalise like English, you should know that. In my mind there's no need to keep months and days uppercased because it's not much of a technical context that demands any additional stylistic feature, especially one inherited from the source language.