### PR TITLE
bugfix: missing TS3.1 typings in npm package.

### DIFF
--- a/scripts/npm_prepublish.sh
+++ b/scripts/npm_prepublish.sh
@@ -31,6 +31,7 @@ mkdir $dest
 
 cp $src/moment.js $dest
 cp $src/moment.d.ts $dest
+cp -r $src/ts3.1-typings $dest
 cp $src/package.json $dest
 cp $src/README.md $dest
 cp $src/CHANGELOG.md $dest


### PR DESCRIPTION
Fixes missing TypeScript 3.1 typings in the npm package for moment. Fixes #5486.

Since 2.25.0, package.json specifies:

```json
    "typesVersions": {
        ">=3.1": {
            "*": [
                "ts3.1-typings/*"
            ]
        }
    },
```

but the `ts3.1-typings` folder was not included in the npm package.
