### PR TITLE
[bugfix] added NaN to ensure moment doesn't format NaN

### DIFF
--- a/src/lib/create/valid.js
+++ b/src/lib/create/valid.js
@@ -4,7 +4,7 @@ import getParsingFlags from '../create/parsing-flags';
 import some from '../utils/some';
 
 export function isValid(m) {
-    if (m._isValid == null) {
+    if (m._isValid == null || isNaN(m)) {
         var flags = getParsingFlags(m);
         var parsedParts = some.call(flags.parsedDateParts, function (i) {
             return i != null;

--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -64,7 +64,7 @@ function makeFormatFunction(format) {
 
 // format date using native date object
 export function formatMoment(m, format) {
-    if (!m.isValid()) {
+    if (!m.isValid() || isNaN(m)) {
         return m.localeData().invalidDate();
     }
 


### PR DESCRIPTION
fixes #5292 

For some reason NaN wasn't being identified as invalid. This little fix will get rid of NaN as a valid year, month, day format