### PR TITLE
[misc] Cache loadLocale failures to reduce FS ops

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -48,14 +48,18 @@ function chooseLocale(names) {
 function loadLocale(name) {
     var oldLocale = null;
     // TODO: Find a better way to register and load all the locales in Node
-    if (!locales[name] && (typeof module !== 'undefined') &&
+    if (locales[name] === undefined && (typeof module !== 'undefined') &&
             module && module.exports) {
         try {
             oldLocale = globalLocale._abbr;
             var aliasedRequire = require;
             aliasedRequire('./locale/' + name);
             getSetGlobalLocale(oldLocale);
-        } catch (e) {}
+        } catch (e) {
+            // mark as not found to avoid repeating expensive file require call causing high CPU
+            // when trying to find en-US, en_US, en-us for every format call
+            locales[name] = null; // null means not found
+        }
     }
     return locales[name];
 }

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -66,6 +66,15 @@ test('library getters and setters', function (assert) {
     assert.equal(moment.locale(), 'en-gb', 'Normalize locale key underscore');
 });
 
+test('locale loading performance', function (assert) {
+    // this will fallback to en
+    const start = Date.now();
+    for (var i = 0; i < 1000; i++) {
+        moment.locale('en-US');
+    }
+    assert.ok(Date.now() - start < 10);
+});
+
 test('library setter array of locales', function (assert) {
     assert.equal(moment.locale(['non-existent', 'fr', 'also-non-existent']), 'fr', 'passing an array uses the first valid locale');
     assert.equal(moment.locale(['es', 'fr', 'also-non-existent']), 'es', 'passing an array uses the first valid locale');


### PR DESCRIPTION
Environment: nodejs
Issue: whenever DateTime formatting is used for en-US, it keeps trying to load en-US, en-us before falling back to en locale taking 100% CPU for every formatting call. 
Expected: whenever a missing locale is found, it should not attempt to load/require it again and proceed to fallback locale.