### PR TITLE
[bugfix] Support unusual historic timezone offsets (#5236)

### DIFF
--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -81,7 +81,7 @@ export function cloneWithOffset(input, model) {
 function getDateOffset (m) {
     // On Firefox.24 Date#getTimezoneOffset returns a floating point.
     // https://github.com/moment/moment/pull/1871
-    return -Math.round(m._d.getTimezoneOffset() / 15) * 15;
+    return -Math.round(m._d.getTimezoneOffset());
 }
 
 // HOOKS


### PR DESCRIPTION
Remove unnecessary code that rounded off timezone offsets to 15 minute intervals.

This will improve the accuracy of the displayed timezone offset for various dates before countries synchronised clocks properly.

Fixes #5236 