### PR TITLE
[locale] (sw) Improve Translation

### DIFF
--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -41,7 +41,7 @@ export default moment.defineLocale('sw', {
         h: 'saa limoja',
         hh: 'masaa %d',
         d: 'siku moja',
-        dd: 'masiku %d',
+        dd: 'siku %d',
         M: 'mwezi mmoja',
         MM: 'miezi %d',
         y: 'mwaka mmoja',

--- a/src/test/locale/sw.js
+++ b/src/test/locale/sw.js
@@ -209,7 +209,7 @@ test('from', function (assert) {
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ h: 36 }), true),
-        'masiku 2',
+        'siku 2',
         '36 hours = 2 days'
     );
     assert.equal(
@@ -219,12 +219,12 @@ test('from', function (assert) {
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ d: 5 }), true),
-        'masiku 5',
+        'siku 5',
         '5 days = 5 days'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ d: 25 }), true),
-        'masiku 25',
+        'siku 25',
         '25 days = 25 days'
     );
     assert.equal(
@@ -310,7 +310,7 @@ test('fromNow', function (assert) {
     );
     assert.equal(
         moment().add({ d: 5 }).fromNow(),
-        'masiku 5 baadaye',
+        'siku 5 baadaye',
         'in 5 days'
     );
 });


### PR DESCRIPTION
It appears that "masiku" does not usually have a plural , going back to "siku" ,
Other prepositions from https://github.com/moment/moment/pull/5544 sounds a bit nice and native,

 But, sadly we cannot have them since they are likely to change on future Relative Time , so it is better if they stay that way

fixes https://github.com/moment/moment/issues/5182