### PR TITLE
[feature] Add isoWeeksInISOWeekYear

### DIFF
--- a/src/lib/moment/prototype.js
+++ b/src/lib/moment/prototype.js
@@ -86,8 +86,9 @@ import {
     getSetWeekYear,
     getSetISOWeekYear,
     getWeeksInYear,
-    getISOWeeksInYear,
     getWeeksInWeekYear,
+    getISOWeeksInYear,
+    getISOWeeksInISOWeekYear,
 } from '../units/week-year';
 proto.weekYear = getSetWeekYear;
 proto.isoWeekYear = getSetISOWeekYear;
@@ -108,6 +109,7 @@ proto.isoWeek = proto.isoWeeks = getSetISOWeek;
 proto.weeksInYear = getWeeksInYear;
 proto.weeksInWeekYear = getWeeksInWeekYear;
 proto.isoWeeksInYear = getISOWeeksInYear;
+proto.isoWeeksInISOWeekYear = getISOWeeksInISOWeekYear;
 
 // Day
 import { getSetDayOfMonth } from '../units/day-of-month';

--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -99,6 +99,10 @@ export function getSetISOWeekYear(input) {
 }
 
 export function getISOWeeksInYear() {
+    return weeksInYear(this.year(), 1, 4);
+}
+
+export function getISOWeeksInISOWeekYear() {
     return weeksInYear(this.isoWeekYear(), 1, 4);
 }
 

--- a/src/test/moment/weeks_in_year.js
+++ b/src/test/moment/weeks_in_year.js
@@ -3,89 +3,112 @@ import moment from '../../moment';
 
 module('weeks in year');
 
