### PR TITLE
[bugfix] Fix the bug of repeatedly setting `weekYear (number)`

### DIFF
--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -77,6 +77,14 @@ addWeekParseToken(['gg', 'GG'], function (input, week, config, token) {
 // MOMENTS
 
 export function getSetWeekYear(input) {
+    if (
+        input != null &&
+        this.format(this._f) !== this._i &&
+        hooks.isMoment(this)
+    ) {
+        var createFunc = this._isUTC ? hooks.utc : hooks;
+        this._d = createFunc(this._i, this._f, this._strict)._d;
+    }
     return getSetWeekYearHelper.call(
         this,
         input,

--- a/src/test/moment/week_year.js
+++ b/src/test/moment/week_year.js
@@ -1075,12 +1075,24 @@ test('week year setter works', function (assert) {
 });
 
 test('week year repeatedly settings under different locales', function (assert) {
-    var localeList = [[1, 4, '2015-12-31 Th'], [1, 7, '2015-01-01 Th'], [0, 6, '2015-01-02 Fr'], [6, 12, '2015-12-27 Sa']];
-    for (var i = 0, len = localeList.length; i < len; i++) {
-        var item = localeList[i];
-        moment.locale('locale test' + i, { week: { dow: item[0], doy: item[1] } })
-        var originDate = moment.utc('2016-01-01', moment.ISO_8601, true)
-        for (var j = 0; j < 3; j++) {
+    var localeList = [
+            [1, 4, '2015-12-31 Th'],
+            [1, 7, '2015-01-01 Th'],
+            [0, 6, '2015-01-02 Fr'],
+            [6, 12, '2015-12-27 Sa'],
+        ],
+        i,
+        j,
+        len,
+        originDate,
+        item;
+    for (i = 0, len = localeList.length; i < len; i++) {
+        item = localeList[i];
+        moment.locale('locale test' + i, {
+            week: { dow: item[0], doy: item[1] },
+        });
+        originDate = moment.utc('2016-01-01', moment.ISO_8601, true);
+        for (j = 0; j < 3; j++) {
             assert.equal(
                 originDate.weekYear(2015).format('gggg-MM-DD dd'),
                 item[2],

--- a/src/test/moment/week_year.js
+++ b/src/test/moment/week_year.js
@@ -1073,3 +1073,19 @@ test('week year setter works', function (assert) {
         '2013-w30-4 to 2015'
     );
 });
+
+test('week year repeatedly settings under different locales', function (assert) {
+    var localeList = [[1, 4, '2015-12-31 Th'], [1, 7, '2015-01-01 Th'], [0, 6, '2015-01-02 Fr'], [6, 12, '2015-12-27 Sa']];
+    for (var i = 0, len = localeList.length; i < len; i++) {
+        var item = localeList[i];
+        moment.locale('locale test' + i, { week: { dow: item[0], doy: item[1] } })
+        var originDate = moment.utc('2016-01-01', moment.ISO_8601, true)
+        for (var j = 0; j < 3; j++) {
+            assert.equal(
+                originDate.weekYear(2015).format('gggg-MM-DD dd'),
+                item[2],
+                '2016-01-01 to 2015'
+            );
+        }
+    }
+});


### PR DESCRIPTION
fixes #3944

## Changes
* Fix the bug of repeatedly setting `weekYear (number)`, Keep the purity of `this._d` when repeating settings.
* Fix for issue #3944 .

## Test plan
` src/test/moment/week_year.js`