### PR TITLE
[misc] introduce typescript typesversions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -194,9 +194,10 @@ module.exports = function (grunt) {
     grunt.registerTask('lint', ['jshint', 'jscs']);
 
     // test tasks
-    grunt.registerTask('test', ['test:node', 'test:typescript']);
+    grunt.registerTask('test', ['test:node', 'test:typescript', 'test:typescript-3.1']);
     grunt.registerTask('test:node', ['transpile', 'qtest']);
     grunt.registerTask('test:typescript', ['exec:typescript-test']);
+    grunt.registerTask('test:typescript-3.1', ['exec:ts3.1-typescript-test']);
     // TODO: For some weird reason karma doesn't like the files in
     // build/umd/min/* but works with min/*, so update-index, then git checkout
     grunt.registerTask('test:server', ['transpile', 'update-index', 'karma:server']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -172,6 +172,9 @@ module.exports = function (grunt) {
             'typescript-test': {
                 command: 'npm run typescript-test'
             },
+            'ts3.1-typescript-test': {
+                command: 'npm run ts3.1-typescript-test'
+            },
             'coveralls': {
                 command: 'npm run coveralls'
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,13 +29,30 @@
             "dev": true
         },
         "accepts": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.18",
-                "negotiator": "0.6.1"
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.40.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+                    "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.24",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+                    "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.40.0"
+                    }
+                }
             }
         },
         "adm-zip": {
@@ -76,6 +93,7 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -226,9 +244,9 @@
             "dev": true
         },
         "async-each": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true
         },
         "async-limiter": {
@@ -386,9 +404,9 @@
             }
         },
         "binary-extensions": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-            "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
         },
         "blob": {
@@ -398,9 +416,9 @@
             "dev": true
         },
         "bluebird": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
             "dev": true
         },
         "body": {
@@ -416,27 +434,27 @@
             }
         },
         "body-parser": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
             "dev": true,
             "requires": {
-                "bytes": "3.0.0",
+                "bytes": "3.1.0",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
                 "depd": "~1.1.2",
-                "http-errors": "~1.6.3",
-                "iconv-lite": "0.4.23",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
                 "on-finished": "~2.3.0",
-                "qs": "6.5.2",
-                "raw-body": "2.3.3",
-                "type-is": "~1.6.16"
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "~1.6.17"
             },
             "dependencies": {
                 "bytes": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-                    "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
                     "dev": true
                 },
                 "debug": {
@@ -449,9 +467,9 @@
                     }
                 },
                 "iconv-lite": {
-                    "version": "0.4.23",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "dev": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
@@ -463,15 +481,21 @@
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                },
                 "raw-body": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-                    "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+                    "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
                     "dev": true,
                     "requires": {
-                        "bytes": "3.0.0",
-                        "http-errors": "1.6.3",
-                        "iconv-lite": "0.4.23",
+                        "bytes": "3.1.0",
+                        "http-errors": "1.7.2",
+                        "iconv-lite": "0.4.24",
                         "unpipe": "1.0.0"
                     }
                 }
@@ -632,42 +656,41 @@
             }
         },
         "chokidar": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-            "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+            "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
             "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
-                "async-each": "^1.0.0",
-                "braces": "^2.3.0",
-                "fsevents": "^1.2.2",
+                "async-each": "^1.0.1",
+                "braces": "^2.3.2",
+                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
-                "inherits": "^2.0.1",
+                "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
                 "is-glob": "^4.0.0",
-                "lodash.debounce": "^4.0.8",
-                "normalize-path": "^2.1.1",
+                "normalize-path": "^3.0.0",
                 "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0",
-                "upath": "^1.0.5"
+                "readdirp": "^2.2.1",
+                "upath": "^1.1.1"
             },
             "dependencies": {
                 "is-glob": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-                    "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
                     "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
                     }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
                 }
             }
-        },
-        "circular-json": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-            "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
-            "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
@@ -703,9 +726,9 @@
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "version": "7.1.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -808,15 +831,6 @@
             "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
             "dev": true
         },
-        "combine-lists": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
-            "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.5.0"
-            }
-        },
         "combined-stream": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
@@ -827,9 +841,9 @@
             }
         },
         "commander": {
-            "version": "2.17.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
             "dev": true
         },
         "comment-parser": {
@@ -942,14 +956,14 @@
             }
         },
         "connect": {
-            "version": "3.6.6",
-            "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
-            "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+            "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "finalhandler": "1.1.0",
-                "parseurl": "~1.3.2",
+                "finalhandler": "1.1.2",
+                "parseurl": "~1.3.3",
                 "utils-merge": "1.0.1"
             },
             "dependencies": {
@@ -1112,9 +1126,9 @@
             }
         },
         "date-format": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
-            "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
+            "integrity": "sha512-M6UqVvZVgFYqZL1SfHsRGIQSz3ZL+qgbsV5Lp1Vj61LZVYuEwcMXYay7DRDtYs2HQQBK5hQtQ0fD9aEJ89V0LA==",
             "dev": true
         },
         "date-now": {
@@ -1457,9 +1471,9 @@
             }
         },
         "es6-promise": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-            "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
             "dev": true
         },
         "es6-promisify": {
@@ -1509,9 +1523,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-            "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
             "dev": true
         },
         "exec-sh": {
@@ -1546,40 +1560,6 @@
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
             "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
             "dev": true
-        },
-        "expand-braces": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
-            "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
-            "dev": true,
-            "requires": {
-                "array-slice": "^0.2.3",
-                "array-unique": "^0.2.1",
-                "braces": "^0.1.2"
-            },
-            "dependencies": {
-                "array-slice": {
-                    "version": "0.2.3",
-                    "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-                    "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-                    "dev": true
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
-                    "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^0.1.0"
-                    }
-                }
-            }
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -1627,30 +1607,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
-            }
-        },
-        "expand-range": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
-            "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-            "dev": true,
-            "requires": {
-                "is-number": "^0.1.1",
-                "repeat-string": "^0.2.2"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "0.1.1",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
-                    "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
-                    "dev": true
-                },
-                "repeat-string": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
-                    "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
                     "dev": true
                 }
             }
@@ -1889,17 +1845,17 @@
             }
         },
         "finalhandler": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-            "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.1",
+                "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.3.1",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
                 "unpipe": "~1.0.0"
             },
             "dependencies": {
@@ -1916,12 +1872,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                },
-                "statuses": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-                    "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
                     "dev": true
                 }
             }
@@ -2000,29 +1950,12 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-            "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+            "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
             "dev": true,
             "requires": {
-                "debug": "=3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
+                "debug": "^3.2.6"
             }
         },
         "for-in": {
@@ -2101,14 +2034,14 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-            "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -2120,7 +2053,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2141,12 +2075,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2161,17 +2097,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2180,12 +2119,12 @@
                     "optional": true
                 },
                 "debug": {
-                    "version": "2.6.9",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "deep-extend": {
@@ -2288,7 +2227,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2300,6 +2240,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2314,6 +2255,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2321,12 +2263,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2345,29 +2289,30 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "needle": {
-                    "version": "2.2.4",
+                    "version": "2.3.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
+                        "debug": "^4.1.0",
                         "iconv-lite": "^0.4.4",
                         "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.10.3",
+                    "version": "0.12.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2395,13 +2340,13 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.5",
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.2.0",
+                    "version": "1.4.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2425,7 +2370,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2437,6 +2383,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2522,7 +2469,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2537,7 +2485,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "5.6.0",
+                    "version": "5.7.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2558,6 +2506,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2577,6 +2526,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2620,12 +2570,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -2981,14 +2933,14 @@
             }
         },
         "grunt-contrib-jshint": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-2.0.0.tgz",
-            "integrity": "sha512-4qR411I1bhvVrPkKBzCUcrWkTEtBuWioXi9ABWRXHoplRScg03jiMqLDpzS4pDhVsLOTx5F9l+0cnMc+Gd2MWg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-2.1.0.tgz",
+            "integrity": "sha512-65S2/C/6RfjY/umTxfwXXn+wVvaYmykHkHSsW6Q6rhkbv3oudTEgqnFFZvWzWCoHUb+3GMZLbP3oSrNyvshmIQ==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
+                "chalk": "^2.4.2",
                 "hooker": "^0.2.3",
-                "jshint": "~2.9.6"
+                "jshint": "~2.10.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3029,14 +2981,14 @@
             }
         },
         "grunt-contrib-uglify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-4.0.0.tgz",
-            "integrity": "sha512-vy3Vop2KDqdiwcGOGAjyKvjHFrRD/YK4KPQWR3Yt6OdYlgFw1z7HCuk66+IJ9s7oJmp9uRQXuuSHyawKRAgiMw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-4.0.1.tgz",
+            "integrity": "sha512-dwf8/+4uW1+7pH72WButOEnzErPGmtUvc8p08B0eQS/6ON0WdeQu0+WFeafaPTbbY1GqtS25lsHWaDeiTQNWPg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
                 "maxmin": "^2.1.0",
-                "uglify-js": "~3.4.8",
+                "uglify-js": "^3.5.0",
                 "uri-path": "^1.0.0"
             },
             "dependencies": {
@@ -3145,9 +3097,9 @@
             }
         },
         "grunt-karma": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-3.0.1.tgz",
-            "integrity": "sha512-iNt1Qe5GoePMIfBQmeffvfrvnvwTfJ9/h9p9gqGMIuEdVsUo4PKhTxIwyW5NMbHrgD8p2UEdeTJH4l0QGz4YtA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-3.0.2.tgz",
+            "integrity": "sha512-imNhQO1bR1O7X6/3F5vO0o7mKy4xdkpSd40QVfxGO70cBAFcOqjv2Zu5QzsfEsSrppuu3N0vIQPbfBRjeGdpWg==",
             "dev": true,
             "requires": {
                 "lodash": "^4.17.10"
@@ -3475,15 +3427,16 @@
             }
         },
         "http-errors": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
             "dev": true,
             "requires": {
                 "depd": "~1.1.2",
                 "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
             }
         },
         "http-parser-js": {
@@ -3900,16 +3853,16 @@
             }
         },
         "jshint": {
-            "version": "2.9.7",
-            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.7.tgz",
-            "integrity": "sha512-Q8XN38hGsVQhdlM+4gd1Xl7OB1VieSuCJf+fEJjpo59JH99bVJhXRXAh26qQ15wfdd1VPMuDWNeSWoNl53T4YA==",
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz",
+            "integrity": "sha512-e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==",
             "dev": true,
             "requires": {
                 "cli": "~1.0.0",
                 "console-browserify": "1.1.x",
                 "exit": "0.1.x",
                 "htmlparser2": "3.8.x",
-                "lodash": "~4.17.10",
+                "lodash": "~4.17.11",
                 "minimatch": "~3.0.2",
                 "shelljs": "0.3.x",
                 "strip-json-comments": "1.0.x"
@@ -4046,28 +3999,27 @@
             }
         },
         "karma": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.4.tgz",
-            "integrity": "sha512-31Vo8Qr5glN+dZEVIpnPCxEGleqE0EY6CtC2X9TagRV3rRQ3SNrvfhddICkJgUK3AgqpeKSZau03QumTGhGoSw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-4.1.0.tgz",
+            "integrity": "sha512-xckiDqyNi512U4dXGOOSyLKPwek6X/vUizSy2f3geYevbLj+UIdvNwbn7IwfUIL2g1GXEPWt/87qFD1fBbl/Uw==",
             "dev": true,
             "requires": {
                 "bluebird": "^3.3.0",
                 "body-parser": "^1.16.1",
+                "braces": "^2.3.2",
                 "chokidar": "^2.0.3",
                 "colors": "^1.1.0",
-                "combine-lists": "^1.0.0",
                 "connect": "^3.6.0",
                 "core-js": "^2.2.0",
                 "di": "^0.0.1",
                 "dom-serialize": "^2.2.0",
-                "expand-braces": "^0.1.1",
                 "flatted": "^2.0.0",
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.1.2",
                 "http-proxy": "^1.13.0",
                 "isbinaryfile": "^3.0.0",
-                "lodash": "^4.17.5",
-                "log4js": "^3.0.0",
+                "lodash": "^4.17.11",
+                "log4js": "^4.0.0",
                 "mime": "^2.3.1",
                 "minimatch": "^3.0.2",
                 "optimist": "^0.6.1",
@@ -4088,9 +4040,9 @@
                     "dev": true
                 },
                 "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "version": "7.1.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -4161,9 +4113,9 @@
             "dev": true
         },
         "karma-qunit": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/karma-qunit/-/karma-qunit-2.1.0.tgz",
-            "integrity": "sha512-QFt2msjpFNx1ZqB1EcD7rXaFRa3P+kLrgm6uRDYV/1MO7qGMxnTDgsFB1KyAKCpMreOmB5MMpEm5sX52j4c0aw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/karma-qunit/-/karma-qunit-3.1.2.tgz",
+            "integrity": "sha512-3m3zP7NpYkOCxoJ5SQyHQowLSiqz9sNEa1/jJmtgt+U4akxm58lgsXDpdquNgQ8dzs65kEkQIt5ihEoVe2SHEQ==",
             "dev": true
         },
         "karma-sauce-launcher": {
@@ -4297,12 +4249,6 @@
             "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
-        "lodash.debounce": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-            "dev": true
-        },
         "log-driver": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
@@ -4310,16 +4256,27 @@
             "dev": true
         },
         "log4js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
