### PR TITLE
[pkg] add missing ts3.1-typings folder in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "files": [
             "moment.js",
             "moment.d.ts",
+            "ts3.1-typings",
             "locale"
         ],
         "map": {


### PR DESCRIPTION
fix #5481