### PR TITLE
[feature] Support relative weeks

### DIFF
--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -6,7 +6,8 @@ var thresholds = {
     s : 45,         // seconds to minute
     m : 45,         // minutes to hour
     h : 22,         // hours to day
-    d : 26,         // days to month
+    d : 26,         // days to month/week
+    w : null,       // weeks to month
     M : 11          // months to year
 };
 
@@ -22,6 +23,7 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
     var hours    = round(duration.as('h'));
     var days     = round(duration.as('d'));
     var months   = round(duration.as('M'));
+    var weeks    = round(duration.as('w'));
     var years    = round(duration.as('y'));
 
     var a = seconds <= thresholds.ss && ['s', seconds]  ||
@@ -31,7 +33,14 @@ function relativeTime (posNegDuration, withoutSuffix, locale) {
             hours   <= 1             && ['h']           ||
             hours   < thresholds.h   && ['hh', hours]   ||
             days    <= 1             && ['d']           ||
-            days    < thresholds.d   && ['dd', days]    ||
+            days    < thresholds.d   && ['dd', days];
+
+    if (thresholds.w != null) {
+        a = a ||
+            weeks   <= 1             && ['w']           ||
+            weeks   < thresholds.w   && ['ww', weeks];
+    }
+    a = a ||
             months  <= 1             && ['M']           ||
             months  < thresholds.M   && ['MM', months]  ||
             years   <= 1             && ['y']           || ['yy', years];

--- a/src/lib/locale/relative.js
+++ b/src/lib/locale/relative.js
@@ -9,6 +9,8 @@ export var defaultRelativeTime = {
     hh : '%d hours',
     d  : 'a day',
     dd : '%d days',
+    w  : 'a week',
+    ww : '%d weeks',
     M  : 'a month',
     MM : '%d months',
     y  : 'a year',

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -80,8 +80,28 @@ test('default thresholds toNow', function (assert) {
 });
 
 test('custom thresholds', function (assert) {
-    var a;
+    var a, dd;
 
+    // including weeks
+    moment.relativeTimeThreshold('w', 4);
+    dd = moment.relativeTimeThreshold('d');
+    moment.relativeTimeThreshold('d', 7);
+    // threshold for days to weeks with including weeks
+    a = moment();
+    a.subtract(6, 'days');
+    assert.equal(a.fromNow(), '6 days ago', 'Below threshold days for weeks');
+    a.subtract(1, 'days');
+    assert.equal(a.fromNow(), 'a week ago', 'Above threshold days for weeks');
+
+    // threshold for days to weeks with including weeks
+    a = moment();
+    a.subtract(3, 'weeks');
+    assert.equal(a.fromNow(), '3 weeks ago', 'Below threshold weeks for months');
+    a.subtract(1, 'week');
+    assert.equal(a.fromNow(), 'a month ago', 'Above threshold weeks for months');
+    // moment.relativeTimeIncludeWeeks(false);
+    moment.relativeTimeThreshold('w', null);
+    moment.relativeTimeThreshold('d', dd);
     // Seconds to minute threshold, under 30
     moment.relativeTimeThreshold('s', 25);
 


### PR DESCRIPTION
This patch adds support for relative time in the form '%d weeks'. It is by default disabled. To enable it set relativeTimeThreshold for 'w' to a number (like 4), and optionally lower the 'd' threshold (like 7), so
anything >= 7 days is considered a week, and 4 weeks are considered a month.

Related #4910