### PR TITLE
[bugfix] Set name when updating non-existent locale

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -188,6 +188,12 @@ export function updateLocale(name, config) {
                 parentConfig = tmpLocale._config;
             }
             config = mergeConfigs(parentConfig, config);
+            if (tmpLocale == null) {
+                // updateLocale is called for creating a new locale
+                // Set abbr so it will have a name (getters return
+                // undefined otherwise).
+                config.abbr = name;
+            }
             locale = new Locale(config);
             locale.parentLocale = locales[name];
             locales[name] = locale;

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -286,6 +286,14 @@ test('update existing locale', function (assert) {
     moment.updateLocale('de', null);
 });
 
+test('update non-existing locale', function (assert) {
+    moment.locale('en');
+    moment.updateLocale('dude', { months: ['Movember'] });
+    assert.equal(moment.locale(), 'dude');
+    assert.equal(moment().locale('dude').locale(), 'dude');
+    moment.defineLocale('dude', null);
+});
+
 test('reset locale', function (assert) {
     moment.locale('de');
     var resultBeforeUpdate = moment('2017-02-01').format('YYYY MMM MMMM');


### PR DESCRIPTION
Fixes #5043

There is another PR for the same issue: https://github.com/moment/moment/pull/5044

The problem is the way it is handled. updateLocale was always implemented with the idea that it will handle non-existing locales. It picks the default (base) locale and updates that. The problem was that a name was not set, so after such an update the `locale()` function returned `undefined`.

So the proper fix is to simply set the locale name.