### PR TITLE
[bugfix] Fix humanize api

### DIFF
--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -79,33 +79,27 @@ export function getSetRelativeTimeThreshold(threshold, limit) {
     return true;
 }
 
-export function humanize(withSuffixOrOptions) {
+export function humanize(argWithSuffix, argThresholds) {
     if (!this.isValid()) {
         return this.localeData().invalidDate();
     }
 
     var withSuffix = false,
         th = thresholds,
-        ws,
-        t,
         locale,
         output;
 
-    if (typeof withSuffixOrOptions === 'boolean') {
-        withSuffix = withSuffixOrOptions;
-    } else if (typeof withSuffixOrOptions === 'object') {
-        ws = withSuffixOrOptions.withSuffix;
-        if (typeof ws === 'boolean') {
-            withSuffix = ws;
-        }
-
-        t = withSuffixOrOptions.thresholds;
-        if (typeof t === 'object') {
-            // Fill in missing keys with the current values
-            th = Object.assign({}, thresholds, t);
-            if (typeof t.s === 'number') {
-                th.ss = t.s - 1;
-            }
+    if (typeof argWithSuffix === 'object') {
+        argThresholds = argWithSuffix;
+        argWithSuffix = false;
+    }
+    if (typeof argWithSuffix === 'boolean') {
+        withSuffix = argWithSuffix;
+    }
+    if (typeof argThresholds === 'object') {
+        th = Object.assign({}, thresholds, argThresholds);
+        if (argThresholds.s != null && argThresholds.ss == null) {
+            th.ss = argThresholds.s - 1;
         }
     }
 

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -1153,44 +1153,30 @@ test('humanize duration with suffix', function (assert) {
         'in a few seconds',
         '44 seconds = a few seconds'
     );
-    assert.equal(
-        moment.duration({ seconds: 44 }).humanize({ withSuffix: true }),
-        'in a few seconds',
-        '44 seconds = a few seconds'
-    );
-    assert.equal(
-        moment.duration({ seconds: -44 }).humanize({ withSuffix: true }),
-        'a few seconds ago',
-        '44 seconds = a few seconds'
-    );
-    assert.equal(
-        moment.duration({ seconds: +44 }).humanize({ withSuffix: true }),
-        'in a few seconds',
-        '44 seconds = a few seconds'
-    );
 });
 
-test('humanize duration with options', function (assert) {
+test('humanize duration with thresholds', function (assert) {
     var thresholds = { s: 9 };
     moment.locale('en');
     assert.equal(
-        moment.duration({ seconds: -10 }).humanize({ thresholds: thresholds }),
+        moment.duration({ seconds: -10 }).humanize(thresholds),
         'a minute',
         '10 seconds = a minute (with thresholds)'
     );
     assert.equal(
-        moment
-            .duration({ seconds: 10 })
-            .humanize({ thresholds: thresholds, withSuffix: true }),
+        moment.duration({ seconds: 10 }).humanize(true, thresholds),
         'in a minute',
         '10 seconds = a minute (with thresholds and suffix)'
     );
     assert.equal(
-        moment
-            .duration({ weeks: 3 })
-            .humanize({ thresholds: { d: 7, w: 4 }, withSuffix: true }),
+        moment.duration({ weeks: 3 }).humanize(true, { d: 7, w: 4 }),
         'in 3 weeks',
         'in 3 weeks = in 3 weeks (with thresholds and suffix)'
+    );
+    assert.equal(
+        moment.duration({ weeks: 3 }).humanize(false, { d: 7, w: 4 }),
+        '3 weeks',
+        '3 weeks = 3 weeks (with thresholds and suffix == false)'
     );
 });
 


### PR DESCRIPTION
Humanize API was changed in PR [4296](https://github.com/moment/moment/pull/4296) to support an options argument which
contained both suffix and thresholds. No other moment API contains such
an options object. So this change just splits suffix and thresholds into
two different arguments, allowing for arbitrary order.