### PR TITLE
[misc] Remove stray second arg from `parseFloat`

### DIFF
--- a/src/lib/units/timestamp.js
+++ b/src/lib/units/timestamp.js
@@ -13,7 +13,7 @@ addFormatToken('x', 0, 0, 'valueOf');
 addRegexToken('x', matchSigned);
 addRegexToken('X', matchTimestamp);
 addParseToken('X', function (input, array, config) {
-    config._d = new Date(parseFloat(input, 10) * 1000);
+    config._d = new Date(parseFloat(input) * 1000);
 });
 addParseToken('x', function (input, array, config) {
     config._d = new Date(toInt(input));


### PR DESCRIPTION
Looks like someone was thinking of parseInt which takes a `radix` param.
In parseFloat there should be one argument only.