### PR TITLE
[bugfix] - enable isoWeek when using add/subtract functions

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -298,7 +298,7 @@ declare namespace moment {
     type _quarter = "quarter" | "quarters" | "Q";
     type _isoWeek = "isoWeek" | "isoWeeks" | "W";
     type _date = "date" | "dates" | "D";
-    type DurationConstructor = Base | _quarter;
+    type DurationConstructor = Base | _isoWeek | _quarter;
 
     type DurationAs = Base;
 


### PR DESCRIPTION
## Overview

If you use `isoWeek` within the add or subtract functions you get the following type error reported: 

```
Argument of type 'number' is not assignable to parameter of type 'DurationConstructor'.
```

Adding `_isoWeek` as valid type for `DurationConstructor` type to fix this problem. This was original raised within #5007.