### PR TITLE
[feature] jsnext:main => module

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "ender"
     ],
     "main": "./moment.js",
-    "jsnext:main": "./src/moment.js",
+    "module": "./src/moment.js",
     "typings": "./moment.d.ts",
     "engines": {
         "node": "*"


### PR DESCRIPTION
`jsnext:main` is deprecated in favor of `module`. This change is [backed by webpack authors](https://twitter.com/TheLarkInn/status/1138558140272668672)