### PR TITLE
[bugfix] Fixing right-hand instanceof on missing Function

### DIFF
--- a/src/lib/utils/is-function.js
+++ b/src/lib/utils/is-function.js
@@ -1,3 +1,3 @@
 export default function isFunction(input) {
-    return input instanceof Function || Object.prototype.toString.call(input) === '[object Function]';
+    return Function !== undefined && input instanceof Function || Object.prototype.toString.call(input) === '[object Function]';
 }

--- a/src/lib/utils/is-function.js
+++ b/src/lib/utils/is-function.js
@@ -1,3 +1,3 @@
 export default function isFunction(input) {
-    return Function !== undefined && input instanceof Function || Object.prototype.toString.call(input) === '[object Function]';
+    return typeof Function !== 'undefined' && input instanceof Function || Object.prototype.toString.call(input) === '[object Function]';
 }


### PR DESCRIPTION
### Issue being fixed or implemented  
In some specific context (running js in protected area, in eval conditions), Function might not be available (see / run pastebin here : https://pastebin.com/dPjgkbs9). Therefore, trying to convert unix to isoString will fail with a `TypeError: Right-hand side of 'instanceof' is not an object`.
This PR tries to fix that.

### What was done  
- Added simple Function existance verification in isFunction

### Notes  

Fixes https://github.com/moment/moment/issues/5173.

