### PR TITLE
[locale] id: Sunday changed to first day of week

### DIFF
--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -70,7 +70,7 @@ export default moment.defineLocale('id', {
         yy: '%d tahun',
     },
     week: {
-        dow: 1, // Monday is the first day of the week.
-        doy: 7, // The week that contains Jan 7th is the first week of the year.
+        dow: 0, // Sunday is the first day of the week.
+        doy: 6, // The week that contains Jan 6th is the first week of the year.
     },
 });

--- a/src/test/locale/id.js
+++ b/src/test/locale/id.js
@@ -55,7 +55,7 @@ test('format', function (assert) {
             ['D Do DD', '14 14 14'],
             ['d do dddd ddd dd', '0 0 Minggu Min Mg'],
             ['DDD DDDo DDDD', '45 45 045'],
-            ['w wo ww', '7 7 07'],
+            ['w wo ww', '8 8 08'],
             ['h hh', '3 03'],
             ['H HH', '15 15'],
             ['m mm', '25 25'],
@@ -380,19 +380,19 @@ test('calendar all else', function (assert) {
 
 test('weeks year starting sunday formatted', function (assert) {
     assert.equal(
-        moment([2011, 11, 26]).format('w ww wo'),
-        '1 01 1',
-        'Dec 26 2011 should be week 1'
-    );
-    assert.equal(
         moment([2012, 0, 1]).format('w ww wo'),
         '1 01 1',
-        'Jan  1 2012 should be week 1'
+        'Jan 1 2012 should be week 1'
     );
     assert.equal(
         moment([2012, 0, 2]).format('w ww wo'),
-        '2 02 2',
-        'Jan  2 2012 should be week 2'
+        '1 01 1',
+        'Jan  2 2012 should be week 1'
+    );
+    assert.equal(
+        moment([2012, 0, 7]).format('w ww wo'),
+        '1 01 1',
+        'Jan  7 2012 should be week 1'
     );
     assert.equal(
         moment([2012, 0, 8]).format('w ww wo'),
@@ -400,8 +400,8 @@ test('weeks year starting sunday formatted', function (assert) {
         'Jan  8 2012 should be week 2'
     );
     assert.equal(
-        moment([2012, 0, 9]).format('w ww wo'),
-        '3 03 3',
-        'Jan  9 2012 should be week 3'
+        moment([2012, 0, 14]).format('w ww wo'),
+        '2 02 2',
+        'Jan  14 2012 should be week 2'
     );
 });


### PR DESCRIPTION
Fixes #5370

Sunday changed to first day of week for Indonesia locale.

Fixes done assuming that doy should be changed to 06, as that is the case for most locales where dow is 0.