### PR TITLE
[bugfix] isoWeeksInYear was modifying the source object

### DIFF
--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -21,10 +21,6 @@ import toInt from '../utils/to-int';
 import { hooks } from '../utils/hooks';
 import { createUTCDate } from '../create/date-from-array';
 
-// CONSTANTS
-
-const THURSDAY = 4;
-
 // FORMATTING
 
 addFormatToken(0, ['gg', 2], 0, function () {
@@ -103,7 +99,7 @@ export function getSetISOWeekYear(input) {
 }
 
 export function getISOWeeksInYear() {
-    return weeksInYear(this.isoWeekday(THURSDAY).year(), 1, 4);
+    return weeksInYear(this.isoWeekYear(), 1, 4);
 }
 
 export function getWeeksInYear() {

--- a/src/test/moment/weeks_in_year.js
+++ b/src/test/moment/weeks_in_year.js
@@ -177,6 +177,7 @@ test('weeksInYear doy/dow = 0/6', function (assert) {
 });
 
 test('isoWeeksInYear calendar year !== ISO year', function (assert) {
+    var m = moment('2010-01-01');
     assert.equal(
         moment('2019-12-31').isoWeeksInYear(),
         53,
@@ -186,5 +187,15 @@ test('isoWeeksInYear calendar year !== ISO year', function (assert) {
         moment('2020-12-31').isoWeeksInYear(),
         53,
         'December 31, 2020 is in ISO year 2020 and ISO year 2020 has 53 weeks'
+    );
+    assert.equal(
+        m.isoWeeksInYear(),
+        53,
+        '2010-01-01 is isoWeekYear 2009, which has 53 iso weeks'
+    );
+    assert.equal(
+        +m,
+        +moment('2010-01-01'),
+        'isoWeeksInYear does not modify moment object'
     );
 });


### PR DESCRIPTION
I noticed that isoWeeksInYear was silently modifying the object it is called on, which is pretty bad.