### PR TITLE
[locale] ja: Define the last day of 'Heisei' Era

### DIFF
--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -15,6 +15,7 @@ export default moment.defineLocale('ja', {
         },
         {
             since: '1989-01-08',
+            until: '2019-04-30',
             offset: 1,
             name: '平成',
             narrow: '㍻',


### PR DESCRIPTION
### Abstract
As @ichernev is mentioned in PR#5471, the until definition is missing.
So, I wrote this PR to fix this.

This patch just define the last day of 'Heisei' Era in Japanese locale.
Though the result itself is not changed.