### PR TITLE
[locale] sl: Fix date format

### DIFF
--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -97,7 +97,7 @@ export default moment.defineLocale('sl', {
     longDateFormat : {
         LT : 'H:mm',
         LTS : 'H:mm:ss',
-        L : 'DD.MM.YYYY',
+        L : 'DD. MM. YYYY',
         LL : 'D. MMMM YYYY',
         LLL : 'D. MMMM YYYY H:mm',
         LLLL : 'dddd, D. MMMM YYYY H:mm'


### PR DESCRIPTION
[locale] corrected to official Slovenian date format for short dates