### PR TITLE
[bugfix] Do not set locale in updateLocale or defineLocale

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -155,11 +155,6 @@ export function defineLocale(name, config) {
             });
         }
 
-        // backwards compat for now: also set the locale
-        // make sure we set the locale AFTER all child locales have been
-        // created, so we won't end up with the child locale set.
-        getSetGlobalLocale(name);
-
         return locales[name];
     } else {
         // useful for testing
@@ -195,8 +190,9 @@ export function updateLocale(name, config) {
             locales[name] = locale;
         }
 
-        // backwards compat for now: also set the locale
-        getSetGlobalLocale(name);
+        if (name === getSetGlobalLocale()) {
+            getSetGlobalLocale(name);
+        }
     } else {
         // pass null for config to unupdate, useful for tests
         if (locales[name] != null) {

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -189,10 +189,6 @@ export function updateLocale(name, config) {
             locale.parentLocale = locales[name];
             locales[name] = locale;
         }
-
-        if (name === getSetGlobalLocale()) {
-            getSetGlobalLocale(name);
-        }
     } else {
         // pass null for config to unupdate, useful for tests
         if (locales[name] != null) {

--- a/src/test/moment/calendar.js
+++ b/src/test/moment/calendar.js
@@ -61,6 +61,7 @@ test('extending calendar options', function (assert) {
             sameElse: 'L',
         },
     });
+    moment.locale('en');
 
     a = moment('2016-01-01').add(28, 'days');
     b = moment('2016-01-01').add(1, 'month');

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -575,6 +575,7 @@ test('week year formats', function (assert) {
     };
 
     moment.defineLocale('dow:1,doy:4', { week: { dow: 1, doy: 4 } });
+    moment.locale('dow:1,doy:4');
 
     eachOwnProp(cases, function (i) {
         var isoWeekYear, formatted5, formatted4, formatted2;
@@ -641,6 +642,7 @@ test('iso weekday formats', function (assert) {
 
 test('weekday formats', function (assert) {
     moment.defineLocale('dow: 3,doy: 5', { week: { dow: 3, doy: 5 } });
+    moment.locale('dow: 3,doy: 5');
     assert.equal(
         moment([1985, 1, 6]).format('e'),
         '0',
@@ -690,6 +692,7 @@ test('toJSON skips postformat', function (assert) {
             s.replace(/./g, 'X');
         },
     });
+    moment.locale('postformat');
     assert.equal(
         moment.utc([2000, 0, 1]).toJSON(),
         '2000-01-01T00:00:00.000Z',

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -272,7 +272,11 @@ test('library deprecations', function (assert) {
 test('defineLocale', function (assert) {
     moment.locale('en');
     moment.defineLocale('dude', { months: ['Movember'] });
-    assert.equal(moment().locale(), 'dude', 'defineLocale also sets it');
+    assert.equal(
+        moment().locale(),
+        'en',
+        'defineLocale does not set the locale'
+    );
     assert.equal(
         moment().locale('dude').locale(),
         'dude',
@@ -965,6 +969,7 @@ test('when in strict mode with inexact parsing, treat periods in short weekdays 
         weekdaysShort: 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),
         weekdaysParseExact: false,
     });
+    moment.locale('periods-in-short-weekdays');
 
     moment().locale('periods-in-short-weekdays');
     assert.equal(moment('thurs', 'ddd', true).format('dddd'), 'Thursday');
@@ -978,6 +983,7 @@ test('when in strict mode with inexact parsing, treat periods in full weekdays l
         weekdaysShort: 'mon_tues_wed_thurs_fri_sat_sun'.split('_'),
         weekdaysParseExact: false,
     });
+    moment.locale('periods-in-full-weekdays');
 
     moment().locale('periods-in-full-weekdays');
     assert.equal(moment('Thursday', 'dddd', true).format('ddd'), 'thurs');
@@ -991,6 +997,7 @@ test('when in strict mode with inexact parsing, treat periods in min-weekdays li
         weekdaysMin: 'mon_t...s_wed_thurs_fri_sat_sun'.split('_'),
         weekdaysParseExact: false,
     });
+    moment.locale('periods-in-min-weekdays');
 
     moment().locale('periods-in-min-weekdays');
     assert.equal(moment('thurs', 'dd', true).format('dddd'), 'Thursday');

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -175,6 +175,7 @@ test('ordinal', function (assert) {
         parentLocale: 'base-ordinal-1',
         ordinal: '%dy',
     });
+    moment.locale('child-ordinal-1');
 
     assert.equal(
         moment.utc('2015-02-03', moment.ISO_8601).format('Do'),
@@ -191,6 +192,7 @@ test('ordinal', function (assert) {
             return num + 'y';
         },
     });
+    moment.locale('child-ordinal-2');
 
     assert.equal(
         moment.utc('2015-02-03', moment.ISO_8601).format('Do'),
@@ -207,6 +209,7 @@ test('ordinal', function (assert) {
         parentLocale: 'base-ordinal-3',
         ordinal: '%dy',
     });
+    moment.locale('child-ordinal-3');
 
     assert.equal(
         moment.utc('2015-02-03', moment.ISO_8601).format('Do'),
@@ -223,6 +226,7 @@ test('ordinal parse', function (assert) {
         parentLocale: 'base-ordinal-parse-1',
         dayOfMonthOrdinalParse: /\d{1,2}y/,
     });
+    moment.locale('child-ordinal-parse-1');
 
     assert.ok(
         moment.utc('2015-01-1y', 'YYYY-MM-Do', true).isValid(),
@@ -236,6 +240,7 @@ test('ordinal parse', function (assert) {
         parentLocale: 'base-ordinal-parse-2',
         dayOfMonthOrdinalParse: /\d{1,2}/,
     });
+    moment.locale('child-ordinal-parse-2');
 
     assert.ok(
         moment.utc('2015-01-1', 'YYYY-MM-Do', true).isValid(),
@@ -255,6 +260,7 @@ test('months', function (assert) {
             '_'
         ),
     });
+    moment.locale('child-months');
     assert.ok(
         moment.utc('2015-01-01', 'YYYY-MM-DD').format('MMMM'),
         'First',
@@ -272,6 +278,7 @@ test('define child locale before parent', function (assert) {
             '_'
         ),
     });
+    moment.locale('months-x');
     assert.equal(
         moment.locale(),
         'en',
@@ -293,11 +300,6 @@ test('define child locale before parent', function (assert) {
             '_'
         ),
     });
-    assert.equal(
-        moment.locale(),
-        'base-months-x',
-        'defineLocale should also set the locale (regardless of child locales)'
-    );
 
     assert.equal(
         moment().locale('months-x').month(0).format('MMMM'),
@@ -324,6 +326,7 @@ test('lazy load parentLocale', function (assert) {
             'M12',
         ],
     });
+    moment.locale('de_test');
     assert.equal(
         moment.locale(),
         'de_test',

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -174,6 +174,7 @@ test('ordinal', function (assert) {
     moment.updateLocale('ordinal-1', {
         ordinal: '%dy',
     });
+    moment.locale('ordinal-1');
 
     assert.equal(
         moment.utc('2015-02-03', moment.ISO_8601).format('Do'),
@@ -190,6 +191,7 @@ test('ordinal', function (assert) {
             return num + 'y';
         },
     });
+    moment.locale('ordinal-2');
 
     assert.equal(
         moment.utc('2015-02-03', moment.ISO_8601).format('Do'),
@@ -206,6 +208,7 @@ test('ordinal', function (assert) {
     moment.updateLocale('ordinal-3', {
         ordinal: '%dy',
     });
+    moment.locale('ordinal-3');
 
     assert.equal(
         moment.utc('2015-02-03', moment.ISO_8601).format('Do'),
@@ -222,6 +225,7 @@ test('ordinal parse', function (assert) {
     moment.updateLocale('ordinal-parse-1', {
         dayOfMonthOrdinalParse: /\d{1,2}y/,
     });
+    moment.locale('ordinal-parse-1');
 
     assert.ok(
         moment.utc('2015-01-1y', 'YYYY-MM-Do', true).isValid(),
@@ -235,6 +239,7 @@ test('ordinal parse', function (assert) {
     moment.updateLocale('ordinal-parse-2', {
         dayOfMonthOrdinalParse: /\d{1,2}/,
     });
+    moment.locale('ordinal-parse-2');
 
     assert.ok(
         moment.utc('2015-01-1', 'YYYY-MM-Do', true).isValid(),
@@ -255,6 +260,7 @@ test('months', function (assert) {
             '_'
         ),
     });
+    moment.locale('months');
     assert.ok(
         moment.utc('2015-01-01', 'YYYY-MM-DD').format('MMMM'),
         'First',
@@ -263,6 +269,7 @@ test('months', function (assert) {
 });
 
 test('update existing locale', function (assert) {
+    moment.locale('de');
     moment.updateLocale('de', {
         monthsShort: [
             'JAN',
@@ -279,6 +286,7 @@ test('update existing locale', function (assert) {
             'DEZ',
         ],
     });
+
     assert.equal(
         moment('2017-02-01').format('YYYY MMM MMMM'),
         '2017 FEB Februar'
@@ -289,6 +297,7 @@ test('update existing locale', function (assert) {
 test('update non-existing locale', function (assert) {
     moment.locale('en');
     moment.updateLocale('dude', { months: ['Movember'] });
+    moment.locale('dude');
     assert.equal(moment.locale(), 'dude');
     assert.equal(moment().locale('dude').locale(), 'dude');
     moment.defineLocale('dude', null);

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -269,7 +269,6 @@ test('months', function (assert) {
 });
 
 test('update existing locale', function (assert) {
-    moment.locale('de');
     moment.updateLocale('de', {
         monthsShort: [
             'JAN',
@@ -286,6 +285,7 @@ test('update existing locale', function (assert) {
             'DEZ',
         ],
     });
+    moment.locale('de');
 
     assert.equal(
         moment('2017-02-01').format('YYYY MMM MMMM'),


### PR DESCRIPTION
Addresses #5410 

The issue mentions updateLocale but uses defineLocale in the example - it seems that consistent logic between the two would be desirable so I modified both.