### PR TITLE
[locale] Update zh-hk meridiem hour range

### DIFF
--- a/src/locale/zh-hk.js
+++ b/src/locale/zh-hk.js
@@ -3,6 +3,7 @@
 //! author : Ben : https://github.com/ben-lin
 //! author : Chris Lam : https://github.com/hehachris
 //! author : Konstantin : https://github.com/skfd
+//! author : Anthony : https://github.com/anthonylau
 
 import moment from '../moment';
 

--- a/src/locale/zh-hk.js
+++ b/src/locale/zh-hk.js
@@ -43,9 +43,9 @@ export default moment.defineLocale('zh-hk', {
             return '凌晨';
         } else if (hm < 900) {
             return '早上';
-        } else if (hm < 1130) {
+        } else if (hm < 1200) {
             return '上午';
-        } else if (hm < 1230) {
+        } else if (hm === 1200) {
             return '中午';
         } else if (hm < 1800) {
             return '下午';

--- a/src/test/locale/zh-hk.js
+++ b/src/test/locale/zh-hk.js
@@ -169,16 +169,16 @@ test('calendar all else', function (assert) {
 test('meridiem', function (assert) {
     assert.equal(moment([2011, 2, 23,  0, 0]).format('a'), '凌晨', 'before dawn');
     assert.equal(moment([2011, 2, 23,  6, 0]).format('a'), '早上', 'morning');
-    assert.equal(moment([2011, 2, 23,  9, 0]).format('a'), '上午', 'before noon');
+    assert.equal(moment([2011, 2, 23,  11, 59]).format('a'), '上午', 'before noon');
     assert.equal(moment([2011, 2, 23, 12, 0]).format('a'), '中午', 'noon');
-    assert.equal(moment([2011, 2, 23, 13, 0]).format('a'), '下午', 'after noon');
+    assert.equal(moment([2011, 2, 23, 12, 1]).format('a'), '下午', 'after noon');
     assert.equal(moment([2011, 2, 23, 18, 0]).format('a'), '晚上', 'night');
 
     assert.equal(moment([2011, 2, 23,  0, 0]).format('A'), '凌晨', 'before dawn');
     assert.equal(moment([2011, 2, 23,  6, 0]).format('A'), '早上', 'morning');
-    assert.equal(moment([2011, 2, 23,  9, 0]).format('A'), '上午', 'before noon');
+    assert.equal(moment([2011, 2, 23,  11, 59]).format('A'), '上午', 'before noon');
     assert.equal(moment([2011, 2, 23, 12, 0]).format('A'), '中午', 'noon');
-    assert.equal(moment([2011, 2, 23, 13, 0]).format('A'), '下午', 'afternoon');
+    assert.equal(moment([2011, 2, 23, 12, 1]).format('A'), '下午', 'afternoon');
     assert.equal(moment([2011, 2, 23, 18, 0]).format('A'), '晚上', 'night');
 });
 


### PR DESCRIPTION
In Hong Kong, `中午` is exactly 1200

References
* `第二節 (上午11時30分至下午1時)` 1130 `上午` https://www.legco.gov.hk/yr18-19/chinese/bc/bc54/agenda/bc5420190427.htm
* `上午11時30分至中午12時` 1200 `中午`  https://www.gov.hk/tc/theme/bf/consultation/10104.htm
* `上 午 9 時 至 下 午 12 時 30 分` 1230 `下午` https://www.immd.gov.hk/hkt/services/travel_document/immigrationoffices.html