### PR TITLE
[locale] Fix Indian week start date and week number

### DIFF
--- a/src/locale/en-in.js
+++ b/src/locale/en-in.js
@@ -62,7 +62,7 @@ export default moment.defineLocale('en-in', {
         return number + output;
     },
     week: {
-        dow: 1, // Monday is the first day of the week.
-        doy: 4, // The week that contains Jan 4th is the first week of the year.
+        dow: 0, // Sunday is the first day of the week.
+        doy: 6, // The week that contains Jan 1st is the first week of the year.
     },
 });

--- a/src/test/locale/en-in.js
+++ b/src/test/locale/en-in.js
@@ -40,7 +40,7 @@ test('format', function (assert) {
             ['D Do DD', '14 14th 14'],
             ['d do dddd ddd dd', '0 0th Sunday Sun Su'],
             ['DDD DDDo DDDD', '45 45th 045'],
-            ['w wo ww', '6 6th 06'],
+            ['w wo ww', '8 8th 08'],
             ['h hh', '3 03'],
             ['H HH', '15 15'],
             ['m mm', '25 25'],
@@ -404,8 +404,8 @@ test('calendar all else', function (assert) {
 test('weeks year starting sunday formatted', function (assert) {
     assert.equal(
         moment([2012, 0, 1]).format('w ww wo'),
-        '52 52 52nd',
-        'Jan  1 2012 should be week 52'
+        '1 01 1st',
+        'Jan  1 2012 should be week 1'
     );
     assert.equal(
         moment([2012, 0, 2]).format('w ww wo'),
@@ -414,8 +414,8 @@ test('weeks year starting sunday formatted', function (assert) {
     );
     assert.equal(
         moment([2012, 0, 8]).format('w ww wo'),
-        '1 01 1st',
-        'Jan  8 2012 should be week 1'
+        '2 02 2nd',
+        'Jan  8 2012 should be week 2'
     );
     assert.equal(
         moment([2012, 0, 9]).format('w ww wo'),
@@ -424,8 +424,8 @@ test('weeks year starting sunday formatted', function (assert) {
     );
     assert.equal(
         moment([2012, 0, 15]).format('w ww wo'),
-        '2 02 2nd',
-        'Jan 15 2012 should be week 2'
+        '3 03 3rd',
+        'Jan 15 2012 should be week 3'
     );
 });
 
@@ -438,8 +438,8 @@ test('Weekdays sort by locale', function (assert) {
     );
     assert.deepEqual(
         moment().localeData('en-in').weekdays(true),
-        'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'.split('_'),
-        'locale-sorted weekdays start on Monday'
+        'Sunday_Monday_Tuesday_Wednesday_Thursday_Friday_Saturday'.split('_'),
+        'locale-sorted weekdays start on Sunday'
     );
     assert.deepEqual(
         moment().localeData('en-in').weekdaysShort(),
@@ -448,8 +448,8 @@ test('Weekdays sort by locale', function (assert) {
     );
     assert.deepEqual(
         moment().localeData('en-in').weekdaysShort(true),
-        'Mon_Tue_Wed_Thu_Fri_Sat_Sun'.split('_'),
-        'locale-sorted weekdaysShort start on Monday'
+        'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
+        'locale-sorted weekdaysShort start on Sunday'
     );
     assert.deepEqual(
         moment().localeData('en-in').weekdaysMin(),
@@ -458,7 +458,7 @@ test('Weekdays sort by locale', function (assert) {
     );
     assert.deepEqual(
         moment().localeData('en-in').weekdaysMin(true),
-        'Mo_Tu_We_Th_Fr_Sa_Su'.split('_'),
-        'locale-sorted weekdaysMin start on Monday'
+        'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
+        'locale-sorted weekdaysMin start on Sunday'
     );
 });


### PR DESCRIPTION
@ichernev - following the directions in [previous PR](https://github.com/moment/moment/pull/4626#issuecomment-619652118), I'm updating the en-in locale.

The Indian week starts on a Sunday, and 1st January is the first day of the week. This is the most official source I could find:
https://unicode-org.github.io/cldr-staging/charts/37/supplemental/territory_information.html#IN

![image](https://user-images.githubusercontent.com/760112/80911423-de52ed00-8d53-11ea-889c-b71ab6e2b950.png)

If I understand the "Days in week (min)" column, the value of 1 would also mean that the first week would start on 1st Jan, even if it's a Saturday. Am I correct?