### PR TITLE
[locale] Fix incorrect Slovak translation "za" -> "o"

### DIFF
--- a/src/locale/sk.js
+++ b/src/locale/sk.js
@@ -124,7 +124,7 @@ export default moment.defineLocale('sk', {
         sameElse: 'L'
     },
     relativeTime : {
-        future : 'za %s',
+        future : 'o %s',
         past : 'pred %s',
         s : translate,
         ss : translate,

--- a/src/test/locale/sk.js
+++ b/src/test/locale/sk.js
@@ -138,7 +138,7 @@ test('from', function (assert) {
 });
 
 test('suffix', function (assert) {
-    assert.equal(moment(30000).from(0), 'za pár sekúnd',  'prefix');
+    assert.equal(moment(30000).from(0), 'o pár sekúnd',  'prefix');
     assert.equal(moment(0).from(30000), 'pred pár sekundami', 'suffix');
 });
 
@@ -147,22 +147,22 @@ test('now from now', function (assert) {
 });
 
 test('fromNow (future)', function (assert) {
-    assert.equal(moment().add({s: 30}).fromNow(), 'za pár sekúnd', 'in a few seconds');
-    assert.equal(moment().add({m: 1}).fromNow(), 'za minútu', 'in a minute');
-    assert.equal(moment().add({m: 3}).fromNow(), 'za 3 minúty', 'in 3 minutes');
-    assert.equal(moment().add({m: 10}).fromNow(), 'za 10 minút', 'in 10 minutes');
-    assert.equal(moment().add({h: 1}).fromNow(), 'za hodinu', 'in an hour');
-    assert.equal(moment().add({h: 3}).fromNow(), 'za 3 hodiny', 'in 3 hours');
-    assert.equal(moment().add({h: 10}).fromNow(), 'za 10 hodín', 'in 10 hours');
-    assert.equal(moment().add({d: 1}).fromNow(), 'za deň', 'in a day');
-    assert.equal(moment().add({d: 3}).fromNow(), 'za 3 dni', 'in 3 days');
-    assert.equal(moment().add({d: 10}).fromNow(), 'za 10 dní', 'in 10 days');
-    assert.equal(moment().add({M: 1}).fromNow(), 'za mesiac', 'in a month');
-    assert.equal(moment().add({M: 3}).fromNow(), 'za 3 mesiace', 'in 3 months');
-    assert.equal(moment().add({M: 10}).fromNow(), 'za 10 mesiacov', 'in 10 months');
-    assert.equal(moment().add({y: 1}).fromNow(), 'za rok', 'in a year');
-    assert.equal(moment().add({y: 3}).fromNow(), 'za 3 roky', 'in 3 years');
-    assert.equal(moment().add({y: 10}).fromNow(), 'za 10 rokov', 'in 10 years');
+    assert.equal(moment().add({s: 30}).fromNow(), 'o pár sekúnd', 'in a few seconds');
+    assert.equal(moment().add({m: 1}).fromNow(), 'o minútu', 'in a minute');
+    assert.equal(moment().add({m: 3}).fromNow(), 'o 3 minúty', 'in 3 minutes');
+    assert.equal(moment().add({m: 10}).fromNow(), 'o 10 minút', 'in 10 minutes');
+    assert.equal(moment().add({h: 1}).fromNow(), 'o hodinu', 'in an hour');
+    assert.equal(moment().add({h: 3}).fromNow(), 'o 3 hodiny', 'in 3 hours');
+    assert.equal(moment().add({h: 10}).fromNow(), 'o 10 hodín', 'in 10 hours');
+    assert.equal(moment().add({d: 1}).fromNow(), 'o deň', 'in a day');
+    assert.equal(moment().add({d: 3}).fromNow(), 'o 3 dni', 'in 3 days');
+    assert.equal(moment().add({d: 10}).fromNow(), 'o 10 dní', 'in 10 days');
+    assert.equal(moment().add({M: 1}).fromNow(), 'o mesiac', 'in a month');
+    assert.equal(moment().add({M: 3}).fromNow(), 'o 3 mesiace', 'in 3 months');
+    assert.equal(moment().add({M: 10}).fromNow(), 'o 10 mesiacov', 'in 10 months');
+    assert.equal(moment().add({y: 1}).fromNow(), 'o rok', 'in a year');
+    assert.equal(moment().add({y: 3}).fromNow(), 'o 3 roky', 'in 3 years');
+    assert.equal(moment().add({y: 10}).fromNow(), 'o 10 rokov', 'in 10 years');
 });
 
 test('fromNow (past)', function (assert) {
@@ -283,7 +283,7 @@ test('calendar all else', function (assert) {
 
 test('humanize duration', function (assert) {
     assert.equal(moment.duration(1, 'minutes').humanize(), 'minúta', 'a minute (future)');
-    assert.equal(moment.duration(1, 'minutes').humanize(true), 'za minútu', 'in a minute');
+    assert.equal(moment.duration(1, 'minutes').humanize(true), 'o minútu', 'in a minute');
     assert.equal(moment.duration(-1, 'minutes').humanize(), 'minúta', 'a minute (past)');
     assert.equal(moment.duration(-1, 'minutes').humanize(true), 'pred minútou', 'a minute ago');
 });


### PR DESCRIPTION
"Za" is commonly (and _**incorrectly**_) used to relatively refer to a moment in the future. This error is mainly influenced by Czech language, which is very similar and most Slovaks will understand it, many times domesticating phrases from Czech language. In Czech, "za" is used, though in Slovak, "o" must be used.

Here are references to both "za" and "o" in the official dictionary of Slovak language (_KSSJ_):
https://slovnik.juls.savba.sk/?w=o&s=exact&d=kssj4
https://slovnik.juls.savba.sk/?w=za&s=exact&d=kssj4
And here is a more readable unofficial explanation: https://www.pravopisne.sk/o-hodinu-x-za-hodinu/

...
Okay, so I read the contribution guide that asks to mention the authors of the locale, it appears to me that no one is actualy a Slovak... Anyway... @ichernev, @marwahaha, @mattgrande, @icambron 