### PR TITLE
[locale] (sk) Fix preposition issue (fixes #5408)

### DIFF
--- a/src/locale/sk.js
+++ b/src/locale/sk.js
@@ -124,7 +124,7 @@ export default moment.defineLocale('sk', {
         sameElse: 'L'
     },
     relativeTime : {
-        future : 'za %s',
+        future : 'o %s',
         past : 'pred %s',
         s : translate,
         ss : translate,
@@ -146,4 +146,3 @@ export default moment.defineLocale('sk', {
         doy : 4  // The week that contains Jan 4th is the first week of the year.
     }
 });
-

--- a/src/test/locale/sk.js
+++ b/src/test/locale/sk.js
@@ -138,7 +138,7 @@ test('from', function (assert) {
 });
 
 test('suffix', function (assert) {
-    assert.equal(moment(30000).from(0), 'za pár sekúnd',  'prefix');
+    assert.equal(moment(30000).from(0), 'o pár sekúnd',  'prefix');
     assert.equal(moment(0).from(30000), 'pred pár sekundami', 'suffix');
 });
 
@@ -147,22 +147,22 @@ test('now from now', function (assert) {
 });
 
 test('fromNow (future)', function (assert) {
-    assert.equal(moment().add({s: 30}).fromNow(), 'za pár sekúnd', 'in a few seconds');
-    assert.equal(moment().add({m: 1}).fromNow(), 'za minútu', 'in a minute');
-    assert.equal(moment().add({m: 3}).fromNow(), 'za 3 minúty', 'in 3 minutes');
-    assert.equal(moment().add({m: 10}).fromNow(), 'za 10 minút', 'in 10 minutes');
-    assert.equal(moment().add({h: 1}).fromNow(), 'za hodinu', 'in an hour');
-    assert.equal(moment().add({h: 3}).fromNow(), 'za 3 hodiny', 'in 3 hours');
-    assert.equal(moment().add({h: 10}).fromNow(), 'za 10 hodín', 'in 10 hours');
-    assert.equal(moment().add({d: 1}).fromNow(), 'za deň', 'in a day');
-    assert.equal(moment().add({d: 3}).fromNow(), 'za 3 dni', 'in 3 days');
-    assert.equal(moment().add({d: 10}).fromNow(), 'za 10 dní', 'in 10 days');
-    assert.equal(moment().add({M: 1}).fromNow(), 'za mesiac', 'in a month');
-    assert.equal(moment().add({M: 3}).fromNow(), 'za 3 mesiace', 'in 3 months');
-    assert.equal(moment().add({M: 10}).fromNow(), 'za 10 mesiacov', 'in 10 months');
-    assert.equal(moment().add({y: 1}).fromNow(), 'za rok', 'in a year');
-    assert.equal(moment().add({y: 3}).fromNow(), 'za 3 roky', 'in 3 years');
-    assert.equal(moment().add({y: 10}).fromNow(), 'za 10 rokov', 'in 10 years');
+    assert.equal(moment().add({s: 30}).fromNow(), 'o pár sekúnd', 'in a few seconds');
+    assert.equal(moment().add({m: 1}).fromNow(), 'o minútu', 'in a minute');
+    assert.equal(moment().add({m: 3}).fromNow(), 'o 3 minúty', 'in 3 minutes');
+    assert.equal(moment().add({m: 10}).fromNow(), 'o 10 minút', 'in 10 minutes');
+    assert.equal(moment().add({h: 1}).fromNow(), 'o hodinu', 'in an hour');
+    assert.equal(moment().add({h: 3}).fromNow(), 'o 3 hodiny', 'in 3 hours');
+    assert.equal(moment().add({h: 10}).fromNow(), 'o 10 hodín', 'in 10 hours');
+    assert.equal(moment().add({d: 1}).fromNow(), 'o deň', 'in a day');
+    assert.equal(moment().add({d: 3}).fromNow(), 'o 3 dni', 'in 3 days');
+    assert.equal(moment().add({d: 10}).fromNow(), 'o 10 dní', 'in 10 days');
+    assert.equal(moment().add({M: 1}).fromNow(), 'o mesiac', 'in a month');
+    assert.equal(moment().add({M: 3}).fromNow(), 'o 3 mesiace', 'in 3 months');
+    assert.equal(moment().add({M: 10}).fromNow(), 'o 10 mesiacov', 'in 10 months');
+    assert.equal(moment().add({y: 1}).fromNow(), 'o rok', 'in a year');
+    assert.equal(moment().add({y: 3}).fromNow(), 'o 3 roky', 'in 3 years');
+    assert.equal(moment().add({y: 10}).fromNow(), 'o 10 rokov', 'in 10 years');
 });
 
 test('fromNow (past)', function (assert) {
@@ -283,7 +283,7 @@ test('calendar all else', function (assert) {
 
 test('humanize duration', function (assert) {
     assert.equal(moment.duration(1, 'minutes').humanize(), 'minúta', 'a minute (future)');
-    assert.equal(moment.duration(1, 'minutes').humanize(true), 'za minútu', 'in a minute');
+    assert.equal(moment.duration(1, 'minutes').humanize(true), 'o minútu', 'in a minute');
     assert.equal(moment.duration(-1, 'minutes').humanize(), 'minúta', 'a minute (past)');
     assert.equal(moment.duration(-1, 'minutes').humanize(true), 'pred minútou', 'a minute ago');
 });
@@ -295,4 +295,3 @@ test('weeks year starting sunday formatted', function (assert) {
     assert.equal(moment([2012, 0,  9]).format('w ww wo'),   '2 02 2.', 'Jan  9 2012 should be week 2');
     assert.equal(moment([2012, 0, 15]).format('w ww wo'),   '2 02 2.', 'Jan 15 2012 should be week 2');
 });
-


### PR DESCRIPTION
- Replace `za` preposition with `o` in `src/locale/sk.js` and `src/test/locale/sk.js`.