### PR TITLE
[locale] (en-li) Support ss

### DIFF
--- a/src/locale/en-il.js
+++ b/src/locale/en-il.js
@@ -30,6 +30,7 @@ export default moment.defineLocale('en-il', {
         future : 'in %s',
         past : '%s ago',
         s : 'a few seconds',
+        ss : '%d seconds',
         m : 'a minute',
         mm : '%d minutes',
         h : 'an hour',


### PR DESCRIPTION
In `src/locale/en-li.js`, `ss` is not under `relativeTime`.
So `'%d seconds'` has not been supported yet.