### PR TITLE
[bugfix] Use __dirname for locale import if available

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -53,7 +53,8 @@ function loadLocale(name) {
         try {
             oldLocale = globalLocale._abbr;
             var aliasedRequire = require;
-            aliasedRequire('./locale/' + name);
+            var path = aliasedRequire('path');
+            aliasedRequire(path.resolve(__dirname, './locale/' + name));
             getSetGlobalLocale(oldLocale);
         } catch (e) {}
     }

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -53,8 +53,7 @@ function loadLocale(name) {
         try {
             oldLocale = globalLocale._abbr;
             var aliasedRequire = require;
-            var path = aliasedRequire('path');
-            aliasedRequire(path.resolve(__dirname, './locale/' + name));
+            aliasedRequire(__dirname + '/locale/' + name);
             getSetGlobalLocale(oldLocale);
         } catch (e) {}
     }


### PR DESCRIPTION
Using core `path` module to resolve absolute path to locale files as the current implementation was causing a crash in a release build of an Android app built in react-native (v0.60.4) with Hermes enabled.

This should fix both https://github.com/moment/moment/issues/5252 and https://github.com/moment/moment/issues/5214