### PR TITLE
[locale] br: Fix lack of meridiem override

### DIFF
--- a/locale/br.js
+++ b/locale/br.js
@@ -99,6 +99,13 @@
         week : {
             dow : 1, // Monday is the first day of the week.
             doy : 4  // The week that contains Jan 4th is the first week of the year.
+        },
+        meridiemParse : /a.m.|g.m./, // goude merenn | a-raok merenn
+        isPM : function (token) {
+	        return token === 'g.m.';
+        },
+        meridiem : function (hour, minute, isLower) {
+	        return hour < 12 ? 'a.m.' : 'g.m.';
         }
     });
 


### PR DESCRIPTION
eur e brezhoneg Lizherennañ

Mat eo g.m. evit PM (goude merenn) ha a.m. evit AM (a-raok merenn).

-- 
Should be g.m. for PM, stand for goude merenn and a.m. for AM stand for a-raok Merenn

Here some sources : 
http://www.brezhoneg.bzh/177-divizou-hag-erbedadennou-ar-chuzul-skiantel.htm
https://www.unicode.org/cldr/charts/latest/summary/br.html