### PR TITLE
[feature] Allow sameYear key to be used for calendar function.

### DIFF
--- a/src/lib/moment/calendar.js
+++ b/src/lib/moment/calendar.js
@@ -10,7 +10,8 @@ export function getCalendarFormat(myMoment, now) {
             diff < 0 ? 'lastDay' :
             diff < 1 ? 'sameDay' :
             diff < 2 ? 'nextDay' :
-            diff < 7 ? 'nextWeek' : 'sameElse';
+            diff < 7 ? 'nextWeek' : 
+            myMoment.format('YYYY') === now.format('YYYY') ? 'sameYear' : 'sameElse';
 }
 
 export function calendar (time, formats) {

--- a/src/lib/moment/calendar.js
+++ b/src/lib/moment/calendar.js
@@ -5,13 +5,14 @@ import { hooks } from '../utils/hooks';
 
 export function getCalendarFormat(myMoment, now) {
     var diff = myMoment.diff(now, 'days', true);
+    const sameYear = myMoment.format('YYYY') === now.format('YYYY');
     return diff < -6 ? 'sameElse' :
             diff < -1 ? 'lastWeek' :
             diff < 0 ? 'lastDay' :
             diff < 1 ? 'sameDay' :
             diff < 2 ? 'nextDay' :
-            diff < 7 ? 'nextWeek' : 
-            myMoment.format('YYYY') === now.format('YYYY') ? 'sameYear' : 'sameElse';
+            diff < 7 ? 'nextWeek' :
+            sameYear ? 'sameYear' : 'sameElse';
 }
 
 export function calendar (time, formats) {


### PR DESCRIPTION
The conditional logic was put in the ternary
so that it would not slowdown the performance of the 'days' diff conditions.

An example where this is helpful:
```javascript
    return moment(normalizeTimestamp(timestamp)).calendar(null, {
      sameDay: '[Today]',
      nextDay: '[Tomorrow]',
      nextWeek: 'dddd',
      lastDay: '[Yesterday]',
      lastWeek: '[Last] dddd',
      sameElse: 'MM/DD/YYYY'
    });
```

If a meeting is scheduled for a month in the future but still within the same year.
A more appealing format would be 'MM/DD'

Currently I check the year formatting outside of the calendar function to change the format accordingly.
However, I thought that this change would be helpful for others.

Happy to update the documentation for calendar to accommodate the change.

Result after the change
```javascript
    return moment(normalizeTimestamp(timestamp)).calendar(null, {
      sameDay: '[Today]',
      nextDay: '[Tomorrow]',
      nextWeek: 'dddd',
      lastDay: '[Yesterday]',
      lastWeek: '[Last] dddd',
	  sameYear: 'MM/DD',
      sameElse: 'MM/DD/YYYY'
    });
```