### PR TITLE
[locale] ru: fixes

### DIFF
--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -1,7 +1,7 @@
 //! moment.js locale configuration
 //! locale : Russian [ru]
 //! author : Viktorminator : https://github.com/Viktorminator
-//! Author : Menelion Elensúle : https://github.com/Oire
+//! author : Menelion Elensúle : https://github.com/Oire
 //! author : Коренберг Марк : https://github.com/socketpair
 
 import moment from '../moment';
@@ -57,7 +57,7 @@ export default moment.defineLocale('ru', {
         ),
     },
     monthsShort: {
-        // по CLDR именно "июл." и "июн.", но какой смысл менять букву на точку ?
+        // по CLDR именно "июл." и "июн.", но какой смысл менять букву на точку?
         format: 'янв._февр._мар._апр._мая_июня_июля_авг._сент._окт._нояб._дек.'.split(
             '_'
         ),
@@ -72,7 +72,7 @@ export default moment.defineLocale('ru', {
         format: 'воскресенье_понедельник_вторник_среду_четверг_пятницу_субботу'.split(
             '_'
         ),
-        isFormat: /\[ ?[Вв] ?(?:прошлую|следующую|эту)? ?\] ?dddd/,
+        isFormat: /\[ ?[Вв] ?(?:прошлую|следующую|эту)? ?] ?dddd/,
     },
     weekdaysShort: 'вс_пн_вт_ср_чт_пт_сб'.split('_'),
     weekdaysMin: 'вс_пн_вт_ср_чт_пт_сб'.split('_'),
@@ -89,7 +89,7 @@ export default moment.defineLocale('ru', {
     // полные названия с падежами
     monthsStrictRegex: /^(январ[яь]|феврал[яь]|марта?|апрел[яь]|ма[яй]|июн[яь]|июл[яь]|августа?|сентябр[яь]|октябр[яь]|ноябр[яь]|декабр[яь])/i,
 
-    // Выражение, которое соотвествует только сокращённым формам
+    // Выражение, которое соответствует только сокращённым формам
     monthsShortStrictRegex: /^(янв\.|февр?\.|мар[т.]|апр\.|ма[яй]|июн[ья.]|июл[ья.]|авг\.|сент?\.|окт\.|нояб?\.|дек\.)/i,
     longDateFormat: {
         LT: 'H:mm',


### PR DESCRIPTION
Only `[ \ ^ $ . | ? * + ( )` need to be escaped, so remove redundant `\` before `]`.