### PR TITLE
[locale] Remove abbreviation period for may in SL locale

### DIFF
--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -88,7 +88,7 @@ function processRelativeTime(number, withoutSuffix, key, isFuture) {
 
 export default moment.defineLocale('sl', {
     months : 'januar_februar_marec_april_maj_junij_julij_avgust_september_oktober_november_december'.split('_'),
-    monthsShort : 'jan._feb._mar._apr._maj._jun._jul._avg._sep._okt._nov._dec.'.split('_'),
+    monthsShort : 'jan._feb._mar._apr._maj_jun._jul._avg._sep._okt._nov._dec.'.split('_'),
     monthsParseExact: true,
     weekdays : 'nedelja_ponedeljek_torek_sreda_četrtek_petek_sobota'.split('_'),
     weekdaysShort : 'ned._pon._tor._sre._čet._pet._sob.'.split('_'),

--- a/src/test/locale/sl.js
+++ b/src/test/locale/sl.js
@@ -92,7 +92,7 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'januar jan._februar feb._marec mar._april apr._maj maj._junij jun._julij jul._avgust avg._september sep._oktober okt._november nov._december dec.'.split('_'), i;
+    var expected = 'januar jan._februar feb._marec mar._april apr._maj maj_junij jun._julij jul._avgust avg._september sep._oktober okt._november nov._december dec.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }


### PR DESCRIPTION
In the Slovene language the word for month `may` is `maj` and does not need to be abbreviated with a period like other months.

Mentioning original author for approval as per contributing instructions:
@sedovsek 