### PR TITLE
[feature] Create duration from  human string

### DIFF
--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -112,8 +112,10 @@ export function humanize(argWithSuffix, argThresholds) {
 
     return locale.postformat(output);
 }
+
+// This function allows you to create duration instance from string
 export function parseFromString(duration) {
-    duration = duration.split(" ");
+    duration = duration.split(' ');
     var obj = {};
     for (let i = 1; i <= duration.length; i += 2) {
         obj[duration[i]] = duration[i - 1];

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -112,3 +112,12 @@ export function humanize(argWithSuffix, argThresholds) {
 
     return locale.postformat(output);
 }
+export function parseFromString(duration) {
+    duration = duration.split(" ");
+    let obj = {};
+    for (let i = 1; i <= duration.length; i += 2) {
+        obj[duration[i]] = duration[i - 1];
+    }
+    
+    return createDuration(obj);
+}

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -114,10 +114,10 @@ export function humanize(argWithSuffix, argThresholds) {
 }
 export function parseFromString(duration) {
     duration = duration.split(" ");
-    let obj = {};
+    var obj = {};
     for (let i = 1; i <= duration.length; i += 2) {
         obj[duration[i]] = duration[i - 1];
     }
-    
+
     return createDuration(obj);
 }

--- a/src/lib/duration/prototype.js
+++ b/src/lib/duration/prototype.js
@@ -30,7 +30,7 @@ import {
     years,
     weeks,
 } from './get';
-import { humanize } from './humanize';
+import { humanize, parseFromString } from './humanize';
 import { toISOString } from './iso-string';
 import { lang, locale, localeData } from '../moment/locale';
 import { isValid } from './valid';
@@ -67,6 +67,7 @@ proto.toString = toISOString;
 proto.toJSON = toISOString;
 proto.locale = locale;
 proto.localeData = localeData;
+proto.fromString = parseFromString;
 
 // Deprecations
 import { deprecate } from '../utils/deprecate';


### PR DESCRIPTION
Hello everyone,
This is a new feature can be adding to  moment duration
now we can create duration just from a string like  "1 day 57 minutes 34 seconds" will be  parse into normal object and create duration object
how work??
```js
import moment from 'moment ';
console.log(moment.duration().fromString("1 day 57 minutes 34 seconds" )) // duration object
```
i hope that can be useful  