-test('isoWeeksInYear first day of ISO Year', function (assert) {
+test('isoWeeksInYear', function (assert) {
     assert.equal(
-        moment('2003-12-29').isoWeeksInYear(),
-        53,
-        'ISO year 2004 has 53 iso weeks'
-    );
-    assert.equal(
-        moment('2005-01-03').isoWeeksInYear(),
+        moment([2005]).isoWeeksInYear(),
         52,
-        'ISO year 2005 has 53 iso weeks'
+        'ISO year 2005 has 52 iso weeks'
     );
     assert.equal(
-        moment('2006-01-02').isoWeeksInYear(),
+        moment([2006]).isoWeeksInYear(),
         52,
-        'ISO year 2006 has 53 iso weeks'
+        'ISO year 2006 has 52 iso weeks'
     );
     assert.equal(
-        moment('2007-01-01').isoWeeksInYear(),
-        52,
-        'ISO year 2007 has 52 iso weeks'
-    );
-    assert.equal(
-        moment('2007-12-31').isoWeeksInYear(),
-        52,
-        'ISO year 2008 has 53 iso weeks'
-    );
-    assert.equal(
-        moment('2008-12-29').isoWeeksInYear(),
+        moment([2009]).isoWeeksInYear(),
         53,
         'ISO year 2009 has 53 iso weeks'
     );
     assert.equal(
-        moment('2010-01-04').isoWeeksInYear(),
+        moment([2010]).isoWeeksInYear(),
+        52,
+        'ISO year 2010 has 52 iso weeks'
+    );
+});
+
+test('isoWeeksInISOWeekYear first day of ISO Year', function (assert) {
+    assert.equal(
+        moment('2003-12-29').isoWeeksInISOWeekYear(),
+        53,
+        'ISO year 2004 has 53 iso weeks'
+    );
+    assert.equal(
+        moment('2005-01-03').isoWeeksInISOWeekYear(),
+        52,
+        'ISO year 2005 has 53 iso weeks'
+    );
+    assert.equal(
+        moment('2006-01-02').isoWeeksInISOWeekYear(),
+        52,
+        'ISO year 2006 has 53 iso weeks'
+    );
+    assert.equal(
+        moment('2007-01-01').isoWeeksInISOWeekYear(),
+        52,
+        'ISO year 2007 has 52 iso weeks'
+    );
+    assert.equal(
+        moment('2007-12-31').isoWeeksInISOWeekYear(),
+        52,
+        'ISO year 2008 has 53 iso weeks'
+    );
+    assert.equal(
+        moment('2008-12-29').isoWeeksInISOWeekYear(),
+        53,
+        'ISO year 2009 has 53 iso weeks'
+    );
+    assert.equal(
+        moment('2010-01-04').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2010 has 52 iso weeks'
     );
     assert.equal(
-        moment('2011-01-03').isoWeeksInYear(),
+        moment('2011-01-03').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2011 has 52 iso weeks'
     );
     assert.equal(
-        moment('2012-01-02').isoWeeksInYear(),
+        moment('2012-01-02').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2012 has 52 iso weeks'
     );
     assert.equal(
-        moment('2012-12-31').isoWeeksInYear(),
+        moment('2012-12-31').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2013 has 52 iso weeks'
     );
     assert.equal(
-        moment('2013-12-30').isoWeeksInYear(),
+        moment('2013-12-30').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2014 has 52 iso weeks'
     );
     assert.equal(
-        moment('2014-12-29').isoWeeksInYear(),
+        moment('2014-12-29').isoWeeksInISOWeekYear(),
         53,
         'ISO year 2015 has 53 iso weeks'
     );
     assert.equal(
-        moment('2016-01-04').isoWeeksInYear(),
+        moment('2016-01-04').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2016 has 52 iso weeks'
     );
     assert.equal(
-        moment('2017-01-02').isoWeeksInYear(),
+        moment('2017-01-02').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2017 has 52 iso weeks'
     );
     assert.equal(
-        moment('2018-01-01').isoWeeksInYear(),
+        moment('2018-01-01').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2018 has 52 iso weeks'
     );
     assert.equal(
-        moment('2018-12-31').isoWeeksInYear(),
+        moment('2018-12-31').isoWeeksInISOWeekYear(),
         52,
         'ISO year 2019 has 52 iso weeks'
     );
     assert.equal(
-        moment('2019-12-30').isoWeeksInYear(),
+        moment('2019-12-30').isoWeeksInISOWeekYear(),
         53,
         'ISO year 2020 has 53 iso weeks'
     );
@@ -179,17 +202,17 @@ test('weeksInYear doy/dow = 0/6', function (assert) {
 test('isoWeeksInYear calendar year !== ISO year', function (assert) {
     var m = moment('2010-01-01');
     assert.equal(
-        moment('2019-12-31').isoWeeksInYear(),
+        moment('2019-12-31').isoWeeksInISOWeekYear(),
         53,
         'December 31, 2019 is in ISO year 2020 and ISO year 2020 has 53 weeks'
     );
     assert.equal(
-        moment('2020-12-31').isoWeeksInYear(),
+        moment('2020-12-31').isoWeeksInISOWeekYear(),
         53,
         'December 31, 2020 is in ISO year 2020 and ISO year 2020 has 53 weeks'
     );
     assert.equal(
-        m.isoWeeksInYear(),
+        m.isoWeeksInISOWeekYear(),
         53,
         '2010-01-01 is isoWeekYear 2009, which has 53 iso weeks'
     );


### PR DESCRIPTION
This redoes #4410 properly.

The problem described in #3942, is that when you query about the number of weeks in a given year (specified by a moment object), there are 2 ways to interpret the query:
1. given the current year, how many weeks are in it
2. given the current week year, how many weeks are in it

`year` vs `week year` can differ, especially around new year. Neither one of those interpretations is more correct. If you do extensive week-calendar computations, the second interpretation makes more sense, because each moment is interpreted with it's week-year, week, weekday properties. If you just want to know how many weeks does a given year have, you might just write `moment([2016]).weeksInYear()` and expect that you'll get the number of weeks in 2016 (interpretation 1), but (according to interpretation 2) that might not be the case if `2016.01.01` is in week-year 2015, and you'll get the number of weeks in 2015 instead.

That is why in addition to `weeksInYear` and `isoWeeksInYear` (which use interpretation 1), we now have `weeksInWeekYear` and `isoWeeksInISOWeekYear` that follow interpretation 2.

So this was implemented partially in #4410 (switching from interpretation 1 to 2, which is bad), #4746, and finally patched in here.