### PR TITLE
[locale] (sw) Changed LT to include meridiem

### DIFF
--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -16,7 +16,7 @@ export default moment.defineLocale('sw', {
     weekdaysMin: 'J2_J3_J4_J5_Al_Ij_J1'.split('_'),
     weekdaysParseExact: true,
     longDateFormat: {
-        LT: 'HH:mm',
+        LT: 'hh:mm A',
         LTS: 'HH:mm:ss',
         L: 'DD.MM.YYYY',
         LL: 'D MMMM YYYY',

--- a/src/test/locale/sw.js
+++ b/src/test/locale/sw.js
@@ -319,32 +319,32 @@ test('calendar day', function (assert) {
     var a = moment().hours(12).minutes(0).seconds(0);
     assert.equal(
         moment(a).calendar(),
-        'leo saa 12:00',
+        'leo saa 12:00 PM',
         'today at the same time'
     );
     assert.equal(
         moment(a).add({ m: 25 }).calendar(),
-        'leo saa 12:25',
+        'leo saa 12:25 PM',
         'Now plus 25 min'
     );
     assert.equal(
         moment(a).add({ h: 1 }).calendar(),
-        'leo saa 13:00',
+        'leo saa 01:00 PM',
         'Now plus 1 hour'
     );
     assert.equal(
         moment(a).add({ d: 1 }).calendar(),
-        'kesho saa 12:00',
+        'kesho saa 12:00 PM',
         'tomorrow at the same time'
     );
     assert.equal(
         moment(a).subtract({ h: 1 }).calendar(),
-        'leo saa 11:00',
+        'leo saa 11:00 AM',
         'Now minus 1 hour'
     );
     assert.equal(
         moment(a).subtract({ d: 1 }).calendar(),
-        'jana 12:00',
+        'jana 12:00 PM',
         'yesterday at the same time'
     );
 });


### PR DESCRIPTION
Reverting format to the default behaviour as of https://github.com/moment/moment/issues/5366 , using All Caps for AM & PM