### PR TITLE
[locale] (ro) Fixed month abbreviation for February

### DIFF
--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -2,6 +2,7 @@
 //! locale : Romanian [ro]
 //! author : Vlad Gurdiga : https://github.com/gurdiga
 //! author : Valentin Agachi : https://github.com/avaly
+//! author : Emanuel Cepoi : https://github.com/cepem
 
 import moment from '../moment';
 
@@ -23,7 +24,7 @@ function relativeTimeWithPlural(number, withoutSuffix, key) {
 
 export default moment.defineLocale('ro', {
     months : 'ianuarie_februarie_martie_aprilie_mai_iunie_iulie_august_septembrie_octombrie_noiembrie_decembrie'.split('_'),
-    monthsShort : 'ian._febr._mart._apr._mai_iun._iul._aug._sept._oct._nov._dec.'.split('_'),
+    monthsShort : 'ian._feb._mart._apr._mai_iun._iul._aug._sept._oct._nov._dec.'.split('_'),
     monthsParseExact: true,
     weekdays : 'duminică_luni_marți_miercuri_joi_vineri_sâmbătă'.split('_'),
     weekdaysShort : 'Dum_Lun_Mar_Mie_Joi_Vin_Sâm'.split('_'),

--- a/src/test/locale/ro.js
+++ b/src/test/locale/ro.js
@@ -4,7 +4,7 @@ import moment from '../../moment';
 localeModule('ro');
 
 test('parse', function (assert) {
-    var tests = 'ianuarie ian._februarie febr._martie mart._aprilie apr._mai mai_iunie iun._iulie iul._august aug._septembrie sept._octombrie oct._noiembrie nov._decembrie dec.'.split('_'), i;
+    var tests = 'ianuarie ian._februarie feb._martie mart._aprilie apr._mai mai_iunie iun._iulie iul._august aug._septembrie sept._octombrie oct._noiembrie nov._decembrie dec.'.split('_'), i;
     function equalTest(input, mmm, i) {
         assert.equal(moment(input, mmm).month(), i, input + ' should be month ' + (i + 1));
     }
@@ -25,7 +25,7 @@ test('format', function (assert) {
     var a = [
             ['dddd, MMMM Do YYYY, h:mm:ss A',  'duminică, februarie 14 2010, 3:25:50 PM'],
             ['ddd, hA',                        'Dum, 3PM'],
-            ['M Mo MM MMMM MMM',               '2 2 02 februarie febr.'],
+            ['M Mo MM MMMM MMM',               '2 2 02 februarie feb.'],
             ['YYYY YY',                        '2010 10'],
             ['D Do DD',                        '14 14 14'],
             ['d do dddd ddd dd',               '0 0 duminică Dum Du'],
@@ -43,9 +43,9 @@ test('format', function (assert) {
             ['LLL',                            '14 februarie 2010 15:25'],
             ['LLLL',                           'duminică, 14 februarie 2010 15:25'],
             ['l',                              '14.2.2010'],
-            ['ll',                             '14 febr. 2010'],
-            ['lll',                            '14 febr. 2010 15:25'],
-            ['llll',                           'Dum, 14 febr. 2010 15:25']
+            ['ll',                             '14 feb. 2010'],
+            ['lll',                            '14 feb. 2010 15:25'],
+            ['llll',                           'Dum, 14 feb. 2010 15:25']
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -92,7 +92,7 @@ test('format ordinal', function (assert) {
 });
 
 test('format month', function (assert) {
-    var expected = 'ianuarie ian._februarie febr._martie mart._aprilie apr._mai mai_iunie iun._iulie iul._august aug._septembrie sept._octombrie oct._noiembrie nov._decembrie dec.'.split('_'), i;
+    var expected = 'ianuarie ian._februarie feb._martie mart._aprilie apr._mai mai_iunie iun._iulie iul._august aug._septembrie sept._octombrie oct._noiembrie nov._decembrie dec.'.split('_'), i;
     for (i = 0; i < expected.length; i++) {
         assert.equal(moment([2011, i, 1]).format('MMMM MMM'), expected[i], expected[i]);
     }


### PR DESCRIPTION
I fixed the abbreviation for the February month in Romanian so that it follows Romanian grammar rules.

Resources where this abbreviation is appearing:
- https://web.library.yale.edu/cataloging/months
- http://abrevierile.ro/colectii/lunile-anului
- https://www.baylor.edu/lib/librarystaff/index.php?id=62713

