### PR TITLE
[pkg] Enable source maps for minified artefacts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,6 +109,7 @@ module.exports = function (grunt) {
                 }
             },
             options: {
+                sourceMap: true,
                 mangle: true,
                 compress: {
                     dead_code: false // jshint ignore:line


### PR DESCRIPTION
[pkg] enable `sourceMap` option on `Gruntfile.js` to enable debugging minified file in production enviromnent.

fixes #4186 