### PR TITLE
[bugfix] Ensure correctness of isDurationValid when Object.prototype is extended

### DIFF
--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -6,8 +6,8 @@ import {createDuration} from './create';
 var ordering = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'];
 
 export default function isDurationValid(m) {
-    for (var key in m) {
-        if (m.hasOwnProperty(key) && !(indexOf.call(ordering, key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
+    for (var key of Object.getOwnPropertyNames(m)) {
+        if (!(indexOf.call(ordering, key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
             return false;
         }
     }

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -7,7 +7,7 @@ var ordering = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'se
 
 export default function isDurationValid(m) {
     for (var key in m) {
-        if (!(indexOf.call(ordering, key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
+        if (m.hasOwnProperty(key) && !(indexOf.call(ordering, key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
             return false;
         }
     }

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -6,8 +6,8 @@ import {createDuration} from './create';
 var ordering = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'];
 
 export default function isDurationValid(m) {
-    for (var key of Object.getOwnPropertyNames(m)) {
-        if (!(indexOf.call(ordering, key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
+    for (var key in m) {
+        if (m.hasOwnProperty(key) && !(indexOf.call(ordering, key) !== -1 && (m[key] == null || !isNaN(m[key])))) {
             return false;
         }
     }

--- a/src/test/moment/duration_invalid.js
+++ b/src/test/moment/duration_invalid.js
@@ -85,3 +85,10 @@ test('invalid duration operations', function (assert) {
         assert.equal(invalid.localeData()._abbr, 'en', 'invalid.localeData()._abbr; i=' + i);
     }
 });
+
+test('valid duration with extended prototype', function (assert) {
+    Object.prototype.foo = 'bar';
+    var m = moment.duration({d: null});
+    assert.equal(m.isValid(), true);
+    delete Object.prototype.foo;
+});


### PR DESCRIPTION
`isDurationValid` returns false negatives when `Object.prototype` is extended with additional properties. JSFiddle: https://jsfiddle.net/pcsn3vhL/

The proposed fix is to only enumerate an object's direct properties using `Object.getOwnPropertyNames`.