### PR TITLE
[locale] use correct abbreviations for months and weekdays

### DIFF
--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -2,12 +2,13 @@
 //! locale : Norwegian Bokmål [nb]
 //! authors : Espen Hovlandsdal : https://github.com/rexxars
 //!           Sigurd Gartmann : https://github.com/sigurdga
+//!           Stephen Ramthun : https://github.com/stephenramthun
 
 import moment from '../moment';
 
 export default moment.defineLocale('nb', {
     months : 'januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember'.split('_'),
-    monthsShort : 'jan._feb._mars_april_mai_juni_juli_aug._sep._okt._nov._des.'.split('_'),
+    monthsShort : 'jan._feb._mars_apr._mai_juni_juli_aug._sep._okt._nov._des.'.split('_'),
     monthsParseExact : true,
     weekdays : 'søndag_mandag_tirsdag_onsdag_torsdag_fredag_lørdag'.split('_'),
     weekdaysShort : 'sø._ma._ti._on._to._fr._lø.'.split('_'),

--- a/src/locale/nn.js
+++ b/src/locale/nn.js
@@ -1,15 +1,18 @@
 //! moment.js locale configuration
 //! locale : Nynorsk [nn]
-//! author : https://github.com/mechuwind
+//! authors : https://github.com/mechuwind
+//!           Stephen Ramthun : https://github.com/stephenramthun
 
 import moment from '../moment';
 
 export default moment.defineLocale('nn', {
     months : 'januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember'.split('_'),
-    monthsShort : 'jan_feb_mar_apr_mai_jun_jul_aug_sep_okt_nov_des'.split('_'),
+    monthsShort : 'jan._feb._mars_apr._mai_juni_juli_aug._sep._okt._nov._des.'.split('_'),
+    monthsParseExact : true,
     weekdays : 'sundag_måndag_tysdag_onsdag_torsdag_fredag_laurdag'.split('_'),
-    weekdaysShort : 'sun_mån_tys_ons_tor_fre_lau'.split('_'),
-    weekdaysMin : 'su_må_ty_on_to_fr_lø'.split('_'),
+    weekdaysShort : 'su._må._ty._on._to._fr._lau.'.split('_'),
+    weekdaysMin : 'su_må_ty_on_to_fr_la'.split('_'),
+    weekdaysParseExact : true,
     longDateFormat : {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',

--- a/src/test/locale/nb.js
+++ b/src/test/locale/nb.js
@@ -4,7 +4,7 @@ import moment from '../../moment';
 localeModule('nb');
 
 test('parse', function (assert) {
-    var tests = 'januar jan._februar feb._mars mars_april april_mai mai_juni juni_juli juli_august aug._september sep._oktober okt._november nov._desember des.'.split('_'),
+    var tests = 'januar jan._februar feb._mars mars_april apr._mai mai_juni juni_juli juli_august aug._september sep._oktober okt._november nov._desember des.'.split('_'),
         i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
@@ -93,7 +93,7 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'januar jan._februar feb._mars mars_april april_mai mai_juni juni_juli juli_august aug._september sep._oktober okt._november nov._desember des.'.split('_'), i;
+    var expected = 'januar jan._februar feb._mars mars_april apr._mai mai_juni juni_juli juli_august aug._september sep._oktober okt._november nov._desember des.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }

--- a/src/test/locale/nn.js
+++ b/src/test/locale/nn.js
@@ -4,7 +4,7 @@ import moment from '../../moment';
 localeModule('nn');
 
 test('parse', function (assert) {
-    var tests = 'januar jan_februar feb_mars mar_april apr_mai mai_juni jun_juli jul_august aug_september sep_oktober okt_november nov_desember des'.split('_'), i;
+    var tests = 'januar jan._februar feb._mars mars_april apr._mai mai_juni juni_juli juli_august aug._september sep._oktober okt._november nov._desember des.'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -24,11 +24,11 @@ test('parse', function (assert) {
 test('format', function (assert) {
     var a = [
             ['dddd, MMMM Do YYYY, h:mm:ss a',      'sundag, februar 14. 2010, 3:25:50 pm'],
-            ['ddd, hA',                            'sun, 3PM'],
-            ['M Mo MM MMMM MMM',                   '2 2. 02 februar feb'],
+            ['ddd, hA',                            'su., 3PM'],
+            ['M Mo MM MMMM MMM',                   '2 2. 02 februar feb.'],
             ['YYYY YY',                            '2010 10'],
             ['D Do DD',                            '14 14. 14'],
-            ['d do dddd ddd dd',                   '0 0. sundag sun su'],
+            ['d do dddd ddd dd',                   '0 0. sundag su. su'],
             ['DDD DDDo DDDD',                      '45 45. 045'],
             ['w wo ww',                            '6 6. 06'],
             ['h hh',                               '3 03'],
@@ -43,9 +43,9 @@ test('format', function (assert) {
             ['LLL',                                '14. februar 2010 kl. 15:25'],
             ['LLLL',                               'sundag 14. februar 2010 kl. 15:25'],
             ['l',                                  '14.2.2010'],
-            ['ll',                                 '14. feb 2010'],
-            ['lll',                                '14. feb 2010 kl. 15:25'],
-            ['llll',                               'sun 14. feb 2010 kl. 15:25']
+            ['ll',                                 '14. feb. 2010'],
+            ['lll',                                '14. feb. 2010 kl. 15:25'],
+            ['llll',                               'su. 14. feb. 2010 kl. 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -92,14 +92,14 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'januar jan_februar feb_mars mar_april apr_mai mai_juni jun_juli jul_august aug_september sep_oktober okt_november nov_desember des'.split('_'), i;
+    var expected = 'januar jan._februar feb._mars mars_april apr._mai mai_juni juni_juli juli_august aug._september sep._oktober okt._november nov._desember des.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }
 });
 
 test('format week', function (assert) {
-    var expected = 'sundag sun su_måndag mån må_tysdag tys ty_onsdag ons on_torsdag tor to_fredag fre fr_laurdag lau lø'.split('_'), i;
+    var expected = 'sundag su. su_måndag må. må_tysdag ty. ty_onsdag on. on_torsdag to. to_fredag fr. fr_laurdag lau. la'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, 0, 2 + i]).format('dddd ddd dd'), expected[i], expected[i]);
     }


### PR DESCRIPTION
The Language Council of Norway has [a list of officially recognized abbreviations](https://www.sprakradet.no/sprakhjelp/Skriveregler/Forkortinger/) for dates, months and weekdays (among other things).

The abbreviations used in momentjs for locales `nn` and `nb` were wrong based on this list, so I took the liberty to update them.

@sigurdga 