### PR TITLE
Update eo.js to fix some expressions

### DIFF
--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -3,12 +3,13 @@
 //! author : Colin Dean : https://github.com/colindean
 //! author : Mia Nordentoft Imperatori : https://github.com/miestasmia
 //! comment : miestasmia corrected the translation by colindean
+//! comment : Vivakvo corrected the translation by colindean and miestasmia
 
 import moment from '../moment';
 
 export default moment.defineLocale('eo', {
     months : 'januaro_februaro_marto_aprilo_majo_junio_julio_aŭgusto_septembro_oktobro_novembro_decembro'.split('_'),
-    monthsShort : 'jan_feb_mar_apr_maj_jun_jul_aŭg_sep_okt_nov_dec'.split('_'),
+    monthsShort : 'jan_feb_mart_apr_maj_jun_jul_aŭg_sept_okt_nov_dec'.split('_'),
     weekdays : 'dimanĉo_lundo_mardo_merkredo_ĵaŭdo_vendredo_sabato'.split('_'),
     weekdaysShort : 'dim_lun_mard_merk_ĵaŭ_ven_sab'.split('_'),
     weekdaysMin : 'di_lu_ma_me_ĵa_ve_sa'.split('_'),
@@ -16,9 +17,9 @@ export default moment.defineLocale('eo', {
         LT : 'HH:mm',
         LTS : 'HH:mm:ss',
         L : 'YYYY-MM-DD',
-        LL : 'D[-a de] MMMM, YYYY',
-        LLL : 'D[-a de] MMMM, YYYY HH:mm',
-        LLLL : 'dddd, [la] D[-a de] MMMM, YYYY HH:mm'
+        LL : '[la] D[-an de] MMMM, YYYY',
+        LLL : '[la] D[-an de] MMMM, YYYY HH:mm',
+        LLLL : 'dddd[n], [la] D[-an de] MMMM, YYYY HH:mm'
     },
     meridiemParse: /[ap]\.t\.m/i,
     isPM: function (input) {
@@ -34,25 +35,25 @@ export default moment.defineLocale('eo', {
     calendar : {
         sameDay : '[Hodiaŭ je] LT',
         nextDay : '[Morgaŭ je] LT',
-        nextWeek : 'dddd [je] LT',
+        nextWeek : 'dddd[n je] LT',
         lastDay : '[Hieraŭ je] LT',
-        lastWeek : '[pasinta] dddd [je] LT',
+        lastWeek : '[pasintan] dddd[n je] LT',
         sameElse : 'L'
     },
     relativeTime : {
         future : 'post %s',
         past : 'antaŭ %s',
-        s : 'sekundoj',
+        s : 'kelkaj sekundoj',
         ss : '%d sekundoj',
-        m : 'minuto',
+        m : 'unu minuto',
         mm : '%d minutoj',
-        h : 'horo',
+        h : 'unu horo',
         hh : '%d horoj',
-        d : 'tago',//ne 'diurno', ĉar estas uzita por proksimumo
+        d : 'unu tago',//ne 'diurno', ĉar estas uzita por proksimumo
         dd : '%d tagoj',
-        M : 'monato',
+        M : 'unu monato',
         MM : '%d monatoj',
-        y : 'jaro',
+        y : 'unu jaro',
         yy : '%d jaroj'
     },
     dayOfMonthOrdinalParse: /\d{1,2}a/,


### PR DESCRIPTION
Line 12: adding the letter "t" for the months "marto" and "septembro" to distinguish them from "mardo" (=tuesday) and "sep" (=seven)
Lines 20, 21, 22, 38 and 40: correction of some date expressions in which accusative is needed.
Line 46: adding the word "kelkaj" (=some), because "post sekundoj" and "antaŭ sekundoj" don't really make sense.
Lines 48, 50, 52, 54 and 56: adding the word "unu" (=one) because it's about the quantity "1", and not about an indefinite thing.