### PR TITLE
[feature] TypeScript: Expose type definitions to plain .js files lacking any imports

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -734,3 +734,5 @@ declare namespace moment {
 }
 
 export = moment;
+
+export as namespace moment;

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "qunit": "^2.7.1",
         "rollup": "~0.67.4",
         "spacejam": "latest",
-        "typescript": "^1.8.10",
+        "typescript": "^2.0.10",
         "uglify-js": "latest"
     },
     "ender": "./ender.js",

--- a/typing-tests/moment-js-tests.js
+++ b/typing-tests/moment-js-tests.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+// Ensure can instantiate moment
+console.log(moment().toString());
+
+// Ensure can refer to type: moment.Moment
+function cloneMoment(/** @type moment.Moment */m) {
+    return moment(m);
+}
+cloneMoment(moment());

--- a/typing-tests/tsconfig.json
+++ b/typing-tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "target": "es6",
     "module": "commonjs",
     "noEmit": true,
     "noImplicitAny": true

--- a/typing-tests/tsconfig.json
+++ b/typing-tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "es6",
+    "lib": ["ES2015"],
     "module": "commonjs",
     "noEmit": true,
     "noImplicitAny": true,

--- a/typing-tests/tsconfig.json
+++ b/typing-tests/tsconfig.json
@@ -4,10 +4,12 @@
     "target": "es6",
     "module": "commonjs",
     "noEmit": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "allowJs": true
   },
   "files": [
     "../moment.d.ts",
+    "./moment-js-tests.js",
     "./moment-tests.ts"
   ]
 }


### PR DESCRIPTION
It is now possible to use the `moment` global from a .js file and have TypeScript typecheck that .js file without complaining.

Test case:

```
# (npm install developer version of "moment" with this change)
$ npm install typescript
$ echo 'document.querySelector("body").textContent = moment().toString();' > index.js
$ node_modules/.bin/tsc --allowJs --checkJs --noEmit index.js
# (no errors)
```

Without this change, you would receive the errors:

```
index.js:1:46 - error TS2304: Cannot find name 'moment'.

1 document.querySelector("body").textContent = moment().toString();
                                               ~~~~~~
Found 1 error.
```