### PR TITLE
[bugfix] Inconsistent moment(object) behaviour when using day: 0 (#5097) 

### DIFF
--- a/src/lib/create/from-object.js
+++ b/src/lib/create/from-object.js
@@ -8,7 +8,9 @@ export function configFromObject(config) {
     }
 
     var i = normalizeObjectUnits(config._i);
-    config._a = map([i.year, i.month, i.day || i.date, i.hour, i.minute, i.second, i.millisecond], function (obj) {
+
+    var dayOrDate = i.day === undefined ? i.date : i.day;
+    config._a = map([i.year, i.month, dayOrDate, i.hour, i.minute, i.second, i.millisecond], function (obj) {
         return obj && parseInt(obj, 10);
     });
 

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -47,6 +47,13 @@ test('object', function (assert) {
     }
 });
 
+test('invalid date for object with zero value date or day keys', function (assert) {
+    assert.equal(moment({date: '0'}).format(), 'Invalid date');
+    assert.equal(moment({date: 0}).format(), 'Invalid date');
+    assert.equal(moment({day: '0'}).format(), 'Invalid date');
+    assert.equal(moment({day: 0}).format(), 'Invalid date');
+});
+
 test('multi format array copying', function (assert) {
     var importantArray = ['MM/DD/YYYY', 'YYYY-MM-DD', 'MM-DD-YYYY'];
     moment('1999-02-13', importantArray);


### PR DESCRIPTION
As explained in issue #5097  this fixes a bug where `moment({day: 0})` was acting differently from `day: '0'`, `date: 0` or `date: '0'`. This is ultimately due to the use of `i.day || i.date`. When `i.day` is 0, it is still falsey so it returns `i.date` which is undefined. 

This PR makes the behaviour consistent by explicitly checking whether the key is undefined rather than just falsey. 