### PR TITLE
[bugfix] isoWeeksInISOWeekYear in moment.d.ts

### DIFF
--- a/ts3.1-typing-tests/moment-tests.ts
+++ b/ts3.1-typing-tests/moment-tests.ts
@@ -136,6 +136,9 @@ moment().isoWeeks();
 moment().isoWeeks(45);
 moment().dayOfYear();
 moment().dayOfYear(45);
+moment().weeksInYear();
+moment().isoWeeksInYear();
+moment().isoWeeksInISOWeekYear();
 
 moment().set('year', 2013);
 moment().set('month', 3);  // April

--- a/ts3.1-typings/moment.d.ts
+++ b/ts3.1-typings/moment.d.ts
@@ -543,6 +543,7 @@ declare namespace moment {
     isoWeeks(d: number): Moment;
     weeksInYear(): number;
     isoWeeksInYear(): number;
+    isoWeeksInISOWeekYear(): number;
     dayOfYear(): number;
     dayOfYear(d: number): Moment;
 

--- a/typing-tests/moment-tests.ts
+++ b/typing-tests/moment-tests.ts
@@ -139,6 +139,9 @@ moment().isoWeeks();
 moment().isoWeeks(45);
 moment().dayOfYear();
 moment().dayOfYear(45);
+moment().weeksInYear();
+moment().isoWeeksInYear();
+moment().isoWeeksInISOWeekYear();
 
 moment().set('year', 2013);
 moment().set('month', 3);  // April


### PR DESCRIPTION
## Summary
<img width="435" alt="ts_bug" src="https://user-images.githubusercontent.com/21104054/82196690-98d61880-992c-11ea-8b7a-ad5de82f8be9.png">

## Test plan
`ts3.1-typing-tests/moment-tests.ts` and `typing-tests/moment-tests.ts`
