### PR TITLE
[locale] (pt-br) add invalid date translation

### DIFF
--- a/locale/pt-br.js
+++ b/locale/pt-br.js
@@ -60,8 +60,6 @@
         },
         dayOfMonthOrdinalParse: /\d{1,2}º/,
         ordinal: '%dº',
-        invalidDate: 'Data inválida',
-        
     });
 
     return ptBr;

--- a/locale/pt-br.js
+++ b/locale/pt-br.js
@@ -60,6 +60,8 @@
         },
         dayOfMonthOrdinalParse: /\d{1,2}º/,
         ordinal: '%dº',
+        invalidDate: 'Data inválida',
+        
     });
 
     return ptBr;

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -53,4 +53,5 @@ export default moment.defineLocale('pt-br', {
     },
     dayOfMonthOrdinalParse: /\d{1,2}º/,
     ordinal: '%dº',
+    invalidDate: 'Data inválida',
 });


### PR DESCRIPTION
Hi, I missed this config invalidDate: 'Data inválida' in .../locale/pt-br.js
Tks