### PR TITLE
[locale] ga: Improve month/weekday strings

### DIFF
--- a/locale/ga.js
+++ b/locale/ga.js
@@ -5,21 +5,16 @@
        && typeof require === 'function' ? factory(require('../moment')) :
    typeof define === 'function' && define.amd ? define(['../moment'], factory) :
    factory(global.moment)
-}(this, (function (moment) { 'use strict';
-
-
+}(this, (function (moment) {
+    'use strict';
 
     var months = [
-        'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Méitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deaireadh Fómhair', 'Samhain', 'Nollaig'
+        'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Meitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deireadh Fómhair', 'Samhain', 'Nollaig'
     ];
-
-    var monthsShort = ['Eaná', 'Feab', 'Márt', 'Aibr', 'Beal', 'Méit', 'Iúil', 'Lúna', 'Meán', 'Deai', 'Samh', 'Noll'];
-
-    var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Satharn'];
-
-    var weekdaysShort = ['Dom', 'Lua', 'Mái', 'Céa', 'Déa', 'hAo', 'Sat'];
-
-    var weekdaysMin = ['Do', 'Lu', 'Má', 'Ce', 'Dé', 'hA', 'Sa'];
+    var monthsShort = ['Ean', 'Feabh', 'Márt', 'Aib', 'Beal', 'Meith', 'Iúil', 'Lún', 'M.F.', 'D.F.', 'Samh', 'Noll'];
+    var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Sathairn'];
+    var weekdaysShort = ['Domh', 'Luan', 'Máirt', 'Céad', 'Déar', 'Aoine', 'Sath'];
+    var weekdaysMin = ['Do', 'Lu', 'Má', 'Cé', 'Dé', 'A', 'Sa'];
 
     var ga = moment.defineLocale('ga', {
         months: months,
@@ -40,7 +35,7 @@
             sameDay: '[Inniu ag] LT',
             nextDay: '[Amárach ag] LT',
             nextWeek: 'dddd [ag] LT',
-            lastDay: '[Inné aig] LT',
+            lastDay: '[Inné ag] LT',
             lastWeek: 'dddd [seo caite] [ag] LT',
             sameElse: 'L'
         },

--- a/locale/ga.js
+++ b/locale/ga.js
@@ -1,77 +1,76 @@
 //! moment.js locale configuration
 
 ;(function (global, factory) {
-    typeof exports === 'object' && typeof module !== 'undefined'
-        && typeof require === 'function' ? factory(require('../moment')) :
-    typeof define === 'function' && define.amd ? define(['../moment'], factory) :
-    factory(global.moment)
- }(this, (function (moment) { 'use strict';
- 
- 
- 
-     var months = [
-         'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Méitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deaireadh Fómhair', 'Samhain', 'Nollaig'
-     ];
- 
-     var monthsShort = ['Eaná', 'Feab', 'Márt', 'Aibr', 'Beal', 'Méit', 'Iúil', 'Lúna', 'Meán', 'Deai', 'Samh', 'Noll'];
- 
-     var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Satharn'];
- 
-     var weekdaysShort = ['Dom', 'Lua', 'Mái', 'Céa', 'Déa', 'hAo', 'Sat'];
- 
-     var weekdaysMin = ['Do', 'Lu', 'Má', 'Ce', 'Dé', 'hA', 'Sa'];
- 
-     var ga = moment.defineLocale('ga', {
-         months: months,
-         monthsShort: monthsShort,
-         monthsParseExact: true,
-         weekdays: weekdays,
-         weekdaysShort: weekdaysShort,
-         weekdaysMin: weekdaysMin,
-         longDateFormat: {
-             LT: 'HH:mm',
-             LTS: 'HH:mm:ss',
-             L: 'DD/MM/YYYY',
-             LL: 'D MMMM YYYY',
-             LLL: 'D MMMM YYYY HH:mm',
-             LLLL: 'dddd, D MMMM YYYY HH:mm'
-         },
-         calendar: {
-             sameDay: '[Inniu ag] LT',
-             nextDay: '[Amárach ag] LT',
-             nextWeek: 'dddd [ag] LT',
-             lastDay: '[Inné aig] LT',
-             lastWeek: 'dddd [seo caite] [ag] LT',
-             sameElse: 'L'
-         },
-         relativeTime: {
-             future: 'i %s',
-             past: '%s ó shin',
-             s: 'cúpla soicind',
-             ss: '%d soicind',
-             m: 'nóiméad',
-             mm: '%d nóiméad',
-             h: 'uair an chloig',
-             hh: '%d uair an chloig',
-             d: 'lá',
-             dd: '%d lá',
-             M: 'mí',
-             MM: '%d mí',
-             y: 'bliain',
-             yy: '%d bliain'
-         },
-         dayOfMonthOrdinalParse: /\d{1,2}(d|na|mh)/,
-         ordinal: function (number) {
-             var output = number === 1 ? 'd' : number % 10 === 2 ? 'na' : 'mh';
-             return number + output;
-         },
-         week: {
-             dow: 1, // Monday is the first day of the week.
-             doy: 4  // The week that contains Jan 4th is the first week of the year.
-         }
-     });
- 
-     return ga;
- 
- })));
- 
+   typeof exports === 'object' && typeof module !== 'undefined'
+       && typeof require === 'function' ? factory(require('../moment')) :
+   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
+   factory(global.moment)
+}(this, (function (moment) { 'use strict';
+
+
+
+    var months = [
+        'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Méitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deaireadh Fómhair', 'Samhain', 'Nollaig'
+    ];
+
+    var monthsShort = ['Eaná', 'Feab', 'Márt', 'Aibr', 'Beal', 'Méit', 'Iúil', 'Lúna', 'Meán', 'Deai', 'Samh', 'Noll'];
+
+    var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Satharn'];
+
+    var weekdaysShort = ['Dom', 'Lua', 'Mái', 'Céa', 'Déa', 'hAo', 'Sat'];
+
+    var weekdaysMin = ['Do', 'Lu', 'Má', 'Ce', 'Dé', 'hA', 'Sa'];
+
+    var ga = moment.defineLocale('ga', {
+        months: months,
+        monthsShort: monthsShort,
+        monthsParseExact: true,
+        weekdays: weekdays,
+        weekdaysShort: weekdaysShort,
+        weekdaysMin: weekdaysMin,
+        longDateFormat: {
+            LT: 'HH:mm',
+            LTS: 'HH:mm:ss',
+            L: 'DD/MM/YYYY',
+            LL: 'D MMMM YYYY',
+            LLL: 'D MMMM YYYY HH:mm',
+            LLLL: 'dddd, D MMMM YYYY HH:mm'
+        },
+        calendar: {
+            sameDay: '[Inniu ag] LT',
+            nextDay: '[Amárach ag] LT',
+            nextWeek: 'dddd [ag] LT',
+            lastDay: '[Inné aig] LT',
+            lastWeek: 'dddd [seo caite] [ag] LT',
+            sameElse: 'L'
+        },
+        relativeTime: {
+            future: 'i %s',
+            past: '%s ó shin',
+            s: 'cúpla soicind',
+            ss: '%d soicind',
+            m: 'nóiméad',
+            mm: '%d nóiméad',
+            h: 'uair an chloig',
+            hh: '%d uair an chloig',
+            d: 'lá',
+            dd: '%d lá',
+            M: 'mí',
+            MM: '%d mí',
+            y: 'bliain',
+            yy: '%d bliain'
+        },
+        dayOfMonthOrdinalParse: /\d{1,2}(d|na|mh)/,
+        ordinal: function (number) {
+            var output = number === 1 ? 'd' : number % 10 === 2 ? 'na' : 'mh';
+            return number + output;
+        },
+        week: {
+            dow: 1, // Monday is the first day of the week.
+            doy: 4  // The week that contains Jan 4th is the first week of the year.
+        }
+    });
+
+    return ga;
+
+})));

--- a/locale/ga.js
+++ b/locale/ga.js
@@ -1,71 +1,77 @@
 //! moment.js locale configuration
 
 ;(function (global, factory) {
-   typeof exports === 'object' && typeof module !== 'undefined'
-       && typeof require === 'function' ? factory(require('../moment')) :
-   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
-   factory(global.moment)
-}(this, (function (moment) {
-    'use strict';
-
-    var months = [
-        'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Meitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deireadh Fómhair', 'Samhain', 'Nollaig'
-    ];
-    var monthsShort = ['Ean', 'Feabh', 'Márt', 'Aib', 'Beal', 'Meith', 'Iúil', 'Lún', 'M.F.', 'D.F.', 'Samh', 'Noll'];
-    var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Sathairn'];
-    var weekdaysShort = ['Domh', 'Luan', 'Máirt', 'Céad', 'Déar', 'Aoine', 'Sath'];
-    var weekdaysMin = ['Do', 'Lu', 'Má', 'Cé', 'Dé', 'A', 'Sa'];
-
-    var ga = moment.defineLocale('ga', {
-        months: months,
-        monthsShort: monthsShort,
-        monthsParseExact: true,
-        weekdays: weekdays,
-        weekdaysShort: weekdaysShort,
-        weekdaysMin: weekdaysMin,
-        longDateFormat: {
-            LT: 'HH:mm',
-            LTS: 'HH:mm:ss',
-            L: 'DD/MM/YYYY',
-            LL: 'D MMMM YYYY',
-            LLL: 'D MMMM YYYY HH:mm',
-            LLLL: 'dddd, D MMMM YYYY HH:mm'
-        },
-        calendar: {
-            sameDay: '[Inniu ag] LT',
-            nextDay: '[Amárach ag] LT',
-            nextWeek: 'dddd [ag] LT',
-            lastDay: '[Inné ag] LT',
-            lastWeek: 'dddd [seo caite] [ag] LT',
-            sameElse: 'L'
-        },
-        relativeTime: {
-            future: 'i %s',
-            past: '%s ó shin',
-            s: 'cúpla soicind',
-            ss: '%d soicind',
-            m: 'nóiméad',
-            mm: '%d nóiméad',
-            h: 'uair an chloig',
-            hh: '%d uair an chloig',
-            d: 'lá',
-            dd: '%d lá',
-            M: 'mí',
-            MM: '%d mí',
-            y: 'bliain',
-            yy: '%d bliain'
-        },
-        dayOfMonthOrdinalParse: /\d{1,2}(d|na|mh)/,
-        ordinal: function (number) {
-            var output = number === 1 ? 'd' : number % 10 === 2 ? 'na' : 'mh';
-            return number + output;
-        },
-        week: {
-            dow: 1, // Monday is the first day of the week.
-            doy: 4  // The week that contains Jan 4th is the first week of the year.
-        }
-    });
-
-    return ga;
-
-})));
+    typeof exports === 'object' && typeof module !== 'undefined'
+        && typeof require === 'function' ? factory(require('../moment')) :
+    typeof define === 'function' && define.amd ? define(['../moment'], factory) :
+    factory(global.moment)
+ }(this, (function (moment) { 'use strict';
+ 
+ 
+ 
+     var months = [
+         'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Méitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deaireadh Fómhair', 'Samhain', 'Nollaig'
+     ];
+ 
+     var monthsShort = ['Eaná', 'Feab', 'Márt', 'Aibr', 'Beal', 'Méit', 'Iúil', 'Lúna', 'Meán', 'Deai', 'Samh', 'Noll'];
+ 
+     var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Satharn'];
+ 
+     var weekdaysShort = ['Dom', 'Lua', 'Mái', 'Céa', 'Déa', 'hAo', 'Sat'];
+ 
+     var weekdaysMin = ['Do', 'Lu', 'Má', 'Ce', 'Dé', 'hA', 'Sa'];
+ 
+     var ga = moment.defineLocale('ga', {
+         months: months,
+         monthsShort: monthsShort,
+         monthsParseExact: true,
+         weekdays: weekdays,
+         weekdaysShort: weekdaysShort,
+         weekdaysMin: weekdaysMin,
+         longDateFormat: {
+             LT: 'HH:mm',
+             LTS: 'HH:mm:ss',
+             L: 'DD/MM/YYYY',
+             LL: 'D MMMM YYYY',
+             LLL: 'D MMMM YYYY HH:mm',
+             LLLL: 'dddd, D MMMM YYYY HH:mm'
+         },
+         calendar: {
+             sameDay: '[Inniu ag] LT',
+             nextDay: '[Amárach ag] LT',
+             nextWeek: 'dddd [ag] LT',
+             lastDay: '[Inné aig] LT',
+             lastWeek: 'dddd [seo caite] [ag] LT',
+             sameElse: 'L'
+         },
+         relativeTime: {
+             future: 'i %s',
+             past: '%s ó shin',
+             s: 'cúpla soicind',
+             ss: '%d soicind',
+             m: 'nóiméad',
+             mm: '%d nóiméad',
+             h: 'uair an chloig',
+             hh: '%d uair an chloig',
+             d: 'lá',
+             dd: '%d lá',
+             M: 'mí',
+             MM: '%d mí',
+             y: 'bliain',
+             yy: '%d bliain'
+         },
+         dayOfMonthOrdinalParse: /\d{1,2}(d|na|mh)/,
+         ordinal: function (number) {
+             var output = number === 1 ? 'd' : number % 10 === 2 ? 'na' : 'mh';
+             return number + output;
+         },
+         week: {
+             dow: 1, // Monday is the first day of the week.
+             doy: 4  // The week that contains Jan 4th is the first week of the year.
+         }
+     });
+ 
+     return ga;
+ 
+ })));
+ 

--- a/src/locale/ga.js
+++ b/src/locale/ga.js
@@ -4,18 +4,13 @@
 
 import moment from '../moment';
 
-
 var months = [
-    'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Méitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deaireadh Fómhair', 'Samhain', 'Nollaig'
+    'Eanáir', 'Feabhra', 'Márta', 'Aibreán', 'Bealtaine', 'Meitheamh', 'Iúil', 'Lúnasa', 'Meán Fómhair', 'Deireadh Fómhair', 'Samhain', 'Nollaig'
 ];
-
-var monthsShort = ['Eaná', 'Feab', 'Márt', 'Aibr', 'Beal', 'Méit', 'Iúil', 'Lúna', 'Meán', 'Deai', 'Samh', 'Noll'];
-
-var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Satharn'];
-
-var weekdaysShort = ['Dom', 'Lua', 'Mái', 'Céa', 'Déa', 'hAo', 'Sat'];
-
-var weekdaysMin = ['Do', 'Lu', 'Má', 'Ce', 'Dé', 'hA', 'Sa'];
+var monthsShort = ['Ean', 'Feabh', 'Márt', 'Aib', 'Beal', 'Meith', 'Iúil', 'Lún', 'M.F.', 'D.F.', 'Samh', 'Noll'];
+var weekdays = ['Dé Domhnaigh', 'Dé Luain', 'Dé Máirt', 'Dé Céadaoin', 'Déardaoin', 'Dé hAoine', 'Dé Sathairn'];
+var weekdaysShort = ['Domh', 'Luan', 'Máirt', 'Céad', 'Déar', 'Aoine', 'Sath'];
+var weekdaysMin = ['Do', 'Lu', 'Má', 'Cé', 'Dé', 'A', 'Sa'];
 
 export default moment.defineLocale('ga', {
     months: months,


### PR DESCRIPTION
This PR fixes some spelling mistakes in the Irish language/Gaeilge (GA) locale file.

For example, the correct spelling for October is 'Deireadh Fómhair' (rather than 'Deaireadh Fómhair' previously) (see an authoritative source [here](https://www.tearma.ie/q/October/)).

There may other improvements to be made in terms of how the locale handles ordinal numbers, and I hope to look at this when I have a chance, but this PR addresses the most glaring issues.