-            "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.3.2.tgz",
+            "integrity": "sha512-72GjgSP+ifL156MD/bXEhE7UlFLKS2KkCXujodb1nl1z6PpKhCfS+41dyNQ7zKi4iM49TQl+aWLEISXGLcGCCQ==",
             "dev": true,
             "requires": {
-                "circular-json": "^0.5.5",
-                "date-format": "^1.2.0",
-                "debug": "^3.1.0",
+                "date-format": "^2.0.0",
+                "debug": "^4.1.1",
+                "flatted": "^2.0.0",
                 "rfdc": "^1.1.2",
-                "streamroller": "0.7.0"
+                "streamroller": "^1.0.5"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "loglevel": {
@@ -4332,7 +4289,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "lru-cache": {
             "version": "2.7.3",
@@ -4455,9 +4413,9 @@
             }
         },
         "mime": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-            "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
             "dev": true
         },
         "mime-db": {
@@ -4565,9 +4523,9 @@
             "dev": true
         },
         "nan": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-            "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
             "dev": true,
             "optional": true
         },
@@ -4617,9 +4575,9 @@
             "dev": true
         },
         "negotiator": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
             "dev": true
         },
         "nice-try": {
@@ -4653,7 +4611,8 @@
                     "version": "1.0.9",
                     "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
                     "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "async": {
                     "version": "1.5.2",
@@ -4846,6 +4805,3866 @@
                 "path-key": "^2.0.0"
             }
         },
+        "npx": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/npx/-/npx-10.2.0.tgz",
+            "integrity": "sha512-DqjFkzET0DeaXYXNJnirnvEovwk4lBa33ZQCw1jxMuas4yH9jdU8q2U8L3cLaB2UqzgmW2Ssqk8lcGiPRL8pRg==",
+            "dev": true,
+            "requires": {
+                "libnpx": "10.2.0",
+                "npm": "5.1.0"
+            },
+            "dependencies": {
+                "ansi-align": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "boxen": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-align": "^2.0.0",
+                        "camelcase": "^4.0.0",
+                        "chalk": "^2.0.1",
+                        "cli-boxes": "^1.0.0",
+                        "string-width": "^2.0.0",
+                        "term-size": "^1.2.0",
+                        "widest-line": "^2.0.0"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "builtins": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "capture-stack-trace": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "ci-info": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cli-boxes": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "1.9.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "color-name": "^1.1.1"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "configstore": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "^4.1.0",
+                        "graceful-fs": "^4.1.2",
+                        "make-dir": "^1.0.0",
+                        "unique-string": "^1.0.0",
+                        "write-file-atomic": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "create-error-class": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "capture-stack-trace": "^1.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "crypto-random-string": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                },
+                "dotenv": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "duplexer3": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "global-dirs": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ini": "^1.3.4"
+                    }
+                },
+                "got": {
+                    "version": "6.7.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "hosted-git-info": {
+                    "version": "2.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "import-lazy": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-ci": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^1.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-installed-globally": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "global-dirs": "^0.1.0",
+                        "is-path-inside": "^1.0.0"
+                    }
+                },
+                "is-npm": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-obj": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-path-inside": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-is-inside": "^1.0.1"
+                    }
+                },
+                "is-redirect": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-retry-allowed": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "latest-version": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "package-json": "^4.0.0"
+                    }
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "libnpx": {
+                    "version": "10.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "dotenv": "^5.0.1",
+                        "npm-package-arg": "^6.0.0",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.0",
+                        "update-notifier": "^2.3.0",
+                        "which": "^1.3.0",
+                        "y18n": "^4.0.0",
+                        "yargs": "^11.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lowercase-keys": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "~1.3.1",
+                        "abbrev": "~1.1.0",
+                        "ansi-regex": "~3.0.0",
+                        "ansicolors": "~0.3.2",
+                        "ansistyles": "~0.1.3",
+                        "aproba": "~1.1.2",
+                        "archy": "~1.0.0",
+                        "bluebird": "~3.5.0",
+                        "cacache": "~9.2.9",
+                        "call-limit": "~1.1.0",
+                        "chownr": "~1.0.1",
+                        "cmd-shim": "~2.0.2",
+                        "columnify": "~1.5.4",
+                        "config-chain": "~1.1.11",
+                        "debuglog": "*",
+                        "detect-indent": "~5.0.0",
+                        "dezalgo": "~1.0.3",
+                        "editor": "~1.0.0",
+                        "fs-vacuum": "~1.2.10",
+                        "fs-write-stream-atomic": "~1.0.10",
+                        "fstream": "~1.0.11",
+                        "fstream-npm": "~1.2.1",
+                        "glob": "~7.1.2",
+                        "graceful-fs": "~4.1.11",
+                        "has-unicode": "~2.0.1",
+                        "hosted-git-info": "~2.5.0",
+                        "iferr": "~0.1.5",
+                        "imurmurhash": "*",
+                        "inflight": "~1.0.6",
+                        "inherits": "~2.0.3",
+                        "ini": "~1.3.4",
+                        "init-package-json": "~1.10.1",
+                        "lazy-property": "~1.0.0",
+                        "lockfile": "~1.0.3",
+                        "lodash._baseindexof": "*",
+                        "lodash._baseuniq": "~4.6.0",
+                        "lodash._bindcallback": "*",
+                        "lodash._cacheindexof": "*",
+                        "lodash._createcache": "*",
+                        "lodash._getnative": "*",
+                        "lodash.clonedeep": "~4.5.0",
+                        "lodash.restparam": "*",
+                        "lodash.union": "~4.6.0",
+                        "lodash.uniq": "~4.5.0",
+                        "lodash.without": "~4.4.0",
+                        "lru-cache": "~4.1.1",
+                        "mississippi": "~1.3.0",
+                        "mkdirp": "~0.5.1",
+                        "move-concurrently": "~1.0.1",
+                        "node-gyp": "~3.6.2",
+                        "nopt": "~4.0.1",
+                        "normalize-package-data": "~2.4.0",
+                        "npm-cache-filename": "~1.0.2",
+                        "npm-install-checks": "~3.0.0",
+                        "npm-package-arg": "~5.1.2",
+                        "npm-registry-client": "~8.4.0",
+                        "npm-user-validate": "~1.0.0",
+                        "npmlog": "~4.1.2",
+                        "once": "~1.4.0",
+                        "opener": "~1.4.3",
+                        "osenv": "~0.1.4",
+                        "pacote": "~2.7.38",
+                        "path-is-inside": "~1.0.2",
+                        "promise-inflight": "~1.0.1",
+                        "read": "~1.0.7",
+                        "read-cmd-shim": "~1.0.1",
+                        "read-installed": "~4.0.3",
+                        "read-package-json": "~2.0.9",
+                        "read-package-tree": "~5.1.6",
+                        "readable-stream": "~2.3.2",
+                        "readdir-scoped-modules": "*",
+                        "request": "~2.81.0",
+                        "retry": "~0.10.1",
+                        "rimraf": "~2.6.1",
+                        "safe-buffer": "~5.1.1",
+                        "semver": "~5.3.0",
+                        "sha": "~2.0.1",
+                        "slide": "~1.1.6",
+                        "sorted-object": "~2.0.1",
+                        "sorted-union-stream": "~2.1.3",
+                        "ssri": "~4.1.6",
+                        "strip-ansi": "~4.0.0",
+                        "tar": "~2.2.1",
+                        "text-table": "~0.2.0",
+                        "uid-number": "0.0.6",
+                        "umask": "~1.1.0",
+                        "unique-filename": "~1.1.0",
+                        "unpipe": "~1.0.0",
+                        "update-notifier": "~2.2.0",
+                        "uuid": "~3.1.0",
+                        "validate-npm-package-license": "*",
+                        "validate-npm-package-name": "~3.0.0",
+                        "which": "~1.2.14",
+                        "worker-farm": "~1.3.1",
+                        "wrappy": "~1.0.2",
+                        "write-file-atomic": "~2.1.0"
+                    },
+                    "dependencies": {
+                        "JSONStream": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "jsonparse": "^1.2.0",
+                                "through": ">=2.2.7 <3"
+                            },
+                            "dependencies": {
+                                "jsonparse": {
+                                    "version": "1.3.1",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "through": {
+                                    "version": "2.3.8",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "abbrev": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansicolors": {
+                            "version": "0.3.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansistyles": {
+                            "version": "0.1.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "aproba": {
+                            "version": "1.1.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "archy": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "bluebird": {
+                            "version": "3.5.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "cacache": {
+                            "version": "9.2.9",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "bluebird": "^3.5.0",
+                                "chownr": "^1.0.1",
+                                "glob": "^7.1.2",
+                                "graceful-fs": "^4.1.11",
+                                "lru-cache": "^4.1.1",
+                                "mississippi": "^1.3.0",
+                                "mkdirp": "^0.5.1",
+                                "move-concurrently": "^1.0.1",
+                                "promise-inflight": "^1.0.1",
+                                "rimraf": "^2.6.1",
+                                "ssri": "^4.1.6",
+                                "unique-filename": "^1.1.0",
+                                "y18n": "^3.2.1"
+                            },
+                            "dependencies": {
+                                "lru-cache": {
+                                    "version": "4.1.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "pseudomap": "^1.0.2",
+                                        "yallist": "^2.1.2"
+                                    },
+                                    "dependencies": {
+                                        "pseudomap": {
+                                            "version": "1.0.2",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "yallist": {
+                                            "version": "2.1.2",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "y18n": {
+                                    "version": "3.2.1",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "call-limit": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "chownr": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "cmd-shim": {
+                            "version": "2.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "mkdirp": "~0.5.0"
+                            }
+                        },
+                        "columnify": {
+                            "version": "1.5.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "strip-ansi": "^3.0.0",
+                                "wcwidth": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "strip-ansi": {
+                                    "version": "3.0.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "ansi-regex": "^2.0.0"
+                                    },
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "2.1.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "wcwidth": {
+                                    "version": "1.0.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "defaults": "^1.0.3"
+                                    },
+                                    "dependencies": {
+                                        "defaults": {
+                                            "version": "1.0.3",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "clone": "^1.0.2"
+                                            },
+                                            "dependencies": {
+                                                "clone": {
+                                                    "version": "1.0.2",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "config-chain": {
+                            "version": "1.1.11",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ini": "^1.3.4",
+                                "proto-list": "~1.2.1"
+                            },
+                            "dependencies": {
+                                "proto-list": {
+                                    "version": "1.2.4",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "debuglog": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "detect-indent": {
+                            "version": "5.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "dezalgo": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "asap": "^2.0.0",
+                                "wrappy": "1"
+                            },
+                            "dependencies": {
+                                "asap": {
+                                    "version": "2.0.5",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "editor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "fs-vacuum": {
+                            "version": "1.2.10",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "path-is-inside": "^1.0.1",
+                                "rimraf": "^2.5.2"
+                            }
+                        },
+                        "fs-write-stream-atomic": {
+                            "version": "1.0.10",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "iferr": "^0.1.5",
+                                "imurmurhash": "^0.1.4",
+                                "readable-stream": "1 || 2"
+                            }
+                        },
+                        "fstream": {
+                            "version": "1.0.11",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "inherits": "~2.0.0",
+                                "mkdirp": ">=0.5 0",
+                                "rimraf": "2"
+                            }
+                        },
+                        "fstream-npm": {
+                            "version": "1.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "fstream-ignore": "^1.0.0",
+                                "inherits": "2"
+                            },
+                            "dependencies": {
+                                "fstream-ignore": {
+                                    "version": "1.0.5",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "fstream": "^1.0.0",
+                                        "inherits": "2",
+                                        "minimatch": "^3.0.0"
+                                    },
+                                    "dependencies": {
+                                        "minimatch": {
+                                            "version": "3.0.4",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "brace-expansion": "^1.1.7"
+                                            },
+                                            "dependencies": {
+                                                "brace-expansion": {
+                                                    "version": "1.1.8",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "balanced-match": "^1.0.0",
+                                                        "concat-map": "0.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "balanced-match": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "concat-map": {
+                                                            "version": "0.0.1",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "glob": {
+                            "version": "7.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "fs.realpath": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "minimatch": {
+                                    "version": "3.0.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "brace-expansion": "^1.1.7"
+                                    },
+                                    "dependencies": {
+                                        "brace-expansion": {
+                                            "version": "1.1.8",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "balanced-match": "^1.0.0",
+                                                "concat-map": "0.0.1"
+                                            },
+                                            "dependencies": {
+                                                "balanced-match": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "concat-map": {
+                                                    "version": "0.0.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "path-is-absolute": {
+                                    "version": "1.0.1",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "graceful-fs": {
+                            "version": "4.1.11",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "has-unicode": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "hosted-git-info": {
+                            "version": "2.5.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "imurmurhash": {
+                            "version": "0.1.4",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ini": {
+                            "version": "1.3.4",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "init-package-json": {
+                            "version": "1.10.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "glob": "^7.1.1",
+                                "npm-package-arg": "^4.0.0 || ^5.0.0",
+                                "promzard": "^0.3.0",
+                                "read": "~1.0.1",
+                                "read-package-json": "1 || 2",
+                                "semver": "2.x || 3.x || 4 || 5",
+                                "validate-npm-package-license": "^3.0.1",
+                                "validate-npm-package-name": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "promzard": {
+                                    "version": "0.3.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "read": "1"
+                                    }
+                                }
+                            }
+                        },
+                        "lazy-property": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lockfile": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash._baseindexof": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash._baseuniq": {
+                            "version": "4.6.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "lodash._createset": "~4.0.0",
+                                "lodash._root": "~3.0.0"
+                            },
+                            "dependencies": {
+                                "lodash._createset": {
+                                    "version": "4.0.3",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "lodash._root": {
+                                    "version": "3.0.1",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "lodash._bindcallback": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash._cacheindexof": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash._createcache": {
+                            "version": "3.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "lodash._getnative": "^3.0.0"
+                            }
+                        },
+                        "lodash._getnative": {
+                            "version": "3.9.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash.clonedeep": {
+                            "version": "4.5.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash.restparam": {
+                            "version": "3.6.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash.union": {
+                            "version": "4.6.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash.uniq": {
+                            "version": "4.5.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lodash.without": {
+                            "version": "4.4.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "lru-cache": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "pseudomap": "^1.0.2",
+                                "yallist": "^2.1.2"
+                            },
+                            "dependencies": {
+                                "pseudomap": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "yallist": {
+                                    "version": "2.1.2",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "mississippi": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "concat-stream": "^1.5.0",
+                                "duplexify": "^3.4.2",
+                                "end-of-stream": "^1.1.0",
+                                "flush-write-stream": "^1.0.0",
+                                "from2": "^2.1.0",
+                                "parallel-transform": "^1.1.0",
+                                "pump": "^1.0.0",
+                                "pumpify": "^1.3.3",
+                                "stream-each": "^1.1.0",
+                                "through2": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "concat-stream": {
+                                    "version": "1.6.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "inherits": "^2.0.3",
+                                        "readable-stream": "^2.2.2",
+                                        "typedarray": "^0.0.6"
+                                    },
+                                    "dependencies": {
+                                        "typedarray": {
+                                            "version": "0.0.6",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "duplexify": {
+                                    "version": "3.5.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "end-of-stream": "1.0.0",
+                                        "inherits": "^2.0.1",
+                                        "readable-stream": "^2.0.0",
+                                        "stream-shift": "^1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "end-of-stream": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "once": "~1.3.0"
+                                            },
+                                            "dependencies": {
+                                                "once": {
+                                                    "version": "1.3.3",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "wrappy": "1"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "stream-shift": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "end-of-stream": {
+                                    "version": "1.4.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "once": "^1.4.0"
+                                    }
+                                },
+                                "flush-write-stream": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "inherits": "^2.0.1",
+                                        "readable-stream": "^2.0.4"
+                                    }
+                                },
+                                "from2": {
+                                    "version": "2.3.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "inherits": "^2.0.1",
+                                        "readable-stream": "^2.0.0"
+                                    }
+                                },
+                                "parallel-transform": {
+                                    "version": "1.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "cyclist": "~0.2.2",
+                                        "inherits": "^2.0.3",
+                                        "readable-stream": "^2.1.5"
+                                    },
+                                    "dependencies": {
+                                        "cyclist": {
+                                            "version": "0.2.2",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "pump": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "end-of-stream": "^1.1.0",
+                                        "once": "^1.3.1"
+                                    }
+                                },
+                                "pumpify": {
+                                    "version": "1.3.5",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "duplexify": "^3.1.2",
+                                        "inherits": "^2.0.1",
+                                        "pump": "^1.0.0"
+                                    }
+                                },
+                                "stream-each": {
+                                    "version": "1.2.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "end-of-stream": "^1.1.0",
+                                        "stream-shift": "^1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "stream-shift": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "through2": {
+                                    "version": "2.0.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "readable-stream": "^2.1.5",
+                                        "xtend": "~4.0.1"
+                                    },
+                                    "dependencies": {
+                                        "xtend": {
+                                            "version": "4.0.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "minimist": "0.0.8"
+                            },
+                            "dependencies": {
+                                "minimist": {
+                                    "version": "0.0.8",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "move-concurrently": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "aproba": "^1.1.1",
+                                "copy-concurrently": "^1.0.0",
+                                "fs-write-stream-atomic": "^1.0.8",
+                                "mkdirp": "^0.5.1",
+                                "rimraf": "^2.5.4",
+                                "run-queue": "^1.0.3"
+                            },
+                            "dependencies": {
+                                "copy-concurrently": {
+                                    "version": "1.0.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "aproba": "^1.1.1",
+                                        "fs-write-stream-atomic": "^1.0.8",
+                                        "iferr": "^0.1.5",
+                                        "mkdirp": "^0.5.1",
+                                        "rimraf": "^2.5.4",
+                                        "run-queue": "^1.0.0"
+                                    }
+                                },
+                                "run-queue": {
+                                    "version": "1.0.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "aproba": "^1.1.1"
+                                    }
+                                }
+                            }
+                        },
+                        "node-gyp": {
+                            "version": "3.6.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "fstream": "^1.0.0",
+                                "glob": "^7.0.3",
+                                "graceful-fs": "^4.1.2",
+                                "minimatch": "^3.0.2",
+                                "mkdirp": "^0.5.0",
+                                "nopt": "2 || 3",
+                                "npmlog": "0 || 1 || 2 || 3 || 4",
+                                "osenv": "0",
+                                "request": "2",
+                                "rimraf": "2",
+                                "semver": "~5.3.0",
+                                "tar": "^2.0.0",
+                                "which": "1"
+                            },
+                            "dependencies": {
+                                "minimatch": {
+                                    "version": "3.0.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "brace-expansion": "^1.1.7"
+                                    },
+                                    "dependencies": {
+                                        "brace-expansion": {
+                                            "version": "1.1.8",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "balanced-match": "^1.0.0",
+                                                "concat-map": "0.0.1"
+                                            },
+                                            "dependencies": {
+                                                "balanced-match": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "concat-map": {
+                                                    "version": "0.0.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "nopt": {
+                                    "version": "3.0.6",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "abbrev": "1"
+                                    }
+                                }
+                            }
+                        },
+                        "nopt": {
+                            "version": "4.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "abbrev": "1",
+                                "osenv": "^0.1.4"
+                            }
+                        },
+                        "normalize-package-data": {
+                            "version": "2.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "hosted-git-info": "^2.1.4",
+                                "is-builtin-module": "^1.0.0",
+                                "semver": "2 || 3 || 4 || 5",
+                                "validate-npm-package-license": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "is-builtin-module": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "builtin-modules": "^1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "builtin-modules": {
+                                            "version": "1.1.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "npm-cache-filename": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "npm-install-checks": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "semver": "^2.3.0 || 3.x || 4 || 5"
+                            }
+                        },
+                        "npm-package-arg": {
+                            "version": "5.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "hosted-git-info": "^2.4.2",
+                                "osenv": "^0.1.4",
+                                "semver": "^5.1.0",
+                                "validate-npm-package-name": "^3.0.0"
+                            }
+                        },
+                        "npm-registry-client": {
+                            "version": "8.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "concat-stream": "^1.5.2",
+                                "graceful-fs": "^4.1.6",
+                                "normalize-package-data": "~1.0.1 || ^2.0.0",
+                                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
+                                "npmlog": "2 || ^3.1.0 || ^4.0.0",
+                                "once": "^1.3.3",
+                                "request": "^2.74.0",
+                                "retry": "^0.10.0",
+                                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                                "slide": "^1.1.3",
+                                "ssri": "^4.1.2"
+                            },
+                            "dependencies": {
+                                "concat-stream": {
+                                    "version": "1.6.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "inherits": "^2.0.3",
+                                        "readable-stream": "^2.2.2",
+                                        "typedarray": "^0.0.6"
+                                    },
+                                    "dependencies": {
+                                        "typedarray": {
+                                            "version": "0.0.6",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "npm-user-validate": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "npmlog": {
+                            "version": "4.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "are-we-there-yet": "~1.1.2",
+                                "console-control-strings": "~1.1.0",
+                                "gauge": "~2.7.3",
+                                "set-blocking": "~2.0.0"
+                            },
+                            "dependencies": {
+                                "are-we-there-yet": {
+                                    "version": "1.1.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "delegates": "^1.0.0",
+                                        "readable-stream": "^2.0.6"
+                                    },
+                                    "dependencies": {
+                                        "delegates": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "console-control-strings": {
+                                    "version": "1.1.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "gauge": {
+                                    "version": "2.7.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "aproba": "^1.0.3",
+                                        "console-control-strings": "^1.0.0",
+                                        "has-unicode": "^2.0.0",
+                                        "object-assign": "^4.1.0",
+                                        "signal-exit": "^3.0.0",
+                                        "string-width": "^1.0.1",
+                                        "strip-ansi": "^3.0.1",
+                                        "wide-align": "^1.1.0"
+                                    },
+                                    "dependencies": {
+                                        "object-assign": {
+                                            "version": "4.1.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "signal-exit": {
+                                            "version": "3.0.2",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "string-width": {
+                                            "version": "1.0.2",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "code-point-at": "^1.0.0",
+                                                "is-fullwidth-code-point": "^1.0.0",
+                                                "strip-ansi": "^3.0.0"
+                                            },
+                                            "dependencies": {
+                                                "code-point-at": {
+                                                    "version": "1.1.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "is-fullwidth-code-point": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "number-is-nan": "^1.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "number-is-nan": {
+                                                            "version": "1.0.1",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "strip-ansi": {
+                                            "version": "3.0.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "ansi-regex": "^2.0.0"
+                                            },
+                                            "dependencies": {
+                                                "ansi-regex": {
+                                                    "version": "2.1.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        },
+                                        "wide-align": {
+                                            "version": "1.1.2",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "string-width": "^1.0.2"
+                                            }
+                                        }
+                                    }
+                                },
+                                "set-blocking": {
+                                    "version": "2.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "wrappy": "1"
+                            }
+                        },
+                        "opener": {
+                            "version": "1.4.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "osenv": {
+                            "version": "0.1.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "os-homedir": "^1.0.0",
+                                "os-tmpdir": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "os-homedir": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "os-tmpdir": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "pacote": {
+                            "version": "2.7.38",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "bluebird": "^3.5.0",
+                                "cacache": "^9.2.9",
+                                "glob": "^7.1.2",
+                                "lru-cache": "^4.1.1",
+                                "make-fetch-happen": "^2.4.13",
+                                "minimatch": "^3.0.4",
+                                "mississippi": "^1.2.0",
+                                "normalize-package-data": "^2.4.0",
+                                "npm-package-arg": "^5.1.2",
+                                "npm-pick-manifest": "^1.0.4",
+                                "osenv": "^0.1.4",
+                                "promise-inflight": "^1.0.1",
+                                "promise-retry": "^1.1.1",
+                                "protoduck": "^4.0.0",
+                                "safe-buffer": "^5.1.1",
+                                "semver": "^5.3.0",
+                                "ssri": "^4.1.6",
+                                "tar-fs": "^1.15.3",
+                                "tar-stream": "^1.5.4",
+                                "unique-filename": "^1.1.0",
+                                "which": "^1.2.12"
+                            },
+                            "dependencies": {
+                                "make-fetch-happen": {
+                                    "version": "2.4.13",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "agentkeepalive": "^3.3.0",
+                                        "cacache": "^9.2.9",
+                                        "http-cache-semantics": "^3.7.3",
+                                        "http-proxy-agent": "^2.0.0",
+                                        "https-proxy-agent": "^2.0.0",
+                                        "lru-cache": "^4.1.1",
+                                        "mississippi": "^1.2.0",
+                                        "node-fetch-npm": "^2.0.1",
+                                        "promise-retry": "^1.1.1",
+                                        "socks-proxy-agent": "^3.0.0",
+                                        "ssri": "^4.1.6"
+                                    },
+                                    "dependencies": {
+                                        "agentkeepalive": {
+                                            "version": "3.3.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "humanize-ms": "^1.2.1"
+                                            },
+                                            "dependencies": {
+                                                "humanize-ms": {
+                                                    "version": "1.2.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "ms": "^2.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "ms": {
+                                                            "version": "2.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "http-cache-semantics": {
+                                            "version": "3.7.3",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "http-proxy-agent": {
+                                            "version": "2.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "agent-base": "4",
+                                                "debug": "2"
+                                            },
+                                            "dependencies": {
+                                                "agent-base": {
+                                                    "version": "4.1.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "es6-promisify": "^5.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promisify": {
+                                                            "version": "5.0.0",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "es6-promise": "^4.0.3"
+                                                            },
+                                                            "dependencies": {
+                                                                "es6-promise": {
+                                                                    "version": "4.1.1",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "debug": {
+                                                    "version": "2.6.8",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "ms": "2.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "ms": {
+                                                            "version": "2.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "https-proxy-agent": {
+                                            "version": "2.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "agent-base": "^4.1.0",
+                                                "debug": "^2.4.1"
+                                            },
+                                            "dependencies": {
+                                                "agent-base": {
+                                                    "version": "4.1.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "es6-promisify": "^5.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promisify": {
+                                                            "version": "5.0.0",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "es6-promise": "^4.0.3"
+                                                            },
+                                                            "dependencies": {
+                                                                "es6-promise": {
+                                                                    "version": "4.1.1",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "debug": {
+                                                    "version": "2.6.8",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "ms": "2.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "ms": {
+                                                            "version": "2.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "node-fetch-npm": {
+                                            "version": "2.0.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "encoding": "^0.1.11",
+                                                "json-parse-helpfulerror": "^1.0.3",
+                                                "safe-buffer": "^5.0.1"
+                                            },
+                                            "dependencies": {
+                                                "encoding": {
+                                                    "version": "0.1.12",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "iconv-lite": "~0.4.13"
+                                                    },
+                                                    "dependencies": {
+                                                        "iconv-lite": {
+                                                            "version": "0.4.18",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                },
+                                                "json-parse-helpfulerror": {
+                                                    "version": "1.0.3",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "jju": "^1.1.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "jju": {
+                                                            "version": "1.3.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "socks-proxy-agent": {
+                                            "version": "3.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "agent-base": "^4.0.1",
+                                                "socks": "^1.1.10"
+                                            },
+                                            "dependencies": {
+                                                "agent-base": {
+                                                    "version": "4.1.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "es6-promisify": "^5.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promisify": {
+                                                            "version": "5.0.0",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "es6-promise": "^4.0.3"
+                                                            },
+                                                            "dependencies": {
+                                                                "es6-promise": {
+                                                                    "version": "4.1.1",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "socks": {
+                                                    "version": "1.1.10",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "ip": "^1.1.4",
+                                                        "smart-buffer": "^1.0.13"
+                                                    },
+                                                    "dependencies": {
+                                                        "ip": {
+                                                            "version": "1.1.5",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "smart-buffer": {
+                                                            "version": "1.1.15",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "minimatch": {
+                                    "version": "3.0.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "brace-expansion": "^1.1.7"
+                                    },
+                                    "dependencies": {
+                                        "brace-expansion": {
+                                            "version": "1.1.8",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "balanced-match": "^1.0.0",
+                                                "concat-map": "0.0.1"
+                                            },
+                                            "dependencies": {
+                                                "balanced-match": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "concat-map": {
+                                                    "version": "0.0.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "npm-pick-manifest": {
+                                    "version": "1.0.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "npm-package-arg": "^5.1.2",
+                                        "semver": "^5.3.0"
+                                    }
+                                },
+                                "promise-retry": {
+                                    "version": "1.1.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "err-code": "^1.0.0",
+                                        "retry": "^0.10.0"
+                                    },
+                                    "dependencies": {
+                                        "err-code": {
+                                            "version": "1.1.2",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "protoduck": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "genfun": "^4.0.1"
+                                    },
+                                    "dependencies": {
+                                        "genfun": {
+                                            "version": "4.0.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "tar-fs": {
+                                    "version": "1.15.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "chownr": "^1.0.1",
+                                        "mkdirp": "^0.5.1",
+                                        "pump": "^1.0.0",
+                                        "tar-stream": "^1.1.2"
+                                    },
+                                    "dependencies": {
+                                        "pump": {
+                                            "version": "1.0.2",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "end-of-stream": "^1.1.0",
+                                                "once": "^1.3.1"
+                                            },
+                                            "dependencies": {
+                                                "end-of-stream": {
+                                                    "version": "1.4.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "once": "^1.4.0"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "tar-stream": {
+                                    "version": "1.5.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "bl": "^1.0.0",
+                                        "end-of-stream": "^1.0.0",
+                                        "readable-stream": "^2.0.0",
+                                        "xtend": "^4.0.0"
+                                    },
+                                    "dependencies": {
+                                        "bl": {
+                                            "version": "1.2.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "readable-stream": "^2.0.5"
+                                            }
+                                        },
+                                        "end-of-stream": {
+                                            "version": "1.4.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "once": "^1.4.0"
+                                            }
+                                        },
+                                        "xtend": {
+                                            "version": "4.0.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "path-is-inside": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "promise-inflight": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "read": {
+                            "version": "1.0.7",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "mute-stream": "~0.0.4"
+                            },
+                            "dependencies": {
+                                "mute-stream": {
+                                    "version": "0.0.7",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "read-cmd-shim": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2"
+                            }
+                        },
+                        "read-installed": {
+                            "version": "4.0.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "debuglog": "^1.0.1",
+                                "graceful-fs": "^4.1.2",
+                                "read-package-json": "^2.0.0",
+                                "readdir-scoped-modules": "^1.0.0",
+                                "semver": "2 || 3 || 4 || 5",
+                                "slide": "~1.1.3",
+                                "util-extend": "^1.0.1"
+                            },
+                            "dependencies": {
+                                "util-extend": {
+                                    "version": "1.0.3",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "read-package-json": {
+                            "version": "2.0.9",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "glob": "^7.1.1",
+                                "graceful-fs": "^4.1.2",
+                                "json-parse-helpfulerror": "^1.0.2",
+                                "normalize-package-data": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "json-parse-helpfulerror": {
+                                    "version": "1.0.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "jju": "^1.1.0"
+                                    },
+                                    "dependencies": {
+                                        "jju": {
+                                            "version": "1.3.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "read-package-tree": {
+                            "version": "5.1.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "debuglog": "^1.0.1",
+                                "dezalgo": "^1.0.0",
+                                "once": "^1.3.0",
+                                "read-package-json": "^2.0.0",
+                                "readdir-scoped-modules": "^1.0.0"
+                            }
+                        },
+                        "readable-stream": {
+                            "version": "2.3.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~1.0.6",
+                                "safe-buffer": "~5.1.0",
+                                "string_decoder": "~1.0.0",
+                                "util-deprecate": "~1.0.1"
+                            },
+                            "dependencies": {
+                                "core-util-is": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "isarray": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "process-nextick-args": {
+                                    "version": "1.0.7",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "string_decoder": {
+                                    "version": "1.0.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "safe-buffer": "~5.1.0"
+                                    }
+                                },
+                                "util-deprecate": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "readdir-scoped-modules": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "debuglog": "^1.0.1",
+                                "dezalgo": "^1.0.0",
+                                "graceful-fs": "^4.1.2",
+                                "once": "^1.3.0"
+                            }
+                        },
+                        "request": {
+                            "version": "2.81.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "aws-sign2": "~0.6.0",
+                                "aws4": "^1.2.1",
+                                "caseless": "~0.12.0",
+                                "combined-stream": "~1.0.5",
+                                "extend": "~3.0.0",
+                                "forever-agent": "~0.6.1",
+                                "form-data": "~2.1.1",
+                                "har-validator": "~4.2.1",
+                                "hawk": "~3.1.3",
+                                "http-signature": "~1.1.0",
+                                "is-typedarray": "~1.0.0",
+                                "isstream": "~0.1.2",
+                                "json-stringify-safe": "~5.0.1",
+                                "mime-types": "~2.1.7",
+                                "oauth-sign": "~0.8.1",
+                                "performance-now": "^0.2.0",
+                                "qs": "~6.4.0",
+                                "safe-buffer": "^5.0.1",
+                                "stringstream": "~0.0.4",
+                                "tough-cookie": "~2.3.0",
+                                "tunnel-agent": "^0.6.0",
+                                "uuid": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "aws-sign2": {
+                                    "version": "0.6.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "aws4": {
+                                    "version": "1.6.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "caseless": {
+                                    "version": "0.12.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "combined-stream": {
+                                    "version": "1.0.5",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "delayed-stream": "~1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "delayed-stream": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "extend": {
+                                    "version": "3.0.1",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "forever-agent": {
+                                    "version": "0.6.1",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "form-data": {
+                                    "version": "2.1.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "asynckit": "^0.4.0",
+                                        "combined-stream": "^1.0.5",
+                                        "mime-types": "^2.1.12"
+                                    },
+                                    "dependencies": {
+                                        "asynckit": {
+                                            "version": "0.4.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "har-validator": {
+                                    "version": "4.2.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "ajv": "^4.9.1",
+                                        "har-schema": "^1.0.5"
+                                    },
+                                    "dependencies": {
+                                        "ajv": {
+                                            "version": "4.11.8",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "co": "^4.6.0",
+                                                "json-stable-stringify": "^1.0.1"
+                                            },
+                                            "dependencies": {
+                                                "co": {
+                                                    "version": "4.6.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "json-stable-stringify": {
+                                                    "version": "1.0.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "jsonify": "~0.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "jsonify": {
+                                                            "version": "0.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "har-schema": {
+                                            "version": "1.0.5",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "hawk": {
+                                    "version": "3.1.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "boom": "2.x.x",
+                                        "cryptiles": "2.x.x",
+                                        "hoek": "2.x.x",
+                                        "sntp": "1.x.x"
+                                    },
+                                    "dependencies": {
+                                        "boom": {
+                                            "version": "2.10.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "hoek": "2.x.x"
+                                            }
+                                        },
+                                        "cryptiles": {
+                                            "version": "2.0.5",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "boom": "2.x.x"
+                                            }
+                                        },
+                                        "hoek": {
+                                            "version": "2.16.3",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "sntp": {
+                                            "version": "1.0.9",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "hoek": "2.x.x"
+                                            }
+                                        }
+                                    }
+                                },
+                                "http-signature": {
+                                    "version": "1.1.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "assert-plus": "^0.2.0",
+                                        "jsprim": "^1.2.2",
+                                        "sshpk": "^1.7.0"
+                                    },
+                                    "dependencies": {
+                                        "assert-plus": {
+                                            "version": "0.2.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "jsprim": {
+                                            "version": "1.4.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "assert-plus": "1.0.0",
+                                                "extsprintf": "1.0.2",
+                                                "json-schema": "0.2.3",
+                                                "verror": "1.3.6"
+                                            },
+                                            "dependencies": {
+                                                "assert-plus": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "extsprintf": {
+                                                    "version": "1.0.2",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "json-schema": {
+                                                    "version": "0.2.3",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "verror": {
+                                                    "version": "1.3.6",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "extsprintf": "1.0.2"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "sshpk": {
+                                            "version": "1.13.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "asn1": "~0.2.3",
+                                                "assert-plus": "^1.0.0",
+                                                "bcrypt-pbkdf": "^1.0.0",
+                                                "dashdash": "^1.12.0",
+                                                "ecc-jsbn": "~0.1.1",
+                                                "getpass": "^0.1.1",
+                                                "jsbn": "~0.1.0",
+                                                "tweetnacl": "~0.14.0"
+                                            },
+                                            "dependencies": {
+                                                "asn1": {
+                                                    "version": "0.2.3",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "assert-plus": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "bcrypt-pbkdf": {
+                                                    "version": "1.0.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "optional": true,
+                                                    "requires": {
+                                                        "tweetnacl": "^0.14.3"
+                                                    }
+                                                },
+                                                "dashdash": {
+                                                    "version": "1.14.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "assert-plus": "^1.0.0"
+                                                    }
+                                                },
+                                                "ecc-jsbn": {
+                                                    "version": "0.1.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "optional": true,
+                                                    "requires": {
+                                                        "jsbn": "~0.1.0"
+                                                    }
+                                                },
+                                                "getpass": {
+                                                    "version": "0.1.7",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "assert-plus": "^1.0.0"
+                                                    }
+                                                },
+                                                "jsbn": {
+                                                    "version": "0.1.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "optional": true
+                                                },
+                                                "tweetnacl": {
+                                                    "version": "0.14.5",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "optional": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "is-typedarray": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "isstream": {
+                                    "version": "0.1.2",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "json-stringify-safe": {
+                                    "version": "5.0.1",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "mime-types": {
+                                    "version": "2.1.15",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "mime-db": "~1.27.0"
+                                    },
+                                    "dependencies": {
+                                        "mime-db": {
+                                            "version": "1.27.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "oauth-sign": {
+                                    "version": "0.8.2",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "performance-now": {
+                                    "version": "0.2.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "qs": {
+                                    "version": "6.4.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "stringstream": {
+                                    "version": "0.0.5",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "tough-cookie": {
+                                    "version": "2.3.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "punycode": "^1.4.1"
+                                    },
+                                    "dependencies": {
+                                        "punycode": {
+                                            "version": "1.4.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "tunnel-agent": {
+                                    "version": "0.6.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "safe-buffer": "^5.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "retry": {
+                            "version": "0.10.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "rimraf": {
+                            "version": "2.6.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "glob": "^7.0.5"
+                            }
+                        },
+                        "safe-buffer": {
+                            "version": "5.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "semver": {
+                            "version": "5.3.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sha": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "readable-stream": "^2.0.2"
+                            }
+                        },
+                        "slide": {
+                            "version": "1.1.6",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sorted-object": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sorted-union-stream": {
+                            "version": "2.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "from2": "^1.3.0",
+                                "stream-iterate": "^1.1.0"
+                            },
+                            "dependencies": {
+                                "from2": {
+                                    "version": "1.3.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "inherits": "~2.0.1",
+                                        "readable-stream": "~1.1.10"
+                                    },
+                                    "dependencies": {
+                                        "readable-stream": {
+                                            "version": "1.1.14",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "core-util-is": "~1.0.0",
+                                                "inherits": "~2.0.1",
+                                                "isarray": "0.0.1",
+                                                "string_decoder": "~0.10.x"
+                                            },
+                                            "dependencies": {
+                                                "core-util-is": {
+                                                    "version": "1.0.2",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "isarray": {
+                                                    "version": "0.0.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "string_decoder": {
+                                                    "version": "0.10.31",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "stream-iterate": {
+                                    "version": "1.2.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "readable-stream": "^2.1.5",
+                                        "stream-shift": "^1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "stream-shift": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "ssri": {
+                            "version": "4.1.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "tar": {
+                            "version": "2.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "block-stream": "*",
+                                "fstream": "^1.0.2",
+                                "inherits": "2"
+                            },
+                            "dependencies": {
+                                "block-stream": {
+                                    "version": "0.0.9",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "inherits": "~2.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "text-table": {
+                            "version": "0.2.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "uid-number": {
+                            "version": "0.0.6",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "umask": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "unique-filename": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "unique-slug": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "unique-slug": {
+                                    "version": "2.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "imurmurhash": "^0.1.4"
+                                    }
+                                }
+                            }
+                        },
+                        "unpipe": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "update-notifier": {
+                            "version": "2.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "boxen": "^1.0.0",
+                                "chalk": "^1.0.0",
+                                "configstore": "^3.0.0",
+                                "import-lazy": "^2.1.0",
+                                "is-npm": "^1.0.0",
+                                "latest-version": "^3.0.0",
+                                "semver-diff": "^2.0.0",
+                                "xdg-basedir": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "boxen": {
+                                    "version": "1.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "ansi-align": "^2.0.0",
+                                        "camelcase": "^4.0.0",
+                                        "chalk": "^1.1.1",
+                                        "cli-boxes": "^1.0.0",
+                                        "string-width": "^2.0.0",
+                                        "term-size": "^0.1.0",
+                                        "widest-line": "^1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "ansi-align": {
+                                            "version": "2.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "string-width": "^2.0.0"
+                                            }
+                                        },
+                                        "camelcase": {
+                                            "version": "4.1.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "cli-boxes": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "string-width": {
+                                            "version": "2.1.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "is-fullwidth-code-point": "^2.0.0",
+                                                "strip-ansi": "^4.0.0"
+                                            },
+                                            "dependencies": {
+                                                "is-fullwidth-code-point": {
+                                                    "version": "2.0.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                },
+                                                "strip-ansi": {
+                                                    "version": "4.0.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "ansi-regex": "^3.0.0"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "term-size": {
+                                            "version": "0.1.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "execa": "^0.4.0"
+                                            },
+                                            "dependencies": {
+                                                "execa": {
+                                                    "version": "0.4.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "cross-spawn-async": "^2.1.1",
+                                                        "is-stream": "^1.1.0",
+                                                        "npm-run-path": "^1.0.0",
+                                                        "object-assign": "^4.0.1",
+                                                        "path-key": "^1.0.0",
+                                                        "strip-eof": "^1.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "cross-spawn-async": {
+                                                            "version": "2.2.5",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "lru-cache": "^4.0.0",
+                                                                "which": "^1.2.8"
+                                                            }
+                                                        },
+                                                        "is-stream": {
+                                                            "version": "1.1.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "npm-run-path": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "path-key": "^1.0.0"
+                                                            }
+                                                        },
+                                                        "object-assign": {
+                                                            "version": "4.1.1",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "path-key": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "strip-eof": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "widest-line": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "string-width": "^1.0.1"
+                                            },
+                                            "dependencies": {
+                                                "string-width": {
+                                                    "version": "1.0.2",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "code-point-at": "^1.0.0",
+                                                        "is-fullwidth-code-point": "^1.0.0",
+                                                        "strip-ansi": "^3.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "code-point-at": {
+                                                            "version": "1.1.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "is-fullwidth-code-point": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "number-is-nan": "^1.0.0"
+                                                            },
+                                                            "dependencies": {
+                                                                "number-is-nan": {
+                                                                    "version": "1.0.1",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "strip-ansi": {
+                                                            "version": "3.0.1",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "ansi-regex": "^2.0.0"
+                                                            },
+                                                            "dependencies": {
+                                                                "ansi-regex": {
+                                                                    "version": "2.1.1",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "chalk": {
+                                    "version": "1.1.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "ansi-styles": "^2.2.1",
+                                        "escape-string-regexp": "^1.0.2",
+                                        "has-ansi": "^2.0.0",
+                                        "strip-ansi": "^3.0.0",
+                                        "supports-color": "^2.0.0"
+                                    },
+                                    "dependencies": {
+                                        "ansi-styles": {
+                                            "version": "2.2.1",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "escape-string-regexp": {
+                                            "version": "1.0.5",
+                                            "bundled": true,
+                                            "dev": true
+                                        },
+                                        "has-ansi": {
+                                            "version": "2.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "ansi-regex": "^2.0.0"
+                                            },
+                                            "dependencies": {
+                                                "ansi-regex": {
+                                                    "version": "2.1.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        },
+                                        "strip-ansi": {
+                                            "version": "3.0.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "ansi-regex": "^2.0.0"
+                                            },
+                                            "dependencies": {
+                                                "ansi-regex": {
+                                                    "version": "2.1.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        },
+                                        "supports-color": {
+                                            "version": "2.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "configstore": {
+                                    "version": "3.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "dot-prop": "^4.1.0",
+                                        "graceful-fs": "^4.1.2",
+                                        "make-dir": "^1.0.0",
+                                        "unique-string": "^1.0.0",
+                                        "write-file-atomic": "^2.0.0",
+                                        "xdg-basedir": "^3.0.0"
+                                    },
+                                    "dependencies": {
+                                        "dot-prop": {
+                                            "version": "4.1.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "is-obj": "^1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "is-obj": {
+                                                    "version": "1.0.1",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        },
+                                        "make-dir": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "pify": "^2.3.0"
+                                            },
+                                            "dependencies": {
+                                                "pify": {
+                                                    "version": "2.3.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        },
+                                        "unique-string": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "crypto-random-string": "^1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "crypto-random-string": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "dev": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "import-lazy": {
+                                    "version": "2.1.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "is-npm": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "latest-version": {
+                                    "version": "3.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "package-json": "^4.0.0"
+                                    },
+                                    "dependencies": {
+                                        "package-json": {
+                                            "version": "4.0.1",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "got": "^6.7.1",
+                                                "registry-auth-token": "^3.0.1",
+                                                "registry-url": "^3.0.3",
+                                                "semver": "^5.1.0"
+                                            },
+                                            "dependencies": {
+                                                "got": {
+                                                    "version": "6.7.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "create-error-class": "^3.0.0",
+                                                        "duplexer3": "^0.1.4",
+                                                        "get-stream": "^3.0.0",
+                                                        "is-redirect": "^1.0.0",
+                                                        "is-retry-allowed": "^1.0.0",
+                                                        "is-stream": "^1.0.0",
+                                                        "lowercase-keys": "^1.0.0",
+                                                        "safe-buffer": "^5.0.1",
+                                                        "timed-out": "^4.0.0",
+                                                        "unzip-response": "^2.0.1",
+                                                        "url-parse-lax": "^1.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "create-error-class": {
+                                                            "version": "3.0.2",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "capture-stack-trace": "^1.0.0"
+                                                            },
+                                                            "dependencies": {
+                                                                "capture-stack-trace": {
+                                                                    "version": "1.0.0",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        },
+                                                        "duplexer3": {
+                                                            "version": "0.1.4",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "get-stream": {
+                                                            "version": "3.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "is-redirect": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "is-retry-allowed": {
+                                                            "version": "1.1.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "is-stream": {
+                                                            "version": "1.1.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "lowercase-keys": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "timed-out": {
+                                                            "version": "4.0.1",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "unzip-response": {
+                                                            "version": "2.0.1",
+                                                            "bundled": true,
+                                                            "dev": true
+                                                        },
+                                                        "url-parse-lax": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "prepend-http": "^1.0.1"
+                                                            },
+                                                            "dependencies": {
+                                                                "prepend-http": {
+                                                                    "version": "1.0.4",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "registry-auth-token": {
+                                                    "version": "3.3.1",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "rc": "^1.1.6",
+                                                        "safe-buffer": "^5.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "rc": {
+                                                            "version": "1.2.1",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "deep-extend": "~0.4.0",
+                                                                "ini": "~1.3.0",
+                                                                "minimist": "^1.2.0",
+                                                                "strip-json-comments": "~2.0.1"
+                                                            },
+                                                            "dependencies": {
+                                                                "deep-extend": {
+                                                                    "version": "0.4.2",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                },
+                                                                "minimist": {
+                                                                    "version": "1.2.0",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                },
+                                                                "strip-json-comments": {
+                                                                    "version": "2.0.1",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "registry-url": {
+                                                    "version": "3.1.0",
+                                                    "bundled": true,
+                                                    "dev": true,
+                                                    "requires": {
+                                                        "rc": "^1.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "rc": {
+                                                            "version": "1.2.1",
+                                                            "bundled": true,
+                                                            "dev": true,
+                                                            "requires": {
+                                                                "deep-extend": "~0.4.0",
+                                                                "ini": "~1.3.0",
+                                                                "minimist": "^1.2.0",
+                                                                "strip-json-comments": "~2.0.1"
+                                                            },
+                                                            "dependencies": {
+                                                                "deep-extend": {
+                                                                    "version": "0.4.2",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                },
+                                                                "minimist": {
+                                                                    "version": "1.2.0",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                },
+                                                                "strip-json-comments": {
+                                                                    "version": "2.0.1",
+                                                                    "bundled": true,
+                                                                    "dev": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "semver-diff": {
+                                    "version": "2.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "semver": "^5.0.3"
+                                    }
+                                },
+                                "xdg-basedir": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "uuid": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "validate-npm-package-license": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "spdx-correct": "~1.0.0",
+                                "spdx-expression-parse": "~1.0.0"
+                            },
+                            "dependencies": {
+                                "spdx-correct": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "spdx-license-ids": "^1.0.2"
+                                    },
+                                    "dependencies": {
+                                        "spdx-license-ids": {
+                                            "version": "1.2.2",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "spdx-expression-parse": {
+                                    "version": "1.0.4",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "validate-npm-package-name": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "builtins": "^1.0.3"
+                            },
+                            "dependencies": {
+                                "builtins": {
+                                    "version": "1.0.3",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "which": {
+                            "version": "1.2.14",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "isexe": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "isexe": {
+                                    "version": "2.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "worker-farm": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "errno": ">=0.1.1 <0.2.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
+                            },
+                            "dependencies": {
+                                "errno": {
+                                    "version": "0.1.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "prr": "~0.0.0"
+                                    },
+                                    "dependencies": {
+                                        "prr": {
+                                            "version": "0.0.0",
+                                            "bundled": true,
+                                            "dev": true
+                                        }
+                                    }
+                                },
+                                "xtend": {
+                                    "version": "4.0.1",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "write-file-atomic": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.11",
+                                "imurmurhash": "^0.1.4",
+                                "slide": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "npm-package-arg": {
+                    "version": "6.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.6.0",
+                        "osenv": "^0.1.5",
+                        "semver": "^5.5.0",
+                        "validate-npm-package-name": "^3.0.0"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "package-json": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-inside": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "rc": {
+                    "version": "1.2.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    }
+                },
+                "registry-auth-token": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "registry-url": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "rc": "^1.0.1"
+                    }
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.0.5"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver-diff": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "semver": "^5.0.3"
+                    }
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "term-size": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0"
+                    }
+                },
+                "timed-out": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "unique-string": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "crypto-random-string": "^1.0.0"
+                    }
+                },
+                "unzip-response": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "update-notifier": {
+                    "version": "2.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-ci": "^1.0.10",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "^1.0.1"
+                    }
+                },
+                "validate-npm-package-name": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "builtins": "^1.0.3"
+                    }
+                },
+                "which": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "widest-line": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "xdg-basedir": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    },
+                    "dependencies": {
+                        "y18n": {
+                            "version": "3.2.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    }
+                }
+            }
+        },
         "null-check": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
@@ -4897,6 +8716,7 @@
                     "version": "0.1.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "kind-of": "^3.0.2",
                         "longest": "^1.0.1",
@@ -6079,7 +9899,8 @@
                 "longest": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "loose-envify": {
                     "version": "1.3.1",
@@ -7689,9 +11510,9 @@
             }
         },
         "parseurl": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "dev": true
         },
         "pascalcase": {
@@ -7840,7 +11661,8 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "pretty-bytes": {
             "version": "3.0.1",
@@ -7976,9 +11798,9 @@
             "dev": true
         },
         "range-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true
         },
         "raw-body": {
@@ -8286,9 +12108,9 @@
             "dev": true
         },
         "rfdc": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
-            "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+            "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
             "dev": true
         },
         "right-align": {
@@ -8523,9 +12345,9 @@
             }
         },
         "setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
             "dev": true
         },
         "shebang-command": {
@@ -8950,45 +12772,51 @@
             "dev": true
         },
         "streamroller": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
-            "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.5.tgz",
+            "integrity": "sha512-iGVaMcyF5PcUY0cPbW3xFQUXnr9O4RZXNBBjhuLZgrjLO4XCLLGfx4T2sGqygSeylUjwgWRsnNbT9aV0Zb8AYw==",
             "dev": true,
             "requires": {
-                "date-format": "^1.2.0",
-                "debug": "^3.1.0",
-                "mkdirp": "^0.5.1",
-                "readable-stream": "^2.3.0"
+                "async": "^2.6.2",
+                "date-format": "^2.0.0",
+                "debug": "^3.2.6",
+                "fs-extra": "^7.0.1",
+                "lodash": "^4.17.11"
             },
             "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                "async": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "lodash": "^4.17.11"
                     }
                 },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                "fs-extra": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.15",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+                    "dev": true
+                },
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
                     }
                 }
             }
@@ -9139,6 +12967,12 @@
             "integrity": "sha1-fMKRUfD18sQZRvEZ9ZMv5VQXASU=",
             "dev": true
         },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
+        },
         "tracejs": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/tracejs/-/tracejs-0.1.8.tgz",
@@ -9166,6 +13000,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
@@ -9177,13 +13012,30 @@
             "dev": true
         },
         "type-is": {
-            "version": "1.6.16",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "~2.1.18"
+                "mime-types": "~2.1.24"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.40.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+                    "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.24",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+                    "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.40.0"
+                    }
+                }
             }
         },
         "typedarray": {
@@ -9199,12 +13051,12 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-            "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+            "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
             "dev": true,
             "requires": {
-                "commander": "~2.17.1",
+                "commander": "~2.20.0",
                 "source-map": "~0.6.1"
             },
             "dependencies": {
@@ -9282,6 +13134,12 @@
                 }
             }
         },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -9335,9 +13193,9 @@
             }
         },
         "upath": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-            "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
             "dev": true
         },
         "uri-path": {
@@ -9608,7 +13466,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
     "main": "./moment.js",
     "jsnext:main": "./src/moment.js",
     "typings": "./moment.d.ts",
+    "typesVersions": {
+        ">=3.1": {
+            "*": [
+                "ts3.1-typings/*"
+            ]
+        }
+    },
     "engines": {
         "node": "*"
     },
@@ -62,6 +69,7 @@
         "karma-sauce-launcher": "latest",
         "load-grunt-tasks": "~3.5.2",
         "node-qunit": "^1.0.0",
+        "npx": "10.2.0",
         "nyc": "~11.9.0",
         "qunit": "^2.7.1",
         "rollup": "~0.67.4",
@@ -85,6 +93,7 @@
         }
     },
     "scripts": {
+        "ts3.1-typescript-test": "npx typescript@3.1 --project ts3.1-typing-tests",
         "typescript-test": "tsc --project typing-tests",
         "test": "grunt test",
         "coverage": "nyc npm test && nyc report",

--- a/ts3.1-typing-tests/moment-tests.ts
+++ b/ts3.1-typing-tests/moment-tests.ts
@@ -1,0 +1,511 @@
+/// <reference path="../ts3.1-typings/moment.d.ts" />
+import moment = require('../ts3.1-typings/moment');
+
+moment.parseTwoDigitYear("50");
+
+moment().add('hours', 1).fromNow();
+
+var day = new Date(2011, 9, 16);
+var dayWrapper = moment(day);
+var otherDay = moment(new Date(2020, 3, 7));
+
+var day1 = moment(1318781876406);
+var day2 = moment.unix(1318781876);
+var day3 = moment("Dec 25, 1995");
+var day4 = moment("12-25-1995", "MM-DD-YYYY");
+var day5 = moment("12-25-1995", ["MM-DD-YYYY", "YYYY-MM-DD"]);
+var day6 = moment("05-06-1995", ["MM-DD-YYYY", "DD-MM-YYYY"]);
+var now = moment();
+var day7 = moment([2010, 1, 14, 15, 25, 50, 125]);
+var day8 = moment([2010]);
+var day9 = moment([2010, 6]);
+var day10 = moment([2010, 6, 10]);
+var array = [2010, 1, 14, 15, 25, 50, 125];
+var day11 = moment(Date.UTC.apply({}, array));
+var day12 = moment.unix(1318781876);
+
+moment(null);
+moment(undefined);
+moment({ years: 2010, months: 3, days: 5, hours: 15, minutes: 10, seconds: 3, milliseconds: 123 });
+moment("20140101", "YYYYMMDD", true);
+moment("20140101", "YYYYMMDD", "en");
+moment("20140101", "YYYYMMDD", "en", true);
+moment("20140101", ["YYYYMMDD"], true);
+moment("20140101", ["YYYYMMDD"], "en");
+moment("20140101", ["YYYYMMDD"], "en", true);
+
+moment(day.toISOString(), moment.ISO_8601);
+moment(day.toISOString(), moment.ISO_8601, true);
+moment(day.toISOString(), moment.ISO_8601, "en", true);
+moment(day.toISOString(), [moment.ISO_8601]);
+moment(day.toISOString(), [moment.ISO_8601], true);
+moment(day.toISOString(), [moment.ISO_8601], "en", true);
+
+moment(day.toUTCString(), moment.RFC_2822);
+moment(day.toUTCString(), moment.RFC_2822, true);
+moment(day.toUTCString(), moment.RFC_2822, "en", true);
+moment(day.toUTCString(), [moment.RFC_2822]);
+moment(day.toUTCString(), [moment.RFC_2822], true);
+moment(day.toUTCString(), [moment.RFC_2822], "en", true);
+
+var a = moment([2012]);
+var b = moment(a);
+a.year(2000);
+b.year(); // 2012
+
+moment.utc();
+moment.utc(12345);
+moment.utc([12, 34, 56]);
+moment.utc({ years: 2010, months: 3, days: 5, hours: 15, minutes: 10, seconds: 3, milliseconds: 123 });
+moment.utc("1-2-3");
+moment.utc("1-2-3", "3-2-1");
+moment.utc("1-2-3", "3-2-1", true);
+moment.utc("1-2-3", "3-2-1", "en");
+moment.utc("1-2-3", "3-2-1", "en", true);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"]);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], true);
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], "en");
+moment.utc("01-01-2014", ["DD-MM-YYYY", "MM-DD-YYYY"], "en", true);
+
+var a2 = moment.utc([2011, 0, 1, 8]);
+a.hours();
+a.local();
+a.hours();
+
+moment("2011-10-10", "YYYY-MM-DD").isValid();
+moment("2011-10-50", "YYYY-MM-DD").isValid();
+moment("2011-10-10T10:20:90").isValid();
+moment([2011, 0, 1]).isValid();
+moment([2011, 0, 50]).isValid();
+moment("not a date").isValid();
+
+moment().add('days', 7).subtract('months', 1).year(2009).hours(0).minutes(0).seconds(0);
+
+moment().add('days', 7);
+moment().add('days', 7).add('months', 1);
+moment().add({days:7,months:1});
+moment().add('milliseconds', 1000000);
+moment().add('days', 360);
+moment([2010, 0, 31]);
+moment([2010, 0, 31]).add('months', 1);
+var m = moment(new Date(2011, 2, 12, 5, 0, 0));
+m.hours();
+m.add('days', 1).hours();
+var m2 = moment(new Date(2011, 2, 12, 5, 0, 0));
+m2.hours();
+m2.add('hours', 24).hours();
+var duration = moment.duration({'days': 1});
+moment([2012, 0, 31]).add(duration);
+
+moment().add('seconds', 1);
+moment().add(1, 'seconds');
+
+moment().add('1', 'seconds');
+
+moment().subtract('days', 7);
+
+moment().seconds(30);
+moment().minutes(30);
+
+moment().hours(12);
+moment().date(5);
+moment().day(5);
+moment().day("Sunday");
+moment().month(5);
+moment().month("January");
+moment().year(1984);
+moment().startOf('year');
+moment().month(0).date(1).hours(0).minutes(0).seconds(0).milliseconds(0);
+moment().startOf('hour');
+moment().minutes(0).seconds(0).milliseconds(0);
+moment().weekday();
+moment().weekday(0);
+moment().isoWeekday(1);
+moment().isoWeekday();
+moment().weekYear(2);
+moment().weekYear();
+moment().isoWeekYear(3);
+moment().isoWeekYear();
+moment().week();
+moment().week(45);
+moment().weeks();
+moment().weeks(45);
+moment().isoWeek();
+moment().isoWeek(45);
+moment().isoWeeks();
+moment().isoWeeks(45);
+moment().dayOfYear();
+moment().dayOfYear(45);
+
+moment().set('year', 2013);
+moment().set('month', 3);  // April
+moment().set('date', 1);
+moment().set('hour', 13);
+moment().set('minute', 20);
+moment().set('second', 30);
+moment().set('millisecond', 123);
+moment().set({'year': 2013, 'month': 3});
+
+var getMilliseconds: number = moment().milliseconds();
+var getSeconds: number = moment().seconds();
+var getMinutes: number = moment().minutes();
+var getHours: number = moment().hours();
+var getDate: number = moment().date();
+var getDay: number = moment().day();
+var getMonth: number = moment().month();
+var getQuater: number = moment().quarter();
+var getYear: number = moment().year();
+
+moment().hours(0).minutes(0).seconds(0).milliseconds(0);
+
+var a3 = moment([2011, 0, 1, 8]);
+a3.hours();
+a3.utc();
+a3.hours();
+
+var a4 = moment([2010, 1, 14, 15, 25, 50, 125]);
+a4.format("dddd, MMMM Do YYYY, h:mm:ss a");
+a4.format("ddd, hA");
+
+moment().format('\\L');
+moment().format('[today] DDDD');
+
+var a5 = moment([2007, 0, 29]);
+var b5 = moment([2007, 0, 28]);
+a5.from(b5);
+
+var a6 = moment([2007, 0, 29]);
+var b6 = moment([2007, 0, 28]);
+a6.from(b6);
+a6.from([2007, 0, 28]);
+a6.from(new Date(2007, 0, 28));
+a6.from("1-28-2007");
+
+var a7 = moment();
+var b7 = moment("10-10-1900", "MM-DD-YYYY");
+a7.from(b7);
+
+var start = moment([2007, 0, 5]);
+var end = moment([2007, 0, 10]);
+start.from(end);
+start.from(end, true);
+
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow();
+moment([2007, 0, 29]).fromNow(true);
+
+var a8 = moment([2007, 0, 29]);
+var b8 = moment([2007, 0, 28]);
+a8.diff(b8) ;
+a8.diff(b8, 'days');
+a8.diff(b8, 'years')
+a8.diff(b8, 'years', true);
+
+moment.min([a8, b8]);
+moment.min(a8, b8);
+moment.max([a8, b8]);
+moment.max(a8, b8);
+
+moment([2007, 0, 29]).toDate();
+moment([2007, 1, 23]).toISOString();
+moment(1318874398806).valueOf();
+moment(1318874398806).unix();
+moment([2000]).isLeapYear();
+moment().zone();
+moment().utcOffset();
+moment("2012-2", "YYYY-MM").daysInMonth();
+moment([2011, 2, 12]).isDST();
+
+moment.isMoment(new Date());
+moment.isMoment(moment());
+
+moment.isDate(new Date());
+moment.isDate(/regexp/);
+
+moment.isDuration(new Date());
+moment.isDuration(moment.duration());
+
+moment().isBetween(moment(), moment());
+moment().isBetween(new Date(), new Date());
+moment().isBetween([1,1,2000], [1,1,2001], "year");
+moment().isBetween([1,1,2000], [1,1,2001], null, "()");
+
+moment.localeData('fr');
+moment(1316116057189).fromNow();
+
+moment.localeData('en');
+var globalLang = moment();
+var localLang = moment();
+localLang.localeData();
+localLang.format('LLLL');
+globalLang.format('LLLL');
+
+moment.duration(null);
+moment.duration(undefined);
+moment.duration(100);
+moment.duration(2, 'seconds');
+moment.duration({
+    seconds: 2,
+    minutes: 2,
+    hours: 2,
+    days: 2,
+    weeks: 2,
+    months: 2,
+    years: 2
+});
+moment.duration({
+    s: 2,
+    m: 2,
+    h: 2,
+    d: 2,
+    w: 2,
+    M: 2,
+    y: 2,
+});
+moment.duration(1, "minute").clone();
+moment.duration(1, "minutes").humanize();
+moment.duration(500).milliseconds();
+moment.duration(500).asMilliseconds();
+moment.duration(500).seconds();
+moment.duration(500).asSeconds();
+moment.duration().minutes();
+moment.duration().asMinutes();
+moment.duration().toISOString();
+moment.duration().toJSON();
+
+var adur = moment.duration(3, 'd');
+var bdur = moment.duration(2, 'd');
+adur.subtract(bdur).days();
+adur.subtract(1).days();
+adur.subtract(1, 'd').days();
+
+// Selecting a language
+moment.locale();
+moment.locale('en');
+moment.locale(['en', 'fr']);
+
+moment.defineLocale('en', null);
+moment.updateLocale('en', null);
+moment.locale('en', null);
+
+// Defining a custom language:
+moment.locale('en', {
+    months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    weekdays: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    weekdaysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    weekdaysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+    longDateFormat: {
+        LTS: "h:mm:ss A",
+        LT: "h:mm A",
+        L: "MM/DD/YYYY",
+        LL: "MMMM D YYYY",
+        LLL: "MMMM D YYYY LT",
+        LLLL: "dddd, MMMM D YYYY LT"
+    },
+    relativeTime: {
+        future: "in %s",
+        past: "%s ago",
+        s: "seconds",
+        ss: "%d seconds",
+        m: "a minute",
+        mm: "%d minutes",
+        h: "an hour",
+        hh: "%d hours",
+        d: "a day",
+        dd: "%d days",
+        M: "a month",
+        MM: "%d months",
+        y: "a year",
+        yy: "%d years"
+    },
+    meridiem: function (hour: number, minute: number, isLower: boolean) {
+        if (hour < 9) {
+            return "??";
+        } else if (hour < 11 && minute < 30) {
+            return "??";
+        } else if (hour < 13 && minute < 30) {
+            return "??";
+        } else if (hour < 18) {
+            return "??";
+        } else {
+            return "??";
+        }
+    },
+    calendar: {
+        lastDay: '[Yesterday at] LT',
+        sameDay: '[Today at] LT',
+        nextDay: '[Tomorrow at] LT',
+        lastWeek: '[last] dddd [at] LT',
+        nextWeek: 'dddd [at] LT',
+        sameElse: 'L'
+    },
+    ordinal: function (number: number) {
+        var b = number % 10;
+        return (~~(number % 100 / 10) === 1) ? 'th' :
+            (b === 1) ? 'st' :
+            (b === 2) ? 'nd' :
+            (b === 3) ? 'rd' : 'th';
+    },
+    week: {
+        dow: 1,
+        doy: 4
+    }
+});
+
+moment.locale('en', {
+    months : [
+        "January", "February", "March", "April", "May", "June", "July",
+        "August", "September", "October", "November", "December"
+    ]
+});
+
+moment.locale('en', {
+    months : function (momentToFormat: moment.Moment, format: string) {
+        // momentToFormat is the moment currently being formatted
+        // format is the formatting string
+        if (/^MMMM/.test(format)) { // if the format starts with 'MMMM'
+            return this.nominative[momentToFormat.month()];
+        } else {
+            return this.subjective[momentToFormat.month()];
+        }
+    }
+});
+
+moment.locale('en', {
+    monthsShort : [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    ]
+});
+
+moment.locale('en', {
+    monthsShort : function (momentToFormat: moment.Moment, format: string) {
+        if (/^MMMM/.test(format)) {
+            return this.nominative[momentToFormat.month()];
+        } else {
+            return this.subjective[momentToFormat.month()];
+        }
+    }
+});
+
+moment.locale('en', {
+    weekdays : [
+        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+    ]
+});
+
+moment.locale('en', {
+    weekdays : function (momentToFormat: moment.Moment) {
+        return this.weekdays[momentToFormat.day()];
+    }
+});
+
+moment.locale('en', {
+    weekdaysShort : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+});
+
+moment.locale('en', {
+    weekdaysShort : function (momentToFormat: moment.Moment) {
+        return this.weekdaysShort[momentToFormat.day()];
+    }
+});
+
+moment.locale('en', {
+    weekdaysMin : ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+});
+
+moment.locale('en', {
+    weekdaysMin : function (momentToFormat: moment.Moment) {
+        return this.weekdaysMin[momentToFormat.day()];
+    }
+});
+
+moment.locale('en', {
+    longDateFormat : {
+        LTS: "h:mm:ss A",
+        LT: "h:mm A",
+        L: "MM/DD/YYYY",
+        l: "M/D/YYYY",
+        LL: "MMMM Do YYYY",
+        ll: "MMM D YYYY",
+        LLL: "MMMM Do YYYY LT",
+        lll: "MMM D YYYY LT",
+        LLLL: "dddd, MMMM Do YYYY LT",
+        llll: "ddd, MMM D YYYY LT"
+    }
+});
+
+moment.locale('en', {
+    longDateFormat : {
+        LTS: "h:mm A",
+        LT: "h:mm A",
+        L: "MM/DD/YYYY",
+        LL: "MMMM Do YYYY",
+        LLL: "MMMM Do YYYY LT",
+        LLLL: "dddd, MMMM Do YYYY LT"
+    }
+});
+
+moment.locale('en', {
+    relativeTime : {
+        future: "in %s",
+        past:   "%s ago",
+        s:  "seconds",
+        ss: "%d seconds",
+        m:  "a minute",
+        mm: "%d minutes",
+        h:  "an hour",
+        hh: "%d hours",
+        d:  "a day",
+        dd: "%d days",
+        M:  "a month",
+        MM: "%d months",
+        y:  "a year",
+        yy: "%d years"
+    }
+});
+
+moment.locale('en', {
+    meridiem : function (hour: number, minute: number, isLowercase: boolean) {
+        if (hour < 9) {
+            return "早上";
+        } else if (hour < 11 && minute < 30) {
+            return "上午";
+        } else if (hour < 13 && minute < 30) {
+            return "中午";
+        } else if (hour < 18) {
+            return "下午";
+        } else {
+            return "晚上";
+        }
+    }
+});
+
+moment.locale('en', {
+    calendar : {
+        lastDay : '[Yesterday at] LT',
+        sameDay : '[Today at] LT',
+        nextDay : function () {
+          return '[hoy a la' + ((this.hours() !== 1) ? 's' : '') + '] LT';
+        },
+        lastWeek : '[last] dddd [at] LT',
+        nextWeek : 'dddd [at] LT',
+        sameElse : 'L'
+    }
+});
+
+moment.locale('en', {
+    ordinal : function (number: number) {
+        var b = number % 10;
+        var output = (~~ (number % 100 / 10) === 1) ? 'th' :
+            (b === 1) ? 'st' :
+            (b === 2) ? 'nd' :
+            (b === 3) ? 'rd' : 'th';
+        return number + output;
+    }
+});
+
+console.log(moment.version);
+
+moment.defaultFormat = 'YYYY-MM-DD HH:mm';

--- a/ts3.1-typing-tests/tsconfig.json
+++ b/ts3.1-typing-tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+  },
+  "files": [
+    "../ts3.1-typings/moment.d.ts",
+    "./moment-tests.ts"
+  ],
+}

--- a/ts3.1-typing-tests/tsconfig.json
+++ b/ts3.1-typing-tests/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "lib": ["ES2015"],
   },
   "files": [
     "../ts3.1-typings/moment.d.ts",

--- a/ts3.1-typings/moment.d.ts
+++ b/ts3.1-typings/moment.d.ts
@@ -1,0 +1,737 @@
+declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, strict?: boolean): moment.Moment;
+declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, language?: string, strict?: boolean): moment.Moment;
+
+declare namespace moment {
+  type RelativeTimeKey = 's' | 'ss' | 'm' | 'mm' | 'h' | 'hh' | 'd' | 'dd' | 'M' | 'MM' | 'y' | 'yy';
+  type CalendarKey = 'sameDay' | 'nextDay' | 'lastDay' | 'nextWeek' | 'lastWeek' | 'sameElse' | string;
+  type LongDateFormatKey = 'LTS' | 'LT' | 'L' | 'LL' | 'LLL' | 'LLLL' | 'lts' | 'lt' | 'l' | 'll' | 'lll' | 'llll';
+
+  interface Locale {
+    calendar(key?: CalendarKey, m?: Moment, now?: Moment): string;
+
+    longDateFormat(key: LongDateFormatKey): string;
+    invalidDate(): string;
+    ordinal(n: number): string;
+
+    preparse(inp: string): string;
+    postformat(inp: string): string;
+    relativeTime(n: number, withoutSuffix: boolean,
+                 key: RelativeTimeKey, isFuture: boolean): string;
+    pastFuture(diff: number, absRelTime: string): string;
+    set(config: Object): void;
+
+    months(): string[];
+    months(m: Moment, format?: string): string;
+    monthsShort(): string[];
+    monthsShort(m: Moment, format?: string): string;
+    monthsParse(monthName: string, format: string, strict: boolean): number;
+    monthsRegex(strict: boolean): RegExp;
+    monthsShortRegex(strict: boolean): RegExp;
+
+    week(m: Moment): number;
+    firstDayOfYear(): number;
+    firstDayOfWeek(): number;
+
+    weekdays(): string[];
+    weekdays(m: Moment, format?: string): string;
+    weekdaysMin(): string[];
+    weekdaysMin(m: Moment): string;
+    weekdaysShort(): string[];
+    weekdaysShort(m: Moment): string;
+    weekdaysParse(weekdayName: string, format: string, strict: boolean): number;
+    weekdaysRegex(strict: boolean): RegExp;
+    weekdaysShortRegex(strict: boolean): RegExp;
+    weekdaysMinRegex(strict: boolean): RegExp;
+
+    isPM(input: string): boolean;
+    meridiem(hour: number, minute: number, isLower: boolean): string;
+  }
+
+  interface StandaloneFormatSpec {
+    format: string[];
+    standalone: string[];
+    isFormat?: RegExp;
+  }
+
+  interface WeekSpec {
+    dow: number;
+    doy?: number;
+  }
+
+  type CalendarSpecVal = string | ((m?: MomentInput, now?: Moment) => string);
+  interface CalendarSpec {
+    sameDay?: CalendarSpecVal;
+    nextDay?: CalendarSpecVal;
+    lastDay?: CalendarSpecVal;
+    nextWeek?: CalendarSpecVal;
+    lastWeek?: CalendarSpecVal;
+    sameElse?: CalendarSpecVal;
+
+    // any additional properties might be used with moment.calendarFormat
+    [x: string]: CalendarSpecVal | undefined;
+  }
+
+  type RelativeTimeSpecVal = (
+    string |
+    ((n: number, withoutSuffix: boolean,
+      key: RelativeTimeKey, isFuture: boolean) => string)
+  );
+  type RelativeTimeFuturePastVal = string | ((relTime: string) => string);
+
+  interface RelativeTimeSpec {
+    future?: RelativeTimeFuturePastVal;
+    past?: RelativeTimeFuturePastVal;
+    s?: RelativeTimeSpecVal;
+    ss?: RelativeTimeSpecVal;
+    m?: RelativeTimeSpecVal;
+    mm?: RelativeTimeSpecVal;
+    h?: RelativeTimeSpecVal;
+    hh?: RelativeTimeSpecVal;
+    d?: RelativeTimeSpecVal;
+    dd?: RelativeTimeSpecVal;
+    M?: RelativeTimeSpecVal;
+    MM?: RelativeTimeSpecVal;
+    y?: RelativeTimeSpecVal;
+    yy?: RelativeTimeSpecVal;
+  }
+
+  interface LongDateFormatSpec {
+    LTS: string;
+    LT: string;
+    L: string;
+    LL: string;
+    LLL: string;
+    LLLL: string;
+
+    // lets forget for a sec that any upper/lower permutation will also work
+    lts?: string;
+    lt?: string;
+    l?: string;
+    ll?: string;
+    lll?: string;
+    llll?: string;
+  }
+
+  type MonthWeekdayFn = (momentToFormat: Moment, format?: string) => string;
+  type WeekdaySimpleFn = (momentToFormat: Moment) => string;
+
+  interface LocaleSpecification {
+    months?: string[] | StandaloneFormatSpec | MonthWeekdayFn;
+    monthsShort?: string[] | StandaloneFormatSpec | MonthWeekdayFn;
+
+    weekdays?: string[] | StandaloneFormatSpec | MonthWeekdayFn;
+    weekdaysShort?: string[] | StandaloneFormatSpec | WeekdaySimpleFn;
+    weekdaysMin?: string[] | StandaloneFormatSpec | WeekdaySimpleFn;
+
+    meridiemParse?: RegExp;
+    meridiem?: (hour: number, minute:number, isLower: boolean) => string;
+
+    isPM?: (input: string) => boolean;
+
+    longDateFormat?: LongDateFormatSpec;
+    calendar?: CalendarSpec;
+    relativeTime?: RelativeTimeSpec;
+    invalidDate?: string;
+    ordinal?: (n: number) => string;
+    ordinalParse?: RegExp;
+
+    week?: WeekSpec;
+
+    // Allow anything: in general any property that is passed as locale spec is
+    // put in the locale object so it can be used by locale functions
+    [x: string]: any;
+  }
+
+  interface MomentObjectOutput {
+    years: number;
+    /* One digit */
+    months: number;
+    /* Day of the month */
+    date: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    milliseconds: number;
+  }
+
+  interface Duration {
+    clone(): Duration;
+
+    humanize(withSuffix?: boolean): string;
+
+    abs(): Duration;
+
+    as(units: unitOfTime.Base): number;
+    get(units: unitOfTime.Base): number;
+
+    milliseconds(): number;
+    asMilliseconds(): number;
+
+    seconds(): number;
+    asSeconds(): number;
+
+    minutes(): number;
+    asMinutes(): number;
+
+    hours(): number;
+    asHours(): number;
+
+    days(): number;
+    asDays(): number;
+
+    weeks(): number;
+    asWeeks(): number;
+
+    months(): number;
+    asMonths(): number;
+
+    years(): number;
+    asYears(): number;
+
+    add(inp?: DurationInputArg1, unit?: DurationInputArg2): Duration;
+    subtract(inp?: DurationInputArg1, unit?: DurationInputArg2): Duration;
+
+    locale(): string;
+    locale(locale: LocaleSpecifier): Duration;
+    localeData(): Locale;
+
+    toISOString(): string;
+    toJSON(): string;
+
+    isValid(): boolean;
+
+    /**
+     * @deprecated since version 2.8.0
+     */
+    lang(locale: LocaleSpecifier): Moment;
+    /**
+     * @deprecated since version 2.8.0
+     */
+    lang(): Locale;
+    /**
+     * @deprecated
+     */
+    toIsoString(): string;
+  }
+
+  interface MomentRelativeTime {
+    future: any;
+    past: any;
+    s: any;
+    ss: any;
+    m: any;
+    mm: any;
+    h: any;
+    hh: any;
+    d: any;
+    dd: any;
+    M: any;
+    MM: any;
+    y: any;
+    yy: any;
+  }
+
+  interface MomentLongDateFormat {
+    L: string;
+    LL: string;
+    LLL: string;
+    LLLL: string;
+    LT: string;
+    LTS: string;
+
+    l?: string;
+    ll?: string;
+    lll?: string;
+    llll?: string;
+    lt?: string;
+    lts?: string;
+  }
+
+  interface MomentParsingFlags {
+    empty: boolean;
+    unusedTokens: string[];
+    unusedInput: string[];
+    overflow: number;
+    charsLeftOver: number;
+    nullInput: boolean;
+    invalidMonth: string | null;
+    invalidFormat: boolean;
+    userInvalidated: boolean;
+    iso: boolean;
+    parsedDateParts: any[];
+    meridiem: string | null;
+  }
+
+  interface MomentParsingFlagsOpt {
+    empty?: boolean;
+    unusedTokens?: string[];
+    unusedInput?: string[];
+    overflow?: number;
+    charsLeftOver?: number;
+    nullInput?: boolean;
+    invalidMonth?: string;
+    invalidFormat?: boolean;
+    userInvalidated?: boolean;
+    iso?: boolean;
+    parsedDateParts?: any[];
+    meridiem?: string | null;
+  }
+
+  interface MomentBuiltinFormat {
+    __momentBuiltinFormatBrand: any;
+  }
+
+  type MomentFormatSpecification = string | MomentBuiltinFormat | (string | MomentBuiltinFormat)[];
+
+  namespace unitOfTime {
+    type Base = (
+      "year" | "years" | "y" |
+      "month" | "months" | "M" |
+      "week" | "weeks" | "w" |
+      "day" | "days" | "d" |
+      "hour" | "hours" | "h" |
+      "minute" | "minutes" | "m" |
+      "second" | "seconds" | "s" |
+      "millisecond" | "milliseconds" | "ms"
+    );
+
+    type _quarter = "quarter" | "quarters" | "Q";
+    type _isoWeek = "isoWeek" | "isoWeeks" | "W";
+    type _date = "date" | "dates" | "D";
+    type DurationConstructor = Base | _quarter;
+
+    type DurationAs = Base;
+
+    type StartOf = Base | _quarter | _isoWeek | _date | null;
+
+    type Diff = Base | _quarter;
+
+    type MomentConstructor = Base | _date;
+
+    type All = Base | _quarter | _isoWeek | _date |
+      "weekYear" | "weekYears" | "gg" |
+      "isoWeekYear" | "isoWeekYears" | "GG" |
+      "dayOfYear" | "dayOfYears" | "DDD" |
+      "weekday" | "weekdays" | "e" |
+      "isoWeekday" | "isoWeekdays" | "E";
+  }
+
+  interface MomentInputObject {
+    years?: number;
+    year?: number;
+    y?: number;
+
+    months?: number;
+    month?: number;
+    M?: number;
+
+    days?: number;
+    day?: number;
+    d?: number;
+
+    dates?: number;
+    date?: number;
+    D?: number;
+
+    hours?: number;
+    hour?: number;
+    h?: number;
+
+    minutes?: number;
+    minute?: number;
+    m?: number;
+
+    seconds?: number;
+    second?: number;
+    s?: number;
+
+    milliseconds?: number;
+    millisecond?: number;
+    ms?: number;
+  }
+
+  interface DurationInputObject extends MomentInputObject {
+    quarters?: number;
+    quarter?: number;
+    Q?: number;
+
+    weeks?: number;
+    week?: number;
+    w?: number;
+  }
+
+  interface MomentSetObject extends MomentInputObject {
+    weekYears?: number;
+    weekYear?: number;
+    gg?: number;
+
+    isoWeekYears?: number;
+    isoWeekYear?: number;
+    GG?: number;
+
+    quarters?: number;
+    quarter?: number;
+    Q?: number;
+
+    weeks?: number;
+    week?: number;
+    w?: number;
+
+    isoWeeks?: number;
+    isoWeek?: number;
+    W?: number;
+
+    dayOfYears?: number;
+    dayOfYear?: number;
+    DDD?: number;
+
+    weekdays?: number;
+    weekday?: number;
+    e?: number;
+
+    isoWeekdays?: number;
+    isoWeekday?: number;
+    E?: number;
+  }
+
+  interface FromTo {
+    from: MomentInput;
+    to: MomentInput;
+  }
+
+  type MomentInput = Moment | Date | string | number | (number | string)[] | MomentInputObject | null | undefined;
+  type DurationInputArg1 = Duration | number | string | FromTo | DurationInputObject | null | undefined;
+  type DurationInputArg2 = unitOfTime.DurationConstructor;
+  type LocaleSpecifier = string | Moment | Duration | string[] | boolean;
+
+  interface MomentCreationData {
+    input: MomentInput;
+    format?: MomentFormatSpecification;
+    locale: Locale;
+    isUTC: boolean;
+    strict?: boolean;
+  }
+
+  interface Moment extends Object {
+    format(format?: string): string;
+
+    startOf(unitOfTime: unitOfTime.StartOf): Moment;
+    endOf(unitOfTime: unitOfTime.StartOf): Moment;
+
+    add(amount?: DurationInputArg1, unit?: DurationInputArg2): Moment;
+    /**
+     * @deprecated reverse syntax
+     */
+    add(unit: unitOfTime.DurationConstructor, amount: number|string): Moment;
+
+    subtract(amount?: DurationInputArg1, unit?: DurationInputArg2): Moment;
+    /**
+     * @deprecated reverse syntax
+     */
+    subtract(unit: unitOfTime.DurationConstructor, amount: number|string): Moment;
+
+    calendar(time?: MomentInput, formats?: CalendarSpec): string;
+
+    clone(): Moment;
+
+    /**
+     * @return Unix timestamp in milliseconds
+     */
+    valueOf(): number;
+
+    // current date/time in local mode
+    local(keepLocalTime?: boolean): Moment;
+    isLocal(): boolean;
+
+    // current date/time in UTC mode
+    utc(keepLocalTime?: boolean): Moment;
+    isUTC(): boolean;
+    /**
+     * @deprecated use isUTC
+     */
+    isUtc(): boolean;
+
+    parseZone(): Moment;
+    isValid(): boolean;
+    invalidAt(): number;
+
+    hasAlignedHourOffset(other?: MomentInput): boolean;
+
+    creationData(): MomentCreationData;
+    parsingFlags(): MomentParsingFlags;
+
+    year(y: number): Moment;
+    year(): number;
+    /**
+     * @deprecated use year(y)
+     */
+    years(y: number): Moment;
+    /**
+     * @deprecated use year()
+     */
+    years(): number;
+    quarter(): number;
+    quarter(q: number): Moment;
+    quarters(): number;
+    quarters(q: number): Moment;
+    month(M: number|string): Moment;
+    month(): number;
+    /**
+     * @deprecated use month(M)
+     */
+    months(M: number|string): Moment;
+    /**
+     * @deprecated use month()
+     */
+    months(): number;
+    day(d: number|string): Moment;
+    day(): number;
+    days(d: number|string): Moment;
+    days(): number;
+    date(d: number): Moment;
+    date(): number;
+    /**
+     * @deprecated use date(d)
+     */
+    dates(d: number): Moment;
+    /**
+     * @deprecated use date()
+     */
+    dates(): number;
+    hour(h: number): Moment;
+    hour(): number;
+    hours(h: number): Moment;
+    hours(): number;
+    minute(m: number): Moment;
+    minute(): number;
+    minutes(m: number): Moment;
+    minutes(): number;
+    second(s: number): Moment;
+    second(): number;
+    seconds(s: number): Moment;
+    seconds(): number;
+    millisecond(ms: number): Moment;
+    millisecond(): number;
+    milliseconds(ms: number): Moment;
+    milliseconds(): number;
+    weekday(): number;
+    weekday(d: number): Moment;
+    isoWeekday(): number;
+    isoWeekday(d: number|string): Moment;
+    weekYear(): number;
+    weekYear(d: number): Moment;
+    isoWeekYear(): number;
+    isoWeekYear(d: number): Moment;
+    week(): number;
+    week(d: number): Moment;
+    weeks(): number;
+    weeks(d: number): Moment;
+    isoWeek(): number;
+    isoWeek(d: number): Moment;
+    isoWeeks(): number;
+    isoWeeks(d: number): Moment;
+    weeksInYear(): number;
+    isoWeeksInYear(): number;
+    dayOfYear(): number;
+    dayOfYear(d: number): Moment;
+
+    from(inp: MomentInput, suffix?: boolean): string;
+    to(inp: MomentInput, suffix?: boolean): string;
+    fromNow(withoutSuffix?: boolean): string;
+    toNow(withoutPrefix?: boolean): string;
+
+    diff(b: MomentInput, unitOfTime?: unitOfTime.Diff, precise?: boolean): number;
+
+    toArray(): number[];
+    toDate(): Date;
+    toISOString(keepOffset?: boolean): string;
+    inspect(): string;
+    toJSON(): string;
+    unix(): number;
+
+    isLeapYear(): boolean;
+    /**
+     * @deprecated in favor of utcOffset
+     */
+    zone(): number;
+    zone(b: number|string): Moment;
+    utcOffset(): number;
+    utcOffset(b: number|string, keepLocalTime?: boolean): Moment;
+    isUtcOffset(): boolean;
+    daysInMonth(): number;
+    isDST(): boolean;
+
+    zoneAbbr(): string;
+    zoneName(): string;
+
+    isBefore(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+    isAfter(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+    isSame(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+    isSameOrAfter(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+    isSameOrBefore(inp?: MomentInput, granularity?: unitOfTime.StartOf): boolean;
+    isBetween(a: MomentInput, b: MomentInput, granularity?: unitOfTime.StartOf, inclusivity?: "()" | "[)" | "(]" | "[]"): boolean;
+
+    /**
+     * @deprecated as of 2.8.0, use locale
+     */
+    lang(language: LocaleSpecifier): Moment;
+    /**
+     * @deprecated as of 2.8.0, use locale
+     */
+    lang(): Locale;
+
+    locale(): string;
+    locale(locale: LocaleSpecifier): Moment;
+
+    localeData(): Locale;
+
+    /**
+     * @deprecated no reliable implementation
+     */
+    isDSTShifted(): boolean;
+
+    // NOTE(constructor): Same as moment constructor
+    /**
+     * @deprecated as of 2.7.0, use moment.min/max
+     */
+    max(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+    /**
+     * @deprecated as of 2.7.0, use moment.min/max
+     */
+    max(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+    // NOTE(constructor): Same as moment constructor
+    /**
+     * @deprecated as of 2.7.0, use moment.min/max
+     */
+    min(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+    /**
+     * @deprecated as of 2.7.0, use moment.min/max
+     */
+    min(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+    get(unit: unitOfTime.All): number;
+    set(unit: unitOfTime.All, value: number): Moment;
+    set(objectLiteral: MomentSetObject): Moment;
+
+    toObject(): MomentObjectOutput;
+  }
+
+  export var version: string;
+  export var fn: Moment;
+
+  // NOTE(constructor): Same as moment constructor
+  export function utc(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+  export function utc(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+  export function unix(timestamp: number): Moment;
+
+  export function invalid(flags?: MomentParsingFlagsOpt): Moment;
+  export function isMoment(m: any): m is Moment;
+  export function isDate(m: any): m is Date;
+  export function isDuration(d: any): d is Duration;
+
+  /**
+   * @deprecated in 2.8.0
+   */
+  export function lang(language?: string): string;
+  /**
+   * @deprecated in 2.8.0
+   */
+  export function lang(language?: string, definition?: Locale): string;
+
+  export function locale(language?: string): string;
+  export function locale(language?: string[]): string;
+  export function locale(language?: string, definition?: LocaleSpecification | null | undefined): string;
+
+  export function localeData(key?: string | string[]): Locale;
+
+  export function duration(inp?: DurationInputArg1, unit?: DurationInputArg2): Duration;
+
+  // NOTE(constructor): Same as moment constructor
+  export function parseZone(inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean): Moment;
+  export function parseZone(inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean): Moment;
+
+  export function months(): string[];
+  export function months(index: number): string;
+  export function months(format: string): string[];
+  export function months(format: string, index: number): string;
+  export function monthsShort(): string[];
+  export function monthsShort(index: number): string;
+  export function monthsShort(format: string): string[];
+  export function monthsShort(format: string, index: number): string;
+
+  export function weekdays(): string[];
+  export function weekdays(index: number): string;
+  export function weekdays(format: string): string[];
+  export function weekdays(format: string, index: number): string;
+  export function weekdays(localeSorted: boolean): string[];
+  export function weekdays(localeSorted: boolean, index: number): string;
+  export function weekdays(localeSorted: boolean, format: string): string[];
+  export function weekdays(localeSorted: boolean, format: string, index: number): string;
+  export function weekdaysShort(): string[];
+  export function weekdaysShort(index: number): string;
+  export function weekdaysShort(format: string): string[];
+  export function weekdaysShort(format: string, index: number): string;
+  export function weekdaysShort(localeSorted: boolean): string[];
+  export function weekdaysShort(localeSorted: boolean, index: number): string;
+  export function weekdaysShort(localeSorted: boolean, format: string): string[];
+  export function weekdaysShort(localeSorted: boolean, format: string, index: number): string;
+  export function weekdaysMin(): string[];
+  export function weekdaysMin(index: number): string;
+  export function weekdaysMin(format: string): string[];
+  export function weekdaysMin(format: string, index: number): string;
+  export function weekdaysMin(localeSorted: boolean): string[];
+  export function weekdaysMin(localeSorted: boolean, index: number): string;
+  export function weekdaysMin(localeSorted: boolean, format: string): string[];
+  export function weekdaysMin(localeSorted: boolean, format: string, index: number): string;
+
+  export function min(moments: Moment[]): Moment;
+  export function min(...moments: Moment[]): Moment;
+  export function max(moments: Moment[]): Moment;
+  export function max(...moments: Moment[]): Moment;
+
+  /**
+   * Returns unix time in milliseconds. Overwrite for profit.
+   */
+  export function now(): number;
+
+  export function defineLocale(language: string, localeSpec: LocaleSpecification | null): Locale;
+  export function updateLocale(language: string, localeSpec: LocaleSpecification | null): Locale;
+
+  export function locales(): string[];
+
+  export function normalizeUnits(unit: unitOfTime.All): string;
+  export function relativeTimeThreshold(threshold: string): number | boolean;
+  export function relativeTimeThreshold(threshold: string, limit: number): boolean;
+  export function relativeTimeRounding(fn: (num: number) => number): boolean;
+  export function relativeTimeRounding(): (num: number) => number;
+  export function calendarFormat(m: Moment, now: Moment): string;
+
+  export function parseTwoDigitYear(input: string): number;
+
+  /**
+   * Constant used to enable explicit ISO_8601 format parsing.
+   */
+  export var ISO_8601: MomentBuiltinFormat;
+  export var RFC_2822: MomentBuiltinFormat;
+
+  export var defaultFormat: string;
+  export var defaultFormatUtc: string;
+
+  export var HTML5_FMT: {
+    DATETIME_LOCAL: string,
+    DATETIME_LOCAL_SECONDS: string,
+    DATETIME_LOCAL_MS: string,
+    DATE: string,
+    TIME: string,
+    TIME_SECONDS: string,
+    TIME_MS: string,
+    WEEK: string,
+    MONTH: string
+  };
+
+}
+
+export = moment;
+export as namespace moment;


### PR DESCRIPTION
This is an attempt to make use of typescript 3.1 feature `typesVersions` https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions so people with newer versions of typescript can use correct types for moment i.e. with `null | undefined`.
This should not break types for <2.0 user, nothing changes for >=2.0 <3.1 users as well, this only should affect people with >=3.1 typescript version.

Related: https://github.com/moment/moment/issues/3617 https://github.com/moment/moment/pull/3591 https://github.com/moment/moment/pull/3688 https://github.com/moment/moment/issues/4073