### PR TITLE
[bugfix] './locale' path not found in moment/src/lib/locale/locales.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     ],
     "main": "./moment.js",
     "jsnext:main": "./src/moment.js",
-    "module": "./src/moment.js",
     "typings": "./moment.d.ts",
     "typesVersions": {
         ">=3.1": {


### PR DESCRIPTION
seems root of issue was introduced here: https://github.com/moment/moment/commit/9ce89e7fea881b39be23b8c0646f7ef7817985d9

So, this PR reverts it and fixes the following issues:
#4505, #5472, #5497, #5501, #5500, #5378, #5495, #5506, #5508