### PR TITLE
[TODO]Replace the vanilla JS Date object with an independent day-of-week check

### DIFF
--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -1,5 +1,5 @@
 import { configFromStringAndFormat } from './from-string-and-format';
-import { createUTCDate } from './date-from-array';
+import { createUTCDate, createDate } from './date-from-array';
 import { hooks } from '../utils/hooks';
 import { deprecate } from '../utils/deprecate';
 import getParsingFlags from './parsing-flags';
@@ -155,13 +155,18 @@ function preprocessRFC2822(s) {
 
 function checkWeekday(weekdayStr, parsedInput, config) {
     if (weekdayStr) {
-        // TODO: Replace the vanilla JS Date object with an independent day-of-week check.
         var weekdayProvided = defaultLocaleWeekdaysShort.indexOf(weekdayStr),
-            weekdayActual = new Date(
-                parsedInput[0],
-                parsedInput[1],
-                parsedInput[2]
-            ).getDay();
+            i,
+            date,
+            weekdayActual;
+        for (i = 0; i < 7; i++) {
+            parsedInput[i] = parsedInput[i] || 0;
+        }
+        date = (config._useUTC ? createUTCDate : createDate).apply(
+            null,
+            parsedInput
+        );
+        weekdayActual = config._useUTC ? date.getUTCDay() : date.getDay();
         if (weekdayProvided !== weekdayActual) {
             getParsingFlags(config).weekdayMismatch = true;
             config._isValid = false;

--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -18,11 +18,8 @@ export function set(config) {
     this._config = config;
     // Lenient ordinal parsing accepts just a number in addition to
     // number + (possibly) stuff coming from _dayOfMonthOrdinalParse.
-    // TODO: Remove "ordinalParse" fallback in next major release.
     this._dayOfMonthOrdinalParseLenient = new RegExp(
-        (this._dayOfMonthOrdinalParse.source || this._ordinalParse.source) +
-            '|' +
-            /\d{1,2}/.source
+        this._dayOfMonthOrdinalParse.source + '|' + /\d{1,2}/.source
     );
 }
 

--- a/src/lib/units/day-of-month.js
+++ b/src/lib/units/day-of-month.js
@@ -23,9 +23,8 @@ addUnitPriority('date', 9);
 addRegexToken('D', match1to2);
 addRegexToken('DD', match1to2, match2);
 addRegexToken('Do', function (isStrict, locale) {
-    // TODO: Remove "ordinalParse" fallback in next major release.
     return isStrict
-        ? locale._dayOfMonthOrdinalParse || locale._ordinalParse
+        ? locale._dayOfMonthOrdinalParse
         : locale._dayOfMonthOrdinalParseLenient;
 });
 

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -996,34 +996,105 @@ test('when in strict mode with inexact parsing, treat periods in min-weekdays li
     assert.equal(moment('thurs', 'dd', true).format('dddd'), 'Thursday');
 });
 
-// TODO: Enable this after fixing pl months parse hack hack
-// test('monthsParseExact', function (assert) {
-//     var locale = 'test-months-parse-exact';
+test('monthsParseExact', function (assert) {
+    var locale = 'test-months-parse-exact';
 
-//     moment.defineLocale(locale, {
-//         monthsParseExact: true,
-//         months: 'A_AA_AAA_B_B B_BB  B_C_C-C_C,C2C_D_D+D_D`D*D'.split('_'),
-//         monthsShort: 'E_EE_EEE_F_FF_FFF_G_GG_GGG_H_HH_HHH'.split('_')
-//     });
+    moment.defineLocale(locale, {
+        monthsParseExact: true,
+        months: 'A_AA_AAA_B_B B_BB  B_C_C-C_C,C2C_D_D+D_D`D*D'.split('_'),
+        monthsShort: 'E_EE_EEE_F_FF_FFF_G_GG_GGG_H_HH_HHH'.split('_'),
+    });
 
-//     assert.equal(moment('A', 'MMMM', true).month(), 0, 'parse long month 0 with MMMM');
-//     assert.equal(moment('AA', 'MMMM', true).month(), 1, 'parse long month 1 with MMMM');
-//     assert.equal(moment('AAA', 'MMMM', true).month(), 2, 'parse long month 2 with MMMM');
-//     assert.equal(moment('B B', 'MMMM', true).month(), 4, 'parse long month 4 with MMMM');
-//     assert.equal(moment('BB  B', 'MMMM', true).month(), 5, 'parse long month 5 with MMMM');
-//     assert.equal(moment('C-C', 'MMMM', true).month(), 7, 'parse long month 7 with MMMM');
-//     assert.equal(moment('C,C2C', 'MMMM', true).month(), 8, 'parse long month 8 with MMMM');
-//     assert.equal(moment('D+D', 'MMMM', true).month(), 10, 'parse long month 10 with MMMM');
-//     assert.equal(moment('D`D*D', 'MMMM', true).month(), 11, 'parse long month 11 with MMMM');
+    assert.equal(
+        moment('A', 'MMMM', true).month(),
+        0,
+        'parse long month 0 with MMMM'
+    );
+    assert.equal(
+        moment('AA', 'MMMM', true).month(),
+        1,
+        'parse long month 1 with MMMM'
+    );
+    assert.equal(
+        moment('AAA', 'MMMM', true).month(),
+        2,
+        'parse long month 2 with MMMM'
+    );
+    assert.equal(
+        moment('B B', 'MMMM', true).month(),
+        4,
+        'parse long month 4 with MMMM'
+    );
+    assert.equal(
+        moment('BB  B', 'MMMM', true).month(),
+        5,
+        'parse long month 5 with MMMM'
+    );
+    assert.equal(
+        moment('C-C', 'MMMM', true).month(),
+        7,
+        'parse long month 7 with MMMM'
+    );
+    assert.equal(
+        moment('C,C2C', 'MMMM', true).month(),
+        8,
+        'parse long month 8 with MMMM'
+    );
+    assert.equal(
+        moment('D+D', 'MMMM', true).month(),
+        10,
+        'parse long month 10 with MMMM'
+    );
+    assert.equal(
+        moment('D`D*D', 'MMMM', true).month(),
+        11,
+        'parse long month 11 with MMMM'
+    );
 
-//     assert.equal(moment('E', 'MMM', true).month(), 0, 'parse long month 0 with MMM');
-//     assert.equal(moment('EE', 'MMM', true).month(), 1, 'parse long month 1 with MMM');
-//     assert.equal(moment('EEE', 'MMM', true).month(), 2, 'parse long month 2 with MMM');
+    assert.equal(
+        moment('E', 'MMM', true).month(),
+        0,
+        'parse long month 0 with MMM'
+    );
+    assert.equal(
+        moment('EE', 'MMM', true).month(),
+        1,
+        'parse long month 1 with MMM'
+    );
+    assert.equal(
+        moment('EEE', 'MMM', true).month(),
+        2,
+        'parse long month 2 with MMM'
+    );
 
-//     assert.equal(moment('A', 'MMM').month(), 0, 'non-strict parse long month 0 with MMM');
-//     assert.equal(moment('AA', 'MMM').month(), 1, 'non-strict parse long month 1 with MMM');
-//     assert.equal(moment('AAA', 'MMM').month(), 2, 'non-strict parse long month 2 with MMM');
-//     assert.equal(moment('E', 'MMMM').month(), 0, 'non-strict parse short month 0 with MMMM');
-//     assert.equal(moment('EE', 'MMMM').month(), 1, 'non-strict parse short month 1 with MMMM');
-//     assert.equal(moment('EEE', 'MMMM').month(), 2, 'non-strict parse short month 2 with MMMM');
-// });
+    assert.equal(
+        moment('A', 'MMM').month(),
+        0,
+        'non-strict parse long month 0 with MMM'
+    );
+    assert.equal(
+        moment('AA', 'MMM').month(),
+        1,
+        'non-strict parse long month 1 with MMM'
+    );
+    assert.equal(
+        moment('AAA', 'MMM').month(),
+        2,
+        'non-strict parse long month 2 with MMM'
+    );
+    assert.equal(
+        moment('E', 'MMMM').month(),
+        0,
+        'non-strict parse short month 0 with MMMM'
+    );
+    assert.equal(
+        moment('EE', 'MMMM').month(),
+        1,
+        'non-strict parse short month 1 with MMMM'
+    );
+    assert.equal(
+        moment('EEE', 'MMMM').month(),
+        2,
+        'non-strict parse short month 2 with MMMM'
+    );
+});


### PR DESCRIPTION
## Changes

* Rewrite `checkWeekday` API, Replace the vanilla JS Date object with an independent day-of-week check