### PR TITLE
[bugfix] unify duration.valueOf and asMilliseconds

### DIFF
--- a/src/lib/duration/as.js
+++ b/src/lib/duration/as.js
@@ -1,6 +1,5 @@
 import { daysToMonths, monthsToDays } from './bubble';
 import { normalizeUnits } from '../units/aliases';
-import toInt from '../utils/to-int';
 
 export function as(units) {
     if (!this.isValid()) {
@@ -46,19 +45,6 @@ export function as(units) {
     }
 }
 
-// TODO: Use this.as('ms')?
-export function valueOf() {
-    if (!this.isValid()) {
-        return NaN;
-    }
-    return (
-        this._milliseconds +
-        this._days * 864e5 +
-        (this._months % 12) * 2592e6 +
-        toInt(this._months / 12) * 31536e6
-    );
-}
-
 function makeAs(alias) {
     return function () {
         return this.as(alias);
@@ -73,7 +59,8 @@ var asMilliseconds = makeAs('ms'),
     asWeeks = makeAs('w'),
     asMonths = makeAs('M'),
     asQuarters = makeAs('Q'),
-    asYears = makeAs('y');
+    asYears = makeAs('y'),
+    valueOf = makeAs('ms');
 
 export {
     asMilliseconds,
@@ -85,4 +72,5 @@ export {
     asMonths,
     asQuarters,
     asYears,
+    valueOf,
 };

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -2022,3 +2022,9 @@ test('duration plugins', function (assert) {
     };
     durationObject.foo(5);
 });
+
+test('valueOf and asMilliseconds have the same function', function (assert) {
+    var t1 = +moment.duration({ months: 2 }),
+        t2 = moment.duration({ months: 2 }).asMilliseconds();
+    assert.ok(t1 === t2, 'the final value should be equal');
+});


### PR DESCRIPTION
## Changes
* This `valueOf` and `asMilliseconds` should have the same function.
* Fix for issue #5603 .