### PR TITLE
[locale] zh-cn: Improve next/prev week

### DIFF
--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -2,6 +2,7 @@
 //! locale : Chinese (China) [zh-cn]
 //! author : suupic : https://github.com/suupic
 //! author : Zeno Zeng : https://github.com/zenozeng
+//! author : uu109 : https://github.com/uu109
 
 import moment from '../moment';
 

--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -60,9 +60,21 @@ export default moment.defineLocale('zh-cn', {
     calendar: {
         sameDay: '[今天]LT',
         nextDay: '[明天]LT',
-        nextWeek: '[下]ddddLT',
+        nextWeek: function (now) {
+            if (now.week() !== this.week()) {
+                return '[下]dddLT';
+            } else {
+                return '[本]dddLT';
+            }
+        },
         lastDay: '[昨天]LT',
-        lastWeek: '[上]ddddLT',
+        lastWeek: function (now) {
+            if (this.week() !== now.week()) {
+                return '[上]dddLT';
+            } else {
+                return '[本]dddLT';
+            }
+        },
         sameElse: 'L',
     },
     dayOfMonthOrdinalParse: /\d{1,2}(日|月|周)/,

--- a/src/test/locale/zh-cn.js
+++ b/src/test/locale/zh-cn.js
@@ -310,50 +310,94 @@ test('calendar day', function (assert) {
 });
 
 test('calendar next week', function (assert) {
-    var i, m;
+    var i,
+        m,
+        week = moment().week();
     for (i = 2; i < 7; i++) {
         m = moment().add({ d: i });
-        assert.equal(
-            m.calendar(),
-            m.format('[下]ddddLT'),
-            'Today + ' + i + ' days current time'
-        );
-        m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(
-            m.calendar(),
-            m.format('[下]ddddLT'),
-            'Today + ' + i + ' days beginning of day'
-        );
-        m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(
-            m.calendar(),
-            m.format('[下]ddddLT'),
-            'Today + ' + i + ' days end of day'
-        );
+        if (week === m.week()) {
+            assert.equal(
+                m.calendar(),
+                m.format('[本]dddLT'),
+                'Today + ' + i + ' days current time'
+            );
+            m.hours(0).minutes(0).seconds(0).milliseconds(0);
+            assert.equal(
+                m.calendar(),
+                m.format('[本]dddLT'),
+                'Today + ' + i + ' days beginning of day'
+            );
+            m.hours(23).minutes(59).seconds(59).milliseconds(999);
+            assert.equal(
+                m.calendar(),
+                m.format('[本]dddLT'),
+                'Today + ' + i + ' days end of day'
+            );
+        } else {
+            assert.equal(
+                m.calendar(),
+                m.format('[下]dddLT'),
+                'Today + ' + i + ' days current time'
+            );
+            m.hours(0).minutes(0).seconds(0).milliseconds(0);
+            assert.equal(
+                m.calendar(),
+                m.format('[下]dddLT'),
+                'Today + ' + i + ' days beginning of day'
+            );
+            m.hours(23).minutes(59).seconds(59).milliseconds(999);
+            assert.equal(
+                m.calendar(),
+                m.format('[下]dddLT'),
+                'Today + ' + i + ' days end of day'
+            );
+        }
     }
 });
 
 test('calendar last week', function (assert) {
-    var i, m;
+    var i,
+        m,
+        week = moment().week();
     for (i = 2; i < 7; i++) {
         m = moment().subtract({ d: i });
-        assert.equal(
-            m.calendar(),
-            m.format('[上]ddddLT'),
-            'Today - ' + i + ' days current time'
-        );
-        m.hours(0).minutes(0).seconds(0).milliseconds(0);
-        assert.equal(
-            m.calendar(),
-            m.format('[上]ddddLT'),
-            'Today - ' + i + ' days beginning of day'
-        );
-        m.hours(23).minutes(59).seconds(59).milliseconds(999);
-        assert.equal(
-            m.calendar(),
-            m.format('[上]ddddLT'),
-            'Today - ' + i + ' days end of day'
-        );
+        if (week !== m.week()) {
+            assert.equal(
+                m.calendar(),
+                m.format('[上]dddLT'),
+                'Today - ' + i + ' days current time'
+            );
+            m.hours(0).minutes(0).seconds(0).milliseconds(0);
+            assert.equal(
+                m.calendar(),
+                m.format('[上]dddLT'),
+                'Today - ' + i + ' days beginning of day'
+            );
+            m.hours(23).minutes(59).seconds(59).milliseconds(999);
+            assert.equal(
+                m.calendar(),
+                m.format('[上]dddLT'),
+                'Today - ' + i + ' days end of day'
+            );
+        } else {
+            assert.equal(
+                m.calendar(),
+                m.format('[本]dddLT'),
+                'Today - ' + i + ' days current time'
+            );
+            m.hours(0).minutes(0).seconds(0).milliseconds(0);
+            assert.equal(
+                m.calendar(),
+                m.format('[本]dddLT'),
+                'Today - ' + i + ' days beginning of day'
+            );
+            m.hours(23).minutes(59).seconds(59).milliseconds(999);
+            assert.equal(
+                m.calendar(),
+                m.format('[本]dddLT'),
+                'Today - ' + i + ' days end of day'
+            );
+        }
     }
 });
 


### PR DESCRIPTION
This error was introduced by https://github.com/moment/moment/commit/f38d69c3675914442c541c876e116370a731fd40

This PR mostly restore the calendar output to the most common formats, which is almost quite same with what it was before above commit.

This PR passed the test and will fix:
https://github.com/moment/moment/issues/4097
https://github.com/moment/moment/issues/4149
https://github.com/moment/moment/issues/4354
https://github.com/moment/moment/issues/5414 

And you can close other invalid PR like: https://github.com/moment/moment/pull/5357