### PR TITLE
[bugfix] Stricter single digit date parsing

### DIFF
--- a/src/lib/parse/regex.js
+++ b/src/lib/parse/regex.js
@@ -17,6 +17,8 @@ var match1 = /\d/, //       0 - 9
     // any word (or two) characters or numbers including two/three word month in arabic.
     // includes scottish gaelic two word and hyphenated months
     matchWord = /[0-9]{0,256}['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFF07\uFF10-\uFFEF]{1,256}|[\u0600-\u06FF\/]{1,256}(\s*?[\u0600-\u06FF]{1,256}){1,2}/i,
+    match1to2NoLeadingZero = /^[1-9]\d?/, //         1-99
+    match1to2HasZero = /^([1-9]\d|\d)/, //           0-99
     regexes;
 
 export {
@@ -37,6 +39,8 @@ export {
     matchShortOffset,
     matchTimestamp,
     matchWord,
+    match1to2NoLeadingZero,
+    match1to2HasZero,
 };
 
 import hasOwnProp from '../utils/has-own-prop';

--- a/src/lib/units/day-of-month.js
+++ b/src/lib/units/day-of-month.js
@@ -2,7 +2,12 @@ import { makeGetSet } from '../moment/get-set';
 import { addFormatToken } from '../format/format';
 import { addUnitAlias } from './aliases';
 import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
+import {
+    addRegexToken,
+    match1to2,
+    match2,
+    match1to2NoLeadingZero,
+} from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { DATE } from './constants';
 import toInt from '../utils/to-int';
@@ -20,7 +25,7 @@ addUnitPriority('date', 9);
 
 // PARSING
 
-addRegexToken('D', match1to2);
+addRegexToken('D', match1to2, match1to2NoLeadingZero);
 addRegexToken('DD', match1to2, match2);
 addRegexToken('Do', function (isStrict, locale) {
     // TODO: Remove "ordinalParse" fallback in next major release.

--- a/src/lib/units/hour.js
+++ b/src/lib/units/hour.js
@@ -8,6 +8,8 @@ import {
     match2,
     match3to4,
     match5to6,
+    match1to2NoLeadingZero,
+    match1to2HasZero,
 } from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { HOUR, MINUTE, SECOND } from './constants';
@@ -83,9 +85,9 @@ function matchMeridiem(isStrict, locale) {
 
 addRegexToken('a', matchMeridiem);
 addRegexToken('A', matchMeridiem);
-addRegexToken('H', match1to2);
-addRegexToken('h', match1to2);
-addRegexToken('k', match1to2);
+addRegexToken('H', match1to2, match1to2HasZero);
+addRegexToken('h', match1to2, match1to2NoLeadingZero);
+addRegexToken('k', match1to2, match1to2NoLeadingZero);
 addRegexToken('HH', match1to2, match2);
 addRegexToken('hh', match1to2, match2);
 addRegexToken('kk', match1to2, match2);

--- a/src/lib/units/minute.js
+++ b/src/lib/units/minute.js
@@ -2,7 +2,12 @@ import { makeGetSet } from '../moment/get-set';
 import { addFormatToken } from '../format/format';
 import { addUnitAlias } from './aliases';
 import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
+import {
+    addRegexToken,
+    match1to2,
+    match2,
+    match1to2HasZero,
+} from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { MINUTE } from './constants';
 
@@ -20,7 +25,7 @@ addUnitPriority('minute', 14);
 
 // PARSING
 
-addRegexToken('m', match1to2);
+addRegexToken('m', match1to2, match1to2HasZero);
 addRegexToken('mm', match1to2, match2);
 addParseToken(['m', 'mm'], MINUTE);
 

--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -9,6 +9,7 @@ import {
     match2,
     matchWord,
     regexEscape,
+    match1to2NoLeadingZero,
 } from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { hooks } from '../utils/hooks';
@@ -59,7 +60,7 @@ addUnitPriority('month', 8);
 
 // PARSING
 
-addRegexToken('M', match1to2);
+addRegexToken('M', match1to2, match1to2NoLeadingZero);
 addRegexToken('MM', match1to2, match2);
 addRegexToken('MMM', function (isStrict, locale) {
     return locale.monthsShortRegex(isStrict);

--- a/src/lib/units/second.js
+++ b/src/lib/units/second.js
@@ -2,7 +2,12 @@ import { makeGetSet } from '../moment/get-set';
 import { addFormatToken } from '../format/format';
 import { addUnitAlias } from './aliases';
 import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
+import {
+    addRegexToken,
+    match1to2,
+    match2,
+    match1to2HasZero,
+} from '../parse/regex';
 import { addParseToken } from '../parse/token';
 import { SECOND } from './constants';
 
@@ -20,7 +25,7 @@ addUnitPriority('second', 15);
 
 // PARSING
 
-addRegexToken('s', match1to2);
+addRegexToken('s', match1to2, match1to2HasZero);
 addRegexToken('ss', match1to2, match2);
 addParseToken(['s', 'ss'], SECOND);
 

--- a/src/lib/units/week.js
+++ b/src/lib/units/week.js
@@ -1,7 +1,12 @@
 import { addFormatToken } from '../format/format';
 import { addUnitAlias } from './aliases';
 import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
+import {
+    addRegexToken,
+    match1to2,
+    match2,
+    match1to2NoLeadingZero,
+} from '../parse/regex';
 import { addWeekParseToken } from '../parse/token';
 import toInt from '../utils/to-int';
 import { weekOfYear } from './week-calendar-utils';
@@ -23,9 +28,9 @@ addUnitPriority('isoWeek', 5);
 
 // PARSING
 
-addRegexToken('w', match1to2);
+addRegexToken('w', match1to2, match1to2NoLeadingZero);
 addRegexToken('ww', match1to2, match2);
-addRegexToken('W', match1to2);
+addRegexToken('W', match1to2, match1to2NoLeadingZero);
 addRegexToken('WW', match1to2, match2);
 
 addWeekParseToken(['w', 'ww', 'W', 'WW'], function (

--- a/src/test/locale/es-us.js
+++ b/src/test/locale/es-us.js
@@ -483,7 +483,7 @@ test('test short months proper', function (assert) {
 
 test('test lenient month parsing', function (assert) {
     assert.ok(
-        moment('nov 01, 2015', 'MMM D, YYYY', true).isValid(),
+        moment('nov 01, 2015', 'MMM DD, YYYY', true).isValid(),
         'nov 01, 2015 should parse correctly'
     );
 });

--- a/src/test/moment/create.js
+++ b/src/test/moment/create.js
@@ -2199,8 +2199,8 @@ test('strict parsing', function (assert) {
     );
     assert.equal(
         moment('2012-05-25', 'YYYY-M-DD', true).isValid(),
-        true,
-        'valid one-digit month'
+        false,
+        'isValid one-digit month'
     );
     assert.equal(
         moment('2012-05-25', 'YYYY-MM-DD', true).isValid(),
@@ -2220,8 +2220,8 @@ test('strict parsing', function (assert) {
     );
     assert.equal(
         moment('2012-05-02', 'YYYY-MM-D', true).isValid(),
-        true,
-        'valid two-digit day'
+        false,
+        'isValid two-digit day'
     );
     assert.equal(
         moment('2012-05-02', 'YYYY-MM-DD', true).isValid(),
@@ -2255,6 +2255,114 @@ test('strict parsing', function (assert) {
         moment('123', 'S', true).isValid(),
         false,
         'invalid three-digit milisecond'
+    );
+
+    assert.equal(
+        moment('2002-05-02 09:30:26', 'YYYY-MM-DD H:mm:ss', true).isValid(),
+        false,
+        'invalid two-digit hour'
+    );
+
+    assert.equal(
+        moment('2002-05-02 11:30:26', 'YYYY-MM-DD H:mm:ss', true).isValid(),
+        true,
+        'valid two-digit hour'
+    );
+
+    assert.equal(
+        moment('2002-05-02 09:30:26', 'YYYY-MM-DD h:mm:ss', true).isValid(),
+        false,
+        'invalid two-digit hour'
+    );
+
+    assert.equal(
+        moment('2002-05-02 11:30:26', 'YYYY-MM-DD h:mm:ss', true).isValid(),
+        true,
+        'valid two-digit hour'
+    );
+
+    assert.equal(
+        moment('2002-05-02 09:30:26', 'YYYY-MM-DD k:mm:ss', true).isValid(),
+        false,
+        'invalid two-digit hour'
+    );
+
+    assert.equal(
+        moment('2002-05-02 11:30:26', 'YYYY-MM-DD k:mm:ss', true).isValid(),
+        true,
+        'valid two-digit hour'
+    );
+
+    assert.equal(
+        moment('2002-05-02 11:09:26', 'YYYY-MM-DD hh:m:ss', true).isValid(),
+        false,
+        'invalid two-digit minute'
+    );
+
+    assert.equal(
+        moment('2002-05-02 11:12:26', 'YYYY-MM-DD hh:m:ss', true).isValid(),
+        true,
+        'valid two-digit minute'
+    );
+
+    assert.equal(
+        moment('2002-05-02 11:09:06', 'YYYY-MM-DD hh:mm:s', true).isValid(),
+        false,
+        'invalid two-digit second'
+    );
+
+    assert.equal(
+        moment('2002-05-02 11:09:16', 'YYYY-MM-DD hh:mm:s', true).isValid(),
+        true,
+        'valid two-digit second'
+    );
+
+    assert.equal(
+        moment('2012-W07', 'YYYY-[W]W', true).isValid(),
+        false,
+        'invalid two-digit week'
+    );
+
+    assert.equal(
+        moment('2012-W17', 'YYYY-[W]W', true).isValid(),
+        true,
+        'valid two-digit week'
+    );
+
+    assert.equal(
+        moment('2012-W07', 'YYYY-[W]w', true).isValid(),
+        false,
+        'invalid two-digit week'
+    );
+
+    assert.equal(
+        moment('2012-W17', 'YYYY-[W]w', true).isValid(),
+        true,
+        'valid two-digit week'
+    );
+
+    assert.equal(
+        moment('08 June 2012', ['D MMMM YYYY'], true).isValid(),
+        false,
+        'invalid two-digit day'
+    );
+
+    assert.equal(
+        moment('18 June 2012', ['D MMMM YYYY'], true).isValid(),
+        true,
+        'valid two-digit day'
+    );
+
+    assert.equal(
+        moment('2012-05-02', 'YYYY-M-DD', true).isValid(),
+        false,
+        'invalid two-digit month'
+    );
+
+    assert.equal(
+        moment('2012-11-02', 'YYYY-M-DD', true).isValid(),
+        true,
+        'valid two-digit month'
     );
 
     assert.equal(


### PR DESCRIPTION
## Changes
* Fix the issue of  `isValid()` in strict mode.
* Fixes #5314
* Any suggestions for the pull request will help me, thanks.