### PR TITLE
[feature] Support relative weeks

### DIFF
--- a/src/lib/duration/duration.js
+++ b/src/lib/duration/duration.js
@@ -5,14 +5,12 @@ import { createDuration } from './create';
 import { isDuration } from './constructor';
 import {
     getSetRelativeTimeRounding,
-    getSetRelativeTimeThreshold,
-    getSetRelativeTimeIncludeWeeks
+    getSetRelativeTimeThreshold
 } from './humanize';
 
 export {
     createDuration,
     isDuration,
     getSetRelativeTimeRounding,
-    getSetRelativeTimeThreshold,
-    getSetRelativeTimeIncludeWeeks
+    getSetRelativeTimeThreshold
 };

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -1,18 +1,14 @@
 import { createDuration } from './create';
 
 var round = Math.round;
-
 var thresholds = {
     ss: 44,         // a few seconds to seconds
     s : 45,         // seconds to minute
     m : 45,         // minutes to hour
     h : 22,         // hours to day
-    d : 26,         // days to week/month
-    w : 4,          // weeks to months
+    d : 26,         // days to month
     M : 11          // months to year
 };
-
-var includeWeeks = false;
 
 // helper function for moment.fn.from, moment.fn.fromNow, and moment.duration.fn.humanize
 function substituteTimeAgo(string, number, withoutSuffix, isFuture, locale) {
@@ -20,14 +16,13 @@ function substituteTimeAgo(string, number, withoutSuffix, isFuture, locale) {
 }
 
 function relativeTime (posNegDuration, withoutSuffix, locale) {
-    var duration   = createDuration(posNegDuration).abs();
-    var seconds    = round(duration.as('s'));
-    var minutes    = round(duration.as('m'));
-    var hours      = round(duration.as('h'));
-    var days       = round(duration.as('d'));
-    var weeks      = round(duration.as('w'));
-    var months     = round(duration.as('M'));
-    var years      = round(duration.as('y'));
+    var duration = createDuration(posNegDuration).abs();
+    var seconds  = round(duration.as('s'));
+    var minutes  = round(duration.as('m'));
+    var hours    = round(duration.as('h'));
+    var days     = round(duration.as('d'));
+    var months   = round(duration.as('M'));
+    var years    = round(duration.as('y'));
 
     var a = seconds <= thresholds.ss && ['s', seconds]  ||
             seconds < thresholds.s   && ['ss', seconds] ||
@@ -36,15 +31,10 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
             hours   <= 1             && ['h']           ||
             hours   < thresholds.h   && ['hh', hours]   ||
             days    <= 1             && ['d']           ||
-            days    < thresholds.d   && ['dd', days];
-
-    if (includeWeeks) {
-        a = a || weeks <= 1             && ['w']         ||
-                 weeks < thresholds.w   && ['ww', weeks];
-    }
-    a = a || months  <= 1             && ['M']           ||
-             months  < thresholds.M   && ['MM', months]  ||
-             years   <= 1             && ['y']           || ['yy', years];
+            days    < thresholds.d   && ['dd', days]    ||
+            months  <= 1             && ['M']           ||
+            months  < thresholds.M   && ['MM', months]  ||
+            years   <= 1             && ['y']           || ['yy', years];
 
     a[2] = withoutSuffix;
     a[3] = +posNegDuration > 0;
@@ -78,25 +68,8 @@ export function getSetRelativeTimeThreshold (threshold, limit) {
     }
     return true;
 }
-export function getSetRelativeTimeIncludeWeeks(setIncludeWeeks) {
-    if (setIncludeWeeks === undefined) {
-        return includeWeeks;
-    }
-    if (typeof setIncludeWeeks !== 'boolean') {
-        return false;
-    }
-    includeWeeks = setIncludeWeeks;
-    if (includeWeeks === true) {
-        thresholds.w = 4;
-        thresholds.d = 7;
-    }
-    if (includeWeeks === false) {
-        delete thresholds.w;
-        thresholds.d = 26;
-    }
-    return true;
-}
-export function humanize (withSuffix, includeWeeks) {
+
+export function humanize (withSuffix) {
     if (!this.isValid()) {
         return this.localeData().invalidDate();
     }

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -6,7 +6,8 @@ var thresholds = {
     s : 45,         // seconds to minute
     m : 45,         // minutes to hour
     h : 22,         // hours to day
-    d : 26,         // days to month
+    d : 26,         // days to month/week
+    w : null,       // weeks to month
     M : 11          // months to year
 };
 
@@ -22,6 +23,7 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
     var hours    = round(duration.as('h'));
     var days     = round(duration.as('d'));
     var months   = round(duration.as('M'));
+    var weeks    = round(duration.as('w'));
     var years    = round(duration.as('y'));
 
     var a = seconds <= thresholds.ss && ['s', seconds]  ||
@@ -31,7 +33,15 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
             hours   <= 1             && ['h']           ||
             hours   < thresholds.h   && ['hh', hours]   ||
             days    <= 1             && ['d']           ||
-            days    < thresholds.d   && ['dd', days]    ||
+            days    < thresholds.d   && ['dd', days];
+
+    if (thresholds.w != null) {
+        console.log('handle weeks!');
+        a = a ||
+            weeks   <= 1             && ['w']           ||
+            weeks   < thresholds.w   && ['ww', weeks];
+    }
+    a = a ||
             months  <= 1             && ['M']           ||
             months  < thresholds.M   && ['MM', months]  ||
             years   <= 1             && ['y']           || ['yy', years];

--- a/src/lib/locale/relative.js
+++ b/src/lib/locale/relative.js
@@ -9,6 +9,8 @@ export var defaultRelativeTime = {
     hh : '%d hours',
     d  : 'a day',
     dd : '%d days',
+    w  : 'a week',
+    ww : '%d weeks',
     M  : 'a month',
     MM : '%d months',
     y  : 'a year',

--- a/src/lib/locale/relative.js
+++ b/src/lib/locale/relative.js
@@ -9,8 +9,6 @@ export var defaultRelativeTime = {
     hh : '%d hours',
     d  : 'a day',
     dd : '%d days',
-    w  : 'a week',
-    ww : '%d weeks',
     M  : 'a month',
     MM : '%d months',
     y  : 'a year',

--- a/src/moment.js
+++ b/src/moment.js
@@ -42,8 +42,7 @@ import {
     isDuration,
     createDuration              as duration,
     getSetRelativeTimeRounding  as relativeTimeRounding,
-    getSetRelativeTimeThreshold as relativeTimeThreshold,
-    getSetRelativeTimeIncludeWeeks as relativeTimeIncludeWeeks
+    getSetRelativeTimeThreshold as relativeTimeThreshold
 } from './lib/duration/duration';
 
 import { normalizeUnits } from './lib/units/units';
@@ -52,34 +51,33 @@ import isDate from './lib/utils/is-date';
 
 setHookCallback(local);
 
-moment.fn                       = fn;
-moment.min                      = min;
-moment.max                      = max;
-moment.now                      = now;
-moment.utc                      = utc;
-moment.unix                     = unix;
-moment.months                   = months;
-moment.isDate                   = isDate;
-moment.locale                   = locale;
-moment.invalid                  = invalid;
-moment.duration                 = duration;
-moment.isMoment                 = isMoment;
-moment.weekdays                 = weekdays;
-moment.parseZone                = parseZone;
-moment.localeData               = localeData;
-moment.isDuration               = isDuration;
-moment.monthsShort              = monthsShort;
-moment.weekdaysMin              = weekdaysMin;
-moment.defineLocale             = defineLocale;
-moment.updateLocale             = updateLocale;
-moment.locales                  = locales;
-moment.weekdaysShort            = weekdaysShort;
-moment.normalizeUnits           = normalizeUnits;
-moment.relativeTimeRounding     = relativeTimeRounding;
-moment.relativeTimeThreshold    = relativeTimeThreshold;
-moment.relativeTimeIncludeWeeks = relativeTimeIncludeWeeks;
-moment.calendarFormat           = getCalendarFormat;
-moment.prototype                = fn;
+moment.fn                    = fn;
+moment.min                   = min;
+moment.max                   = max;
+moment.now                   = now;
+moment.utc                   = utc;
+moment.unix                  = unix;
+moment.months                = months;
+moment.isDate                = isDate;
+moment.locale                = locale;
+moment.invalid               = invalid;
+moment.duration              = duration;
+moment.isMoment              = isMoment;
+moment.weekdays              = weekdays;
+moment.parseZone             = parseZone;
+moment.localeData            = localeData;
+moment.isDuration            = isDuration;
+moment.monthsShort           = monthsShort;
+moment.weekdaysMin           = weekdaysMin;
+moment.defineLocale          = defineLocale;
+moment.updateLocale          = updateLocale;
+moment.locales               = locales;
+moment.weekdaysShort         = weekdaysShort;
+moment.normalizeUnits        = normalizeUnits;
+moment.relativeTimeRounding  = relativeTimeRounding;
+moment.relativeTimeThreshold = relativeTimeThreshold;
+moment.calendarFormat        = getCalendarFormat;
+moment.prototype             = fn;
 
 // currently HTML5 input type only supports 24-hour formats
 moment.HTML5_FMT = {

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -82,23 +82,6 @@ test('default thresholds toNow', function (assert) {
 test('custom thresholds', function (assert) {
     var a;
 
-    // including weeks
-    moment.relativeTimeIncludeWeeks(true);
-    // threshold for days to weeks with including weeks
-    a = moment();
-    a.subtract(6, 'days');
-    assert.equal(a.fromNow(), '6 days ago', 'Below threshold days for weeks');
-    a.subtract(1, 'days');
-    assert.equal(a.fromNow(), 'a week ago', 'Above threshold days for weeks');
-
-    // threshold for days to weeks with including weeks
-    a = moment();
-    a.subtract(3, 'weeks');
-    assert.equal(a.fromNow(), '3 weeks ago', 'Below threshold weeks for months');
-    a.subtract(1, 'week');
-    assert.equal(a.fromNow(), 'a month ago', 'Above threshold weeks for months');
-    moment.relativeTimeIncludeWeeks(false);
-    assert.equal(moment.relativeTimeIncludeWeeks(), false);
     // Seconds to minute threshold, under 30
     moment.relativeTimeThreshold('s', 25);
 

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -80,8 +80,28 @@ test('default thresholds toNow', function (assert) {
 });
 
 test('custom thresholds', function (assert) {
-    var a;
+    var a, dd;
 
+    // including weeks
+    moment.relativeTimeThreshold('w', 4);
+    dd = moment.relativeTimeThreshold('d');
+    moment.relativeTimeThreshold('d', 7);
+    // threshold for days to weeks with including weeks
+    a = moment();
+    a.subtract(6, 'days');
+    assert.equal(a.fromNow(), '6 days ago', 'Below threshold days for weeks');
+    a.subtract(1, 'days');
+    assert.equal(a.fromNow(), 'a week ago', 'Above threshold days for weeks');
+
+    // threshold for days to weeks with including weeks
+    a = moment();
+    a.subtract(3, 'weeks');
+    assert.equal(a.fromNow(), '3 weeks ago', 'Below threshold weeks for months');
+    a.subtract(1, 'week');
+    assert.equal(a.fromNow(), 'a month ago', 'Above threshold weeks for months');
+    // moment.relativeTimeIncludeWeeks(false);
+    moment.relativeTimeThreshold('w', null);
+    moment.relativeTimeThreshold('d', dd);
     // Seconds to minute threshold, under 30
     moment.relativeTimeThreshold('s', 25);
 


### PR DESCRIPTION
This patch adds support for relative time in the form '%d weeks'. It is by default disabled. To enable it set relativeTimeThreshold for 'w' to a number (like 4), and optionally lower the 'd' threshold (like 7), so
anything >= 7 days is considered a week, and 4 weeks are considered a month.


Related #4910
