### PR TITLE
[locale] pt-br: Fix wrong plural usage for time

### DIFF
--- a/src/lib/locale/formats.js
+++ b/src/lib/locale/formats.js
@@ -9,12 +9,15 @@ export var defaultLongDateFormat = {
     LLLL: 'dddd, MMMM D, YYYY h:mm A',
 };
 
-export function longDateFormat(key) {
+import isFunction from '../utils/is-function';
+
+export function longDateFormat (key, mom, now) {
+
     var format = this._longDateFormat[key],
         formatUpper = this._longDateFormat[key.toUpperCase()];
 
     if (format || !formatUpper) {
-        return format;
+        return isFunction(format) ? format.call(mom, now) : format;
     }
 
     this._longDateFormat[key] = formatUpper

--- a/src/lib/locale/formats.js
+++ b/src/lib/locale/formats.js
@@ -9,15 +9,12 @@ export var defaultLongDateFormat = {
     LLLL: 'dddd, MMMM D, YYYY h:mm A',
 };
 
-import isFunction from '../utils/is-function';
-
-export function longDateFormat (key, mom, now) {
-
+export function longDateFormat(key) {
     var format = this._longDateFormat[key],
         formatUpper = this._longDateFormat[key.toUpperCase()];
 
     if (format || !formatUpper) {
-        return isFunction(format) ? format.call(mom, now) : format;
+        return format;
     }
 
     this._longDateFormat[key] = formatUpper

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -5,34 +5,29 @@
 import moment from '../moment';
 
 export default moment.defineLocale('pt-br', {
-    months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split(
-        '_'
-    ),
-    monthsShort: 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
-    weekdays:
-        'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split(
-            '_'
-        ),
-    weekdaysShort: 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
-    weekdaysMin: 'do_2ª_3ª_4ª_5ª_6ª_sá'.split('_'),
-    weekdaysParseExact: true,
-    longDateFormat: {
-        LT: 'HH:mm',
-        LTS: 'HH:mm:ss',
-        L: 'DD/MM/YYYY',
-        LL: 'D [de] MMMM [de] YYYY',
-        LLL: 'D [de] MMMM [de] YYYY [às] HH:mm',
-        LLLL: 'dddd, D [de] MMMM [de] YYYY [às] HH:mm',
+    months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
+    monthsShort : 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+    weekdays : 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
+    weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
+    weekdaysMin : 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),
+    weekdaysParseExact : true,
+    longDateFormat : {
+        LT : 'HH:mm',
+        LTS : 'HH:mm:ss',
+        L : 'DD/MM/YYYY',
+        LL : 'D [de] MMMM [de] YYYY',
+        LLL : function() { return 'D [de] MMMM [de] YYYY ' + (this.hours() < 2 ? '[à]' : '[às]') + ' HH:mm';},
+        LLLL : function() { return 'dddd, D [de] MMMM [de] YYYY ' + (this.hours() < 2 ? '[à]' : '[às]') + ' HH:mm';},
     },
-    calendar: {
-        sameDay: '[Hoje às] LT',
-        nextDay: '[Amanhã às] LT',
-        nextWeek: 'dddd [às] LT',
-        lastDay: '[Ontem às] LT',
+    calendar:  {
+        sameDay: function() { return '[Hoje] ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
+        nextDay: function() { return '[Amanhã] ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
+        nextWeek: function() { return 'dddd ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
+        lastDay: function() { return '[Ontem] ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
         lastWeek: function () {
-            return this.day() === 0 || this.day() === 6
-                ? '[Último] dddd [às] LT' // Saturday + Sunday
-                : '[Última] dddd [às] LT'; // Monday - Friday
+            return (this.day() === 0 || this.day() === 6) ?
+                '[Último] dddd ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT': // Saturday + Sunday
+                '[Última] dddd ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; // Monday - Friday
         },
         sameElse: 'L',
     },

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -5,29 +5,42 @@
 import moment from '../moment';
 
 export default moment.defineLocale('pt-br', {
-    months : 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-    monthsShort : 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
-    weekdays : 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
-    weekdaysShort : 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
-    weekdaysMin : 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),
-    weekdaysParseExact : true,
-    longDateFormat : {
-        LT : 'HH:mm',
-        LTS : 'HH:mm:ss',
-        L : 'DD/MM/YYYY',
-        LL : 'D [de] MMMM [de] YYYY',
-        LLL : function() { return 'D [de] MMMM [de] YYYY ' + (this.hours() < 2 ? '[à]' : '[às]') + ' HH:mm';},
-        LLLL : function() { return 'dddd, D [de] MMMM [de] YYYY ' + (this.hours() < 2 ? '[à]' : '[às]') + ' HH:mm';},
+    months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split(
+        '_'
+    ),
+    monthsShort: 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
+    weekdays:
+        'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split(
+            '_'
+        ),
+    weekdaysShort: 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
+    weekdaysMin: 'do_2ª_3ª_4ª_5ª_6ª_sá'.split('_'),
+    weekdaysParseExact: true,
+    longDateFormat: {
+        LT: 'HH:mm',
+        LTS: 'HH:mm:ss',
+        L: 'DD/MM/YYYY',
+        LL: 'D [de] MMMM [de] YYYY',
+        LLL: 'D [de] MMMM [de] YYYY [às] HH:mm',
+        LLLL: 'dddd, D [de] MMMM [de] YYYY [às] HH:mm',
     },
-    calendar:  {
-        sameDay: function() { return '[Hoje] ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
-        nextDay: function() { return '[Amanhã] ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
-        nextWeek: function() { return 'dddd ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
-        lastDay: function() { return '[Ontem] ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; },
+    calendar: {
+        sameDay: function () {
+            return '[Hoje ' + (this.hours() >= 2 ? 'às' : 'à') + '] LT';
+        },
+        nextDay: function () {
+            return '[Amanhã ' + (this.hours() >= 2 ? 'às' : 'à') + '] LT';
+        },
+        nextWeek: function () {
+            return 'dddd [' + (this.hours() >= 2 ? 'às' : 'à') + '] LT';
+        },
+        lastDay: function () {
+            return '[Ontem ' + (this.hours() >= 2 ? 'às' : 'à') + '] LT';
+        },
         lastWeek: function () {
-            return (this.day() === 0 || this.day() === 6) ?
-                '[Último] dddd ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT': // Saturday + Sunday
-                '[Última] dddd ' + (this.hours() < 2 ? '[à]' : '[às]') + ' LT'; // Monday - Friday
+            return this.day() === 0 || this.day() === 6
+                ? '[Último] dddd [' + (this.hours() >= 2 ? 'às' : 'à') + '] LT' // Saturday + Sunday
+                : '[Última] dddd [' + (this.hours() >= 2 ? 'às' : 'à') + '] LT'; // Monday - Friday
         },
         sameElse: 'L',
     },

--- a/src/test/locale/pt-br.js
+++ b/src/test/locale/pt-br.js
@@ -345,60 +345,25 @@ test('calendar day', function (assert) {
 test('calendar next week', function (assert) {
     var i, m;
     for (i = 2; i < 7; i++) {
-        m = moment().add({ d: i });
-        assert.equal(
-            m.calendar(),
-            m.format('dddd [às] LT'),
-            'Today + ' + i + ' days current time'
-        );
+        m = moment().add({d: i});
+        assert.equal(m.calendar(), m.hours() > 2 ? m.format('dddd [às] LT') : m.format('dddd [à] LT'),  'Today + ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(
-            m.calendar(),
-            m.format('dddd [às] LT'),
-            'Today + ' + i + ' days beginning of day'
-        );
+        assert.equal(m.calendar(),m.hours() > 2 ? m.format('dddd [às] LT') : m.format('dddd [à] LT'),  'Today + ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(
-            m.calendar(),
-            m.format('dddd [às] LT'),
-            'Today + ' + i + ' days end of day'
-        );
+        assert.equal(m.calendar(),m.hours() > 2 ? m.format('dddd [às] LT') : m.format('dddd [à] LT'),  'Today + ' + i + ' days end of day');
     }
 });
 
 test('calendar last week', function (assert) {
-    var i, m;
+    var i, m, s;
     for (i = 2; i < 7; i++) {
-        m = moment().subtract({ d: i });
-        assert.equal(
-            m.calendar(),
-            m.format(
-                m.day() === 0 || m.day() === 6
-                    ? '[Último] dddd [às] LT'
-                    : '[Última] dddd [às] LT'
-            ),
-            'Today - ' + i + ' days current time'
-        );
+        m = moment().subtract({d: i});
+        s = m.hours() > 2 ? 'às' : 'à'
+        assert.equal(m.calendar(),       m.format((m.day() === 0 || m.day() === 6) ? '[Último] dddd ' + '[' + s + '] LT' : '[Última] dddd ' + '[' + s + '] LT'),  'Today - ' + i + ' days current time');
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(
-            m.calendar(),
-            m.format(
-                m.day() === 0 || m.day() === 6
-                    ? '[Último] dddd [às] LT'
-                    : '[Última] dddd [às] LT'
-            ),
-            'Today - ' + i + ' days beginning of day'
-        );
+        assert.equal(m.calendar(),       m.format((m.day() === 0 || m.day() === 6) ? '[Último] dddd [à] LT' : '[Última] dddd [à] LT'),  'Today - ' + i + ' days beginning of day');
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(
-            m.calendar(),
-            m.format(
-                m.day() === 0 || m.day() === 6
-                    ? '[Último] dddd [às] LT'
-                    : '[Última] dddd [às] LT'
-            ),
-            'Today - ' + i + ' days end of day'
-        );
+        assert.equal(m.calendar(),       m.format((m.day() === 0 || m.day() === 6) ? '[Último] dddd ' + '[' + s + '] LT' : '[Última] dddd ' + '[' + s + '] LT'),  'Today - ' + i + ' days end of day');
     }
 });
 

--- a/src/test/locale/pt-br.js
+++ b/src/test/locale/pt-br.js
@@ -340,30 +340,83 @@ test('calendar day', function (assert) {
         'Ontem às 12:00',
         'yesterday at the same time'
     );
+    assert.equal(
+        moment(a).hours(0).minutes(0).calendar(),
+        'Hoje à 00:00',
+        'today at 00:00 uses à'
+    );
+    assert.equal(
+        moment(a).hours(1).minutes(0).calendar(),
+        'Hoje à 01:00',
+        'today at 01:00 uses à'
+    );
+    assert.equal(
+        moment(a).hours(2).minutes(0).calendar(),
+        'Hoje às 02:00',
+        'today at 02:00 uses às'
+    );
 });
 
 test('calendar next week', function (assert) {
     var i, m;
     for (i = 2; i < 7; i++) {
-        m = moment().add({d: i});
-        assert.equal(m.calendar(), m.hours() > 2 ? m.format('dddd [às] LT') : m.format('dddd [à] LT'),  'Today + ' + i + ' days current time');
+        m = moment().add({ d: i });
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),m.hours() > 2 ? m.format('dddd [às] LT') : m.format('dddd [à] LT'),  'Today + ' + i + ' days beginning of day');
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [à] LT'),
+            'Today + ' + i + ' days at 00:00'
+        );
+        m.hours(1);
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [à] LT'),
+            'Today + ' + i + ' days at 01:00'
+        );
+        m.hours(2);
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [às] LT'),
+            'Today + ' + i + ' days at 02:00'
+        );
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),m.hours() > 2 ? m.format('dddd [às] LT') : m.format('dddd [à] LT'),  'Today + ' + i + ' days end of day');
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [às] LT'),
+            'Today + ' + i + ' days end of day'
+        );
     }
 });
 
 test('calendar last week', function (assert) {
-    var i, m, s;
+    var i, m, prefix;
     for (i = 2; i < 7; i++) {
-        m = moment().subtract({d: i});
-        s = m.hours() > 2 ? 'às' : 'à'
-        assert.equal(m.calendar(),       m.format((m.day() === 0 || m.day() === 6) ? '[Último] dddd ' + '[' + s + '] LT' : '[Última] dddd ' + '[' + s + '] LT'),  'Today - ' + i + ' days current time');
+        m = moment().subtract({ d: i });
+        prefix = m.day() === 0 || m.day() === 6 ? '[Último]' : '[Última]';
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(m.calendar(),       m.format((m.day() === 0 || m.day() === 6) ? '[Último] dddd [à] LT' : '[Última] dddd [à] LT'),  'Today - ' + i + ' days beginning of day');
+        assert.equal(
+            m.calendar(),
+            m.format(prefix + ' dddd [à] LT'),
+            'Today - ' + i + ' days at 00:00'
+        );
+        m.hours(1);
+        assert.equal(
+            m.calendar(),
+            m.format(prefix + ' dddd [à] LT'),
+            'Today - ' + i + ' days at 01:00'
+        );
+        m.hours(2);
+        assert.equal(
+            m.calendar(),
+            m.format(prefix + ' dddd [às] LT'),
+            'Today - ' + i + ' days at 02:00'
+        );
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(m.calendar(),       m.format((m.day() === 0 || m.day() === 6) ? '[Último] dddd ' + '[' + s + '] LT' : '[Última] dddd ' + '[' + s + '] LT'),  'Today - ' + i + ' days end of day');
+        assert.equal(
+            m.calendar(),
+            m.format(prefix + ' dddd [às] LT'),
+            'Today - ' + i + ' days end of day'
+        );
     }
 });
 


### PR DESCRIPTION
This fix #3988

But I need help on 2 test that don't pass, 

Errors:

Module: locale:pt-br Test: date format correctness
Died on test #5     at global.test.QUnit.test (/home/luizcorreia/repos/moment/node_modules/node-qunit/lib/child.js:133:21)
    at defineCommonLocaleTests (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:141:9)
    at localeModule (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:286:9)
    at /home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:289:5
    at /home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:4:43
    at Object.<anonymous> (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:7:2)
    at Module._compile (internal/modules/cjs/loader.js:955:30): localeData[baseToken].replace is not a function
TypeError: localeData[baseToken].replace is not a function
    at /home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:151:56
    at each (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:12:13)
    at /home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:148:17
    at each (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:12:13)
    at Object.<anonymous> (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:145:13)

Module: locale:pt-br Test: format
Died on test #18     at global.test.QUnit.test (/home/luizcorreia/repos/moment/node_modules/node-qunit/lib/child.js:133:21)
    at /home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:311:5
    at /home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:4:43
    at Object.<anonymous> (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:7:2)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32): Cannot read property 'hours' of undefined
TypeError: Cannot read property 'hours' of undefined
    at LLL (/home/luizcorreia/repos/moment/build/umd/locale/pt-br.js:23:72)
    at Locale.longDateFormat (/home/luizcorreia/repos/moment/build/umd/moment.js:442:48)
    at replaceLongDateFormatTokens (/home/luizcorreia/repos/moment/build/umd/moment.js:624:27)
    at String.replace (<anonymous>)
    at expandFormat (/home/luizcorreia/repos/moment/build/umd/moment.js:629:29)
    at formatMoment (/home/luizcorreia/repos/moment/build/umd/moment.js:614:18)
    at Moment.format (/home/luizcorreia/repos/moment/build/umd/moment.js:3379:22)
    at Object.<anonymous> (/home/luizcorreia/repos/moment/build/umd/test/locale/pt-br.js:340:28)
