### PR TITLE
[bugfix] Add 'w' to supported time units.

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -17,7 +17,7 @@ declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSp
 declare function moment(inp?: moment.MomentInput, format?: moment.MomentFormatSpecification, language?: string, strict?: boolean): moment.Moment;
 
 declare namespace moment {
-  type RelativeTimeKey = 's' | 'ss' | 'm' | 'mm' | 'h' | 'hh' | 'd' | 'dd' | 'M' | 'MM' | 'y' | 'yy';
+  type RelativeTimeKey = 's' | 'ss' | 'm' | 'mm' | 'h' | 'hh' | 'd' | 'dd' | 'w' | 'M' | 'MM' | 'y' | 'yy';
   type CalendarKey = 'sameDay' | 'nextDay' | 'lastDay' | 'nextWeek' | 'lastWeek' | 'sameElse' | string;
   type LongDateFormatKey = 'LTS' | 'LT' | 'L' | 'LL' | 'LLL' | 'LLLL' | 'lts' | 'lt' | 'l' | 'll' | 'lll' | 'llll';
 
@@ -104,6 +104,7 @@ declare namespace moment {
     hh?: RelativeTimeSpecVal;
     d?: RelativeTimeSpecVal;
     dd?: RelativeTimeSpecVal;
+    w?: RelativeTimeSpecVal
     M?: RelativeTimeSpecVal;
     MM?: RelativeTimeSpecVal;
     y?: RelativeTimeSpecVal;


### PR DESCRIPTION
Update moment.d.ts to include 'w' in supported time units.