### PR TITLE
[bugfix] ckb-iq added duplicate of ku locale

### DIFF
--- a/component.json
+++ b/component.json
@@ -76,6 +76,7 @@
     "locale/kn.js",
     "locale/ko.js",
     "locale/ku.js",
+    "locale/ckb-iq.js",
     "locale/ky.js",
     "locale/lb.js",
     "locale/lo.js",

--- a/locale/ckb-iq.js
+++ b/locale/ckb-iq.js
@@ -1,0 +1,129 @@
+//! moment.js locale configuration
+//! locale : Kurdish Sorani [ckb-iq]
+//! author : Aram Rafeq : https://github.com/AramRafeq
+
+;(function (global, factory) {
+   typeof exports === 'object' && typeof module !== 'undefined'
+       && typeof require === 'function' ? factory(require('../moment')) :
+   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
+   factory(global.moment)
+}(this, (function (moment) { 'use strict';
+
+    //! moment.js locale configuration
+
+    var symbolMap = {
+            '1': '١',
+            '2': '٢',
+            '3': '٣',
+            '4': '٤',
+            '5': '٥',
+            '6': '٦',
+            '7': '٧',
+            '8': '٨',
+            '9': '٩',
+            '0': '٠',
+        },
+        numberMap = {
+            '١': '1',
+            '٢': '2',
+            '٣': '3',
+            '٤': '4',
+            '٥': '5',
+            '٦': '6',
+            '٧': '7',
+            '٨': '8',
+            '٩': '9',
+            '٠': '0',
+        },
+        months = [
+            'کانونی دووەم',
+            'شوبات',
+            'ئازار',
+            'نیسان',
+            'ئایار',
+            'حوزەیران',
+            'تەمموز',
+            'ئاب',
+            'ئەیلوول',
+            'تشرینی یەكەم',
+            'تشرینی دووەم',
+            'كانونی یەکەم',
+        ];
+
+    var ku = moment.defineLocale('ku', {
+        months: months,
+        monthsShort: months,
+        weekdays: 'یه‌كشه‌ممه‌_دووشه‌ممه‌_سێشه‌ممه‌_چوارشه‌ممه‌_پێنجشه‌ممه‌_هه‌ینی_شه‌ممه‌'.split(
+            '_'
+        ),
+        weekdaysShort: 'یه‌كشه‌م_دووشه‌م_سێشه‌م_چوارشه‌م_پێنجشه‌م_هه‌ینی_شه‌ممه‌'.split(
+            '_'
+        ),
+        weekdaysMin: 'ی_د_س_چ_پ_ه_ش'.split('_'),
+        weekdaysParseExact: true,
+        longDateFormat: {
+            LT: 'HH:mm',
+            LTS: 'HH:mm:ss',
+            L: 'DD/MM/YYYY',
+            LL: 'D MMMM YYYY',
+            LLL: 'D MMMM YYYY HH:mm',
+            LLLL: 'dddd, D MMMM YYYY HH:mm',
+        },
+        meridiemParse: /ئێواره‌|به‌یانی/,
+        isPM: function (input) {
+            return /ئێواره‌/.test(input);
+        },
+        meridiem: function (hour, minute, isLower) {
+            if (hour < 12) {
+                return 'به‌یانی';
+            } else {
+                return 'ئێواره‌';
+            }
+        },
+        calendar: {
+            sameDay: '[ئه‌مرۆ كاتژمێر] LT',
+            nextDay: '[به‌یانی كاتژمێر] LT',
+            nextWeek: 'dddd [كاتژمێر] LT',
+            lastDay: '[دوێنێ كاتژمێر] LT',
+            lastWeek: 'dddd [كاتژمێر] LT',
+            sameElse: 'L',
+        },
+        relativeTime: {
+            future: 'له‌ %s',
+            past: '%s',
+            s: 'چه‌ند چركه‌یه‌ك',
+            ss: 'چركه‌ %d',
+            m: 'یه‌ك خوله‌ك',
+            mm: '%d خوله‌ك',
+            h: 'یه‌ك كاتژمێر',
+            hh: '%d كاتژمێر',
+            d: 'یه‌ك ڕۆژ',
+            dd: '%d ڕۆژ',
+            M: 'یه‌ك مانگ',
+            MM: '%d مانگ',
+            y: 'یه‌ك ساڵ',
+            yy: '%d ساڵ',
+        },
+        preparse: function (string) {
+            return string
+                .replace(/[١٢٣٤٥٦٧٨٩٠]/g, function (match) {
+                    return numberMap[match];
+                })
+                .replace(/،/g, ',');
+        },
+        postformat: function (string) {
+            return string
+                .replace(/\d/g, function (match) {
+                    return symbolMap[match];
+                })
+                .replace(/,/g, '،');
+        },
+        week: {
+            dow: 6, // Saturday is the first day of the week.
+            doy: 12, // The week that contains Jan 12th is the first week of the year.
+        },
+    });
+
+    return ku;
+
+})));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "moment",
-    "version": "2.26.0",
+    "version": "2.27.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -14,54 +14,60 @@
             }
         },
         "@babel/core": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.2.tgz",
-            "integrity": "sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==",
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
+            "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/generator": "^7.10.2",
-                "@babel/helper-module-transforms": "^7.10.1",
-                "@babel/helpers": "^7.10.1",
-                "@babel/parser": "^7.10.2",
-                "@babel/template": "^7.10.1",
-                "@babel/traverse": "^7.10.1",
-                "@babel/types": "^7.10.2",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.0",
+                "@babel/helper-module-transforms": "^7.11.0",
+                "@babel/helpers": "^7.10.4",
+                "@babel/parser": "^7.11.1",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.11.0",
+                "@babel/types": "^7.11.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
                 "json5": "^2.1.2",
-                "lodash": "^4.17.13",
+                "lodash": "^4.17.19",
                 "resolve": "^1.3.2",
                 "semver": "^5.4.1",
                 "source-map": "^0.5.0"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.10.1"
+                        "@babel/highlight": "^7.10.4"
                     }
                 },
                 "@babel/helper-validator-identifier": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-                    "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
                     "dev": true
                 },
                 "@babel/highlight": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
                     "dev": true,
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "@babel/helper-validator-identifier": "^7.10.4",
                         "chalk": "^2.0.0",
                         "js-tokens": "^4.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
                 },
                 "semver": {
                     "version": "5.7.1",
@@ -72,108 +78,115 @@
             }
         },
         "@babel/generator": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
-            "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+            "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.2",
+                "@babel/types": "^7.11.0",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-            "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+            "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.10.1",
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-            "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-            "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+            "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.11.0"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
-            "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+            "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
-            "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+            "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.10.1",
-                "@babel/helper-replace-supers": "^7.10.1",
-                "@babel/helper-simple-access": "^7.10.1",
-                "@babel/helper-split-export-declaration": "^7.10.1",
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1",
-                "lodash": "^4.17.13"
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.11.0",
+                "lodash": "^4.17.19"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-            "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+            "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-            "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+            "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.1",
-                "@babel/helper-optimise-call-expression": "^7.10.1",
-                "@babel/traverse": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
-            "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+            "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-            "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+            "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.11.0"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -183,14 +196,14 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
-            "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+            "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.10.1",
-                "@babel/traverse": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/highlight": {
@@ -205,44 +218,44 @@
             }
         },
         "@babel/parser": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
-            "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.1.tgz",
+            "integrity": "sha512-u9QMIRdKVF7hfEkb3nu2LgZDIzCQPv+yHD9Eg6ruoJLjkrQ9fFz4IBSlF/9XwoNri9+2F1IY+dYuOfZrXq8t3w==",
             "dev": true
         },
         "@babel/template": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
-            "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+            "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.10.1"
+                        "@babel/highlight": "^7.10.4"
                     }
                 },
                 "@babel/helper-validator-identifier": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-                    "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
                     "dev": true
                 },
                 "@babel/highlight": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
                     "dev": true,
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "@babel/helper-validator-identifier": "^7.10.4",
                         "chalk": "^2.0.0",
                         "js-tokens": "^4.0.0"
                     }
@@ -250,44 +263,44 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
-            "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+            "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/generator": "^7.10.1",
-                "@babel/helper-function-name": "^7.10.1",
-                "@babel/helper-split-export-declaration": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.0",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.11.0",
+                "@babel/types": "^7.11.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "lodash": "^4.17.13"
+                "lodash": "^4.17.19"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.10.1"
+                        "@babel/highlight": "^7.10.4"
                     }
                 },
                 "@babel/helper-validator-identifier": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-                    "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
                     "dev": true
                 },
                 "@babel/highlight": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
                     "dev": true,
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "@babel/helper-validator-identifier": "^7.10.4",
                         "chalk": "^2.0.0",
                         "js-tokens": "^4.0.0"
                     }
@@ -297,24 +310,36 @@
                     "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
                     "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
                     "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+                    "dev": true
                 }
             }
         },
         "@babel/types": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
-            "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+            "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
-                "lodash": "^4.17.13",
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
             },
             "dependencies": {
                 "@babel/helper-validator-identifier": {
-                    "version": "7.10.1",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-                    "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.19",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+                    "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
                     "dev": true
                 }
             }
@@ -332,28 +357,6 @@
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                    "dev": true
-                },
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
-                },
                 "resolve-from": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -437,14 +440,6 @@
             "requires": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
-            },
-            "dependencies": {
-                "indent-string": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-                    "dev": true
-                }
             }
         },
         "ajv": {
@@ -566,12 +561,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
             "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
-            "dev": true
-        },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
         "array-slice": {
@@ -775,9 +764,9 @@
             }
         },
         "binary-extensions": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-            "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+            "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
             "dev": true
         },
         "blob": {
@@ -944,20 +933,10 @@
             "dev": true
         },
         "camelcase": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true
-        },
-        "camelcase-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "dev": true,
-            "requires": {
-                "camelcase": "^2.0.0",
-                "map-obj": "^1.0.0"
-            }
         },
         "caseless": {
             "version": "0.12.0",
@@ -983,9 +962,9 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-            "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+            "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.1",
@@ -1122,12 +1101,6 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
-        "coffeescript": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
-            "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
-            "dev": true
-        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1167,12 +1140,6 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
-        },
-        "commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -1366,15 +1333,6 @@
                 }
             }
         },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
-            "requires": {
-                "array-find-index": "^1.0.1"
-            }
-        },
         "custom-event": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -1397,14 +1355,10 @@
             "dev": true
         },
         "dateformat": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-            "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "^4.0.1",
-                "meow": "^3.3.0"
-            }
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true
         },
         "debug": {
             "version": "4.1.1",
@@ -1440,14 +1394,6 @@
             "dev": true,
             "requires": {
                 "strip-bom": "^4.0.0"
-            },
-            "dependencies": {
-                "strip-bom": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-                    "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-                    "dev": true
-                }
             }
         },
         "define-property": {
@@ -1640,15 +1586,6 @@
             "dev": true,
             "requires": {
                 "string-template": "~0.2.1"
-            }
-        },
-        "error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
-            "requires": {
-                "is-arrayish": "^0.2.1"
             }
         },
         "es6-error": {
@@ -2153,13 +2090,13 @@
             }
         },
         "find-up": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
             "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
             }
         },
         "findup-sync": {
@@ -2223,9 +2160,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
-            "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
+            "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==",
             "dev": true
         },
         "for-in": {
@@ -2323,9 +2260,9 @@
             }
         },
         "fromentries": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-            "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+            "integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
             "dev": true
         },
         "fs-extra": {
@@ -2383,12 +2320,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-            "dev": true
-        },
-        "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
             "dev": true
         },
         "get-value": {
@@ -2486,54 +2417,36 @@
             "dev": true
         },
         "grunt": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.1.0.tgz",
-            "integrity": "sha512-+NGod0grmviZ7Nzdi9am7vuRS/h76PcWDsV635mEXF0PEQMUV6Kb+OjTdsVxbi0PZmfQOjCMKb3w8CVZcqsn1g==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.2.1.tgz",
+            "integrity": "sha512-zgJjn9N56tScvRt/y0+1QA+zDBnKTrkpyeSBqQPLcZvbqTD/oyGMrdZQXmm6I3828s+FmPvxc3Xv+lgKFtudOw==",
             "dev": true,
             "requires": {
-                "coffeescript": "~1.10.0",
-                "dateformat": "~1.0.12",
+                "dateformat": "~3.0.3",
                 "eventemitter2": "~0.4.13",
-                "exit": "~0.1.1",
+                "exit": "~0.1.2",
                 "findup-sync": "~0.3.0",
-                "glob": "~7.0.0",
-                "grunt-cli": "~1.2.0",
+                "glob": "~7.1.6",
+                "grunt-cli": "~1.3.2",
                 "grunt-known-options": "~1.1.0",
                 "grunt-legacy-log": "~2.0.0",
                 "grunt-legacy-util": "~1.1.1",
                 "iconv-lite": "~0.4.13",
-                "js-yaml": "~3.13.1",
-                "minimatch": "~3.0.2",
-                "mkdirp": "~1.0.3",
+                "js-yaml": "~3.14.0",
+                "minimatch": "~3.0.4",
+                "mkdirp": "~1.0.4",
                 "nopt": "~3.0.6",
-                "path-is-absolute": "~1.0.0",
-                "rimraf": "~2.6.2"
+                "rimraf": "~3.0.2"
             },
             "dependencies": {
-                "glob": {
-                    "version": "7.0.6",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-                    "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+                "js-yaml": {
+                    "version": "3.14.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+                    "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.2",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "grunt-cli": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
-                    "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
-                    "dev": true,
-                    "requires": {
-                        "findup-sync": "~0.3.0",
-                        "grunt-known-options": "~1.1.0",
-                        "nopt": "~3.0.6",
-                        "resolve": "~1.1.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "mkdirp": {
@@ -2542,11 +2455,14 @@
                     "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
                     "dev": true
                 },
-                "resolve": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-                    "dev": true
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
                 }
             }
         },
@@ -2719,9 +2635,9 @@
             }
         },
         "grunt-contrib-uglify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-4.0.1.tgz",
-            "integrity": "sha512-dwf8/+4uW1+7pH72WButOEnzErPGmtUvc8p08B0eQS/6ON0WdeQu0+WFeafaPTbbY1GqtS25lsHWaDeiTQNWPg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.0.0.tgz",
+            "integrity": "sha512-rIFFPJMWKnh6oxDe2b810Ysg5SKoiI0u/FvuvAVpvJ7VHILkKtGqA4jgJ1JWruWQ+1m5FtB1lVSK81YyzIgDUw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
@@ -2927,13 +2843,27 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "dev": true,
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.3",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+                    "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                }
             }
         },
         "has-ansi": {
@@ -3039,12 +2969,6 @@
             "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
             "dev": true
         },
-        "hosted-git-info": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-            "dev": true
-        },
         "html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3148,13 +3072,10 @@
             "dev": true
         },
         "indent-string": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-            "dev": true,
-            "requires": {
-                "repeating": "^2.0.0"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true
         },
         "indexof": {
             "version": "0.0.1",
@@ -3302,12 +3223,6 @@
                 }
             }
         },
-        "is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
-        },
         "is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3363,9 +3278,9 @@
             }
         },
         "is-docker": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
             "dev": true
         },
         "is-extendable": {
@@ -3378,12 +3293,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
-        },
-        "is-finite": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
             "dev": true
         },
         "is-fullwidth-code-point": {
@@ -3459,12 +3368,6 @@
             "requires": {
                 "unc-path-regex": "^0.1.2"
             }
-        },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -3840,9 +3743,9 @@
             }
         },
         "karma": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-5.1.0.tgz",
-            "integrity": "sha512-I3aPbkuIbwuBo6wSog97P5WnnhCgUTsWTu/bEw1vZVQFbXmKO3PK+cfFhZioOgVtJAuQxoyauGNjnwXNHMCxbw==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-5.1.1.tgz",
+            "integrity": "sha512-xAlOr5PMqUbiKXSv5PCniHWV3aiwj6wIZ0gUVcwpTCPVQm/qH2WAMFWxtnpM6KJqhkRWrIpovR4Rb0rn8GtJzQ==",
             "dev": true,
             "requires": {
                 "body-parser": "^1.19.0",
@@ -4059,19 +3962,6 @@
                 "resolve-pkg": "^2.0.0"
             }
         },
-        "load-json-file": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
-            }
-        },
         "locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4112,16 +4002,6 @@
                 "streamroller": "^2.2.4"
             }
         },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
-            }
-        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4144,12 +4024,6 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
-        },
-        "map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
         },
         "map-visit": {
@@ -4230,24 +4104,6 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
-        },
-        "meow": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "dev": true,
-            "requires": {
-                "camelcase-keys": "^2.0.0",
-                "decamelize": "^1.1.2",
-                "loud-rejection": "^1.0.0",
-                "map-obj": "^1.0.1",
-                "minimist": "^1.1.3",
-                "normalize-package-data": "^2.3.4",
-                "object-assign": "^4.0.1",
-                "read-pkg-up": "^1.0.1",
-                "redent": "^1.0.0",
-                "trim-newlines": "^1.0.0"
-            }
         },
         "micromatch": {
             "version": "3.1.10",
@@ -4399,9 +4255,9 @@
             "dev": true
         },
         "neo-async": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
             "optional": true
         },
@@ -4448,26 +4304,6 @@
             "dev": true,
             "requires": {
                 "abbrev": "1"
-            }
-        },
-        "normalize-package-data": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "dev": true,
-            "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                }
             }
         },
         "normalize-path": {
@@ -4517,22 +4353,6 @@
                 "yargs": "^15.0.2"
             },
             "dependencies": {
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
-                },
                 "resolve-from": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -4773,15 +4593,6 @@
                 "path-root": "^0.1.1"
             }
         },
-        "parse-json": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
-            "requires": {
-                "error-ex": "^1.2.0"
-            }
-        },
         "parse-passwd": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -4819,13 +4630,10 @@
             "dev": true
         },
         "path-exists": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
-            "requires": {
-                "pinkie-promise": "^2.0.0"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -4860,17 +4668,6 @@
             "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
             "dev": true
         },
-        "path-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            }
-        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4883,27 +4680,6 @@
             "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
             "dev": true
         },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "^2.0.0"
-            }
-        },
         "pkg-dir": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -4911,24 +4687,6 @@
             "dev": true,
             "requires": {
                 "find-up": "^4.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
-                }
             }
         },
         "pkg-up": {
@@ -4977,9 +4735,9 @@
             }
         },
         "platform": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-            "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+            "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
             "dev": true
         },
         "posix-character-classes": {
@@ -5106,27 +4864,6 @@
                 "string_decoder": "0.10"
             }
         },
-        "read-pkg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "dev": true,
-            "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
-            }
-        },
-        "read-pkg-up": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "dev": true,
-            "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
-            }
-        },
         "readable-stream": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -5177,16 +4914,6 @@
                 "resolve": "^1.1.6"
             }
         },
-        "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-            "dev": true,
-            "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
-            }
-        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5223,15 +4950,6 @@
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
-        },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "dev": true,
-            "requires": {
-                "is-finite": "^1.0.0"
-            }
         },
         "request": {
             "version": "2.88.2",
@@ -5359,9 +5077,9 @@
             }
         },
         "rollup": {
-            "version": "2.17.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.17.0.tgz",
-            "integrity": "sha512-4Um68vKyyTLzT+EWClgc+nyxSlunlmx8wgCO16RDicwxvccnyBHguoNqxPaJL/YPAdvuAJkqaFPf/BfDojzEZA==",
+            "version": "2.23.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.23.0.tgz",
+            "integrity": "sha512-vLNmZFUGVwrnqNAJ/BvuLk1MtWzu4IuoqsH9UWK5AIdO3rt8/CSiJNvPvCIvfzrbNsqKbNzPAG1V2O4eTe2XZg==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.1.2"
@@ -5880,38 +5598,6 @@
                 }
             }
         },
-        "spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-            "dev": true,
-            "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-            "dev": true
-        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -6042,22 +5728,10 @@
             }
         },
         "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "^0.2.0"
-            }
-        },
-        "strip-indent": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "^4.0.1"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true
         },
         "strip-json-comments": {
             "version": "3.1.0",
@@ -6244,12 +5918,6 @@
             "integrity": "sha1-bCZ4exhT8TcWNGIsHIC8RAJsXXA=",
             "dev": true
         },
-        "trim-newlines": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-            "dev": true
-        },
         "tslib": {
             "version": "1.11.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
@@ -6312,9 +5980,9 @@
             "dev": true
         },
         "typescript3": {
-            "version": "npm:typescript@3.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-            "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+            "version": "npm:typescript@3.9.7",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
             "dev": true
         },
         "ua-parser-js": {
@@ -6324,13 +5992,10 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.9.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
-            "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
-            "dev": true,
-            "requires": {
-                "commander": "~2.20.3"
-            }
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+            "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
+            "dev": true
         },
         "unc-path-regex": {
             "version": "0.1.2",
@@ -6478,16 +6143,6 @@
                 "homedir-polyfill": "^1.0.1"
             }
         },
-        "validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -6625,9 +6280,9 @@
             }
         },
         "ws": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-            "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+            "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
             "dev": true
         },
         "xmlhttprequest-ssl": {
@@ -6643,9 +6298,9 @@
             "dev": true
         },
         "yargs": {
-            "version": "15.3.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-            "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
             "dev": true,
             "requires": {
                 "cliui": "^6.0.0",
@@ -6658,25 +6313,7 @@
                 "string-width": "^4.2.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.1"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
-                }
+                "yargs-parser": "^18.1.2"
             }
         },
         "yargs-parser": {
@@ -6687,14 +6324,6 @@
             "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                    "dev": true
-                }
             }
         },
         "yeast": {

--- a/src/locale/ckb-iq.js
+++ b/src/locale/ckb-iq.js
@@ -1,0 +1,118 @@
+//! moment.js locale configuration
+//! locale : Kurdish Sorani [ckb-iq]
+//! author : Aram Rafeq : https://github.com/AramRafeq
+
+import moment from '../moment';
+
+var symbolMap = {
+        '1': '١',
+        '2': '٢',
+        '3': '٣',
+        '4': '٤',
+        '5': '٥',
+        '6': '٦',
+        '7': '٧',
+        '8': '٨',
+        '9': '٩',
+        '0': '٠',
+    },
+    numberMap = {
+        '١': '1',
+        '٢': '2',
+        '٣': '3',
+        '٤': '4',
+        '٥': '5',
+        '٦': '6',
+        '٧': '7',
+        '٨': '8',
+        '٩': '9',
+        '٠': '0',
+    },
+    months = [
+        'کانونی دووەم',
+        'شوبات',
+        'ئازار',
+        'نیسان',
+        'ئایار',
+        'حوزەیران',
+        'تەمموز',
+        'ئاب',
+        'ئەیلوول',
+        'تشرینی یەكەم',
+        'تشرینی دووەم',
+        'كانونی یەکەم',
+    ];
+
+export default moment.defineLocale('ku', {
+    months: months,
+    monthsShort: months,
+    weekdays: 'یه‌كشه‌ممه‌_دووشه‌ممه‌_سێشه‌ممه‌_چوارشه‌ممه‌_پێنجشه‌ممه‌_هه‌ینی_شه‌ممه‌'.split(
+        '_'
+    ),
+    weekdaysShort: 'یه‌كشه‌م_دووشه‌م_سێشه‌م_چوارشه‌م_پێنجشه‌م_هه‌ینی_شه‌ممه‌'.split(
+        '_'
+    ),
+    weekdaysMin: 'ی_د_س_چ_پ_ه_ش'.split('_'),
+    weekdaysParseExact: true,
+    longDateFormat: {
+        LT: 'HH:mm',
+        LTS: 'HH:mm:ss',
+        L: 'DD/MM/YYYY',
+        LL: 'D MMMM YYYY',
+        LLL: 'D MMMM YYYY HH:mm',
+        LLLL: 'dddd, D MMMM YYYY HH:mm',
+    },
+    meridiemParse: /ئێواره‌|به‌یانی/,
+    isPM: function (input) {
+        return /ئێواره‌/.test(input);
+    },
+    meridiem: function (hour, minute, isLower) {
+        if (hour < 12) {
+            return 'به‌یانی';
+        } else {
+            return 'ئێواره‌';
+        }
+    },
+    calendar: {
+        sameDay: '[ئه‌مرۆ كاتژمێر] LT',
+        nextDay: '[به‌یانی كاتژمێر] LT',
+        nextWeek: 'dddd [كاتژمێر] LT',
+        lastDay: '[دوێنێ كاتژمێر] LT',
+        lastWeek: 'dddd [كاتژمێر] LT',
+        sameElse: 'L',
+    },
+    relativeTime: {
+        future: 'له‌ %s',
+        past: '%s',
+        s: 'چه‌ند چركه‌یه‌ك',
+        ss: 'چركه‌ %d',
+        m: 'یه‌ك خوله‌ك',
+        mm: '%d خوله‌ك',
+        h: 'یه‌ك كاتژمێر',
+        hh: '%d كاتژمێر',
+        d: 'یه‌ك ڕۆژ',
+        dd: '%d ڕۆژ',
+        M: 'یه‌ك مانگ',
+        MM: '%d مانگ',
+        y: 'یه‌ك ساڵ',
+        yy: '%d ساڵ',
+    },
+    preparse: function (string) {
+        return string
+            .replace(/[١٢٣٤٥٦٧٨٩٠]/g, function (match) {
+                return numberMap[match];
+            })
+            .replace(/،/g, ',');
+    },
+    postformat: function (string) {
+        return string
+            .replace(/\d/g, function (match) {
+                return symbolMap[match];
+            })
+            .replace(/,/g, '،');
+    },
+    week: {
+        dow: 6, // Saturday is the first day of the week.
+        doy: 12, // The week that contains Jan 12th is the first week of the year.
+    },
+});

--- a/src/test/locale/ckb-iq.js
+++ b/src/test/locale/ckb-iq.js
@@ -1,0 +1,465 @@
+import { test } from '../qunit';
+import { localeModule } from '../qunit-locale';
+import moment from '../../moment';
+localeModule('ku');
+
+var months = [
+    'کانونی دووەم',
+    'شوبات',
+    'ئازار',
+    'نیسان',
+    'ئایار',
+    'حوزەیران',
+    'تەمموز',
+    'ئاب',
+    'ئەیلوول',
+    'تشرینی یەكەم',
+    'تشرینی دووەم',
+    'كانونی یەکەم',
+];
+
+test('parse', function (assert) {
+    var tests = months,
+        i;
+    function equalTest(input, mmm, i) {
+        assert.equal(
+            moment(input, mmm).month(),
+            i,
+            input +
+                ' should be month ' +
+                (i + 1) +
+                ' instead is month ' +
+                moment(input, mmm).month()
+        );
+    }
+    for (i = 0; i < 12; i++) {
+        equalTest(tests[i], 'MMM', i);
+        equalTest(tests[i], 'MMM', i);
+        equalTest(tests[i], 'MMMM', i);
+        equalTest(tests[i], 'MMMM', i);
+        equalTest(tests[i].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i].toLocaleUpperCase(), 'MMMM', i);
+        equalTest(tests[i].toLocaleUpperCase(), 'MMMM', i);
+    }
+});
+
+test('format', function (assert) {
+    var a = [
+            [
+                'dddd, MMMM Do YYYY, h:mm:ss a',
+                'یه‌كشه‌ممه‌، شوبات ١٤ ٢٠١٠، ٣:٢٥:٥٠ ئێواره‌',
+            ],
+            ['ddd, hA', 'یه‌كشه‌م، ٣ئێواره‌'],
+            ['M Mo MM MMMM MMM', '٢ ٢ ٠٢ شوبات شوبات'],
+            ['YYYY YY', '٢٠١٠ ١٠'],
+            ['D Do DD', '١٤ ١٤ ١٤'],
+            ['d do dddd ddd dd', '٠ ٠ یه‌كشه‌ممه‌ یه‌كشه‌م ی'],
+            ['DDD DDDo DDDD', '٤٥ ٤٥ ٠٤٥'],
+            ['w wo ww', '٨ ٨ ٠٨'],
+            ['h hh', '٣ ٠٣'],
+            ['H HH', '١٥ ١٥'],
+            ['m mm', '٢٥ ٢٥'],
+            ['s ss', '٥٠ ٥٠'],
+            ['a A', 'ئێواره‌ ئێواره‌'],
+            ['[the] DDDo [day of the year]', 'the ٤٥ day of the year'],
+            ['LTS', '١٥:٢٥:٥٠'],
+            ['L', '١٤/٠٢/٢٠١٠'],
+            ['LL', '١٤ شوبات ٢٠١٠'],
+            ['LLL', '١٤ شوبات ٢٠١٠ ١٥:٢٥'],
+            ['LLLL', 'یه‌كشه‌ممه‌، ١٤ شوبات ٢٠١٠ ١٥:٢٥'],
+            ['l', '١٤/٢/٢٠١٠'],
+            ['ll', '١٤ شوبات ٢٠١٠'],
+            ['lll', '١٤ شوبات ٢٠١٠ ١٥:٢٥'],
+            ['llll', 'یه‌كشه‌م، ١٤ شوبات ٢٠١٠ ١٥:٢٥'],
+        ],
+        b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
+        i;
+    for (i = 0; i < a.length; i++) {
+        assert.equal(b.format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
+    }
+});
+
+test('format ordinal', function (assert) {
+    assert.equal(moment([2011, 0, 1]).format('DDDo'), '١', '1');
+    assert.equal(moment([2011, 0, 2]).format('DDDo'), '٢', '2');
+    assert.equal(moment([2011, 0, 3]).format('DDDo'), '٣', '3');
+    assert.equal(moment([2011, 0, 4]).format('DDDo'), '٤', '4');
+    assert.equal(moment([2011, 0, 5]).format('DDDo'), '٥', '5');
+    assert.equal(moment([2011, 0, 6]).format('DDDo'), '٦', '6');
+    assert.equal(moment([2011, 0, 7]).format('DDDo'), '٧', '7');
+    assert.equal(moment([2011, 0, 8]).format('DDDo'), '٨', '8');
+    assert.equal(moment([2011, 0, 9]).format('DDDo'), '٩', '9');
+    assert.equal(moment([2011, 0, 10]).format('DDDo'), '١٠', '10');
+
+    assert.equal(moment([2011, 0, 11]).format('DDDo'), '١١', '11');
+    assert.equal(moment([2011, 0, 12]).format('DDDo'), '١٢', '12');
+    assert.equal(moment([2011, 0, 13]).format('DDDo'), '١٣', '13');
+    assert.equal(moment([2011, 0, 14]).format('DDDo'), '١٤', '14');
+    assert.equal(moment([2011, 0, 15]).format('DDDo'), '١٥', '15');
+    assert.equal(moment([2011, 0, 16]).format('DDDo'), '١٦', '16');
+    assert.equal(moment([2011, 0, 17]).format('DDDo'), '١٧', '17');
+    assert.equal(moment([2011, 0, 18]).format('DDDo'), '١٨', '18');
+    assert.equal(moment([2011, 0, 19]).format('DDDo'), '١٩', '19');
+    assert.equal(moment([2011, 0, 20]).format('DDDo'), '٢٠', '20');
+
+    assert.equal(moment([2011, 0, 21]).format('DDDo'), '٢١', '21');
+    assert.equal(moment([2011, 0, 22]).format('DDDo'), '٢٢', '22');
+    assert.equal(moment([2011, 0, 23]).format('DDDo'), '٢٣', '23');
+    assert.equal(moment([2011, 0, 24]).format('DDDo'), '٢٤', '24');
+    assert.equal(moment([2011, 0, 25]).format('DDDo'), '٢٥', '25');
+    assert.equal(moment([2011, 0, 26]).format('DDDo'), '٢٦', '26');
+    assert.equal(moment([2011, 0, 27]).format('DDDo'), '٢٧', '27');
+    assert.equal(moment([2011, 0, 28]).format('DDDo'), '٢٨', '28');
+    assert.equal(moment([2011, 0, 29]).format('DDDo'), '٢٩', '29');
+    assert.equal(moment([2011, 0, 30]).format('DDDo'), '٣٠', '30');
+    assert.equal(moment([2011, 0, 31]).format('DDDo'), '٣١', '31');
+});
+//ok
+test('format month', function (assert) {
+    var expected = months,
+        i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(
+            moment([2011, i, 1]).format('MMMM'),
+            expected[i],
+            expected[i]
+        );
+        assert.equal(
+            moment([2011, i, 1]).format('MMM'),
+            expected[i],
+            expected[i]
+        );
+    }
+});
+
+test('format week', function (assert) {
+    var expected = 'یه‌كشه‌ممه‌ یه‌كشه‌م ی_دووشه‌ممه‌ دووشه‌م د_سێشه‌ممه‌ سێشه‌م س_چوارشه‌ممه‌ چوارشه‌م چ_پێنجشه‌ممه‌ پێنجشه‌م پ_هه‌ینی هه‌ینی ه_شه‌ممه‌ شه‌ممه‌ ش'.split(
+            '_'
+        ),
+        i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(
+            moment([2011, 0, 2 + i]).format('dddd ddd dd'),
+            expected[i],
+            expected[i]
+        );
+    }
+});
+
+test('from', function (assert) {
+    var start = moment([2007, 1, 28]);
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ s: 44 }), true),
+        'چه‌ند چركه‌یه‌ك',
+        '44 seconds = a few seconds'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ s: 45 }), true),
+        'یه‌ك خوله‌ك',
+        '45 seconds = a minute'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ s: 89 }), true),
+        'یه‌ك خوله‌ك',
+        '89 seconds = a minute'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ s: 90 }), true),
+        '٢ خوله‌ك',
+        '90 seconds = 2 minutes'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ m: 44 }), true),
+        '٤٤ خوله‌ك',
+        '44 minutes = 44 minutes'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ m: 45 }), true),
+        'یه‌ك كاتژمێر',
+        '45 minutes = an hour'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ m: 89 }), true),
+        'یه‌ك كاتژمێر',
+        '89 minutes = an hour'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ m: 90 }), true),
+        '٢ كاتژمێر',
+        '90 minutes = 2 hours'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ h: 5 }), true),
+        '٥ كاتژمێر',
+        '5 hours = 5 hours'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ h: 21 }), true),
+        '٢١ كاتژمێر',
+        '21 hours = 21 hours'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ h: 22 }), true),
+        'یه‌ك ڕۆژ',
+        '22 hours = a day'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ h: 35 }), true),
+        'یه‌ك ڕۆژ',
+        '35 hours = a day'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ h: 36 }), true),
+        '٢ ڕۆژ',
+        '36 hours = 2 days'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 1 }), true),
+        'یه‌ك ڕۆژ',
+        '1 day = a day'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 5 }), true),
+        '٥ ڕۆژ',
+        '5 days = 5 days'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 25 }), true),
+        '٢٥ ڕۆژ',
+        '25 days = 25 days'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 26 }), true),
+        'یه‌ك مانگ',
+        '26 days = a month'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 30 }), true),
+        'یه‌ك مانگ',
+        '30 days = a month'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 43 }), true),
+        'یه‌ك مانگ',
+        '43 days = a month'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 46 }), true),
+        '٢ مانگ',
+        '46 days = 2 months'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 74 }), true),
+        '٢ مانگ',
+        '75 days = 2 months'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 76 }), true),
+        '٣ مانگ',
+        '76 days = 3 months'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ M: 1 }), true),
+        'یه‌ك مانگ',
+        '1 month = a month'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ M: 5 }), true),
+        '٥ مانگ',
+        '5 months = 5 months'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 345 }), true),
+        'یه‌ك ساڵ',
+        '345 days = a year'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 548 }), true),
+        '٢ ساڵ',
+        '548 days = 2 years'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ y: 1 }), true),
+        'یه‌ك ساڵ',
+        '1 year = a year'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ y: 5 }), true),
+        '٥ ساڵ',
+        '5 years = 5 years'
+    );
+});
+
+test('suffix', function (assert) {
+    assert.equal(moment(30000).from(0), 'له‌ چه‌ند چركه‌یه‌ك', 'prefix');
+    assert.equal(moment(0).from(30000), 'چه‌ند چركه‌یه‌ك', 'suffix');
+});
+
+test('now from now', function (assert) {
+    assert.equal(
+        moment().fromNow(),
+        'چه‌ند چركه‌یه‌ك',
+        'now from now should display as in the past'
+    );
+});
+
+test('fromNow', function (assert) {
+    assert.equal(
+        moment().add({ s: 30 }).fromNow(),
+        'له‌ چه‌ند چركه‌یه‌ك',
+        'in a few seconds'
+    );
+    assert.equal(moment().add({ d: 5 }).fromNow(), 'له‌ ٥ ڕۆژ', 'in 5 days');
+});
+
+test('calendar day', function (assert) {
+    var a = moment().hours(12).minutes(0).seconds(0);
+
+    assert.equal(
+        moment(a).calendar(),
+        'ئه‌مرۆ كاتژمێر ١٢:٠٠',
+        'today at the same time'
+    );
+    assert.equal(
+        moment(a).add({ m: 25 }).calendar(),
+        'ئه‌مرۆ كاتژمێر ١٢:٢٥',
+        'Now plus 25 min'
+    );
+    assert.equal(
+        moment(a).add({ h: 1 }).calendar(),
+        'ئه‌مرۆ كاتژمێر ١٣:٠٠',
+        'Now plus 1 hour'
+    );
+    assert.equal(
+        moment(a).add({ d: 1 }).calendar(),
+        'به‌یانی كاتژمێر ١٢:٠٠',
+        'tomorrow at the same time'
+    );
+    assert.equal(
+        moment(a).subtract({ h: 1 }).calendar(),
+        'ئه‌مرۆ كاتژمێر ١١:٠٠',
+        'Now minus 1 hour'
+    );
+    assert.equal(
+        moment(a).subtract({ d: 1 }).calendar(),
+        'دوێنێ كاتژمێر ١٢:٠٠',
+        'yesterday at the same time'
+    );
+});
+
+test('calendar next week', function (assert) {
+    var i, m;
+    for (i = 2; i < 7; i++) {
+        m = moment().add({ d: i });
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [كاتژمێر] LT'),
+            'Today + ' + i + ' days current time'
+        );
+        m.hours(0).minutes(0).seconds(0).milliseconds(0);
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [كاتژمێر] LT'),
+            'Today + ' + i + ' days beginning of day'
+        );
+        m.hours(23).minutes(59).seconds(59).milliseconds(999);
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [كاتژمێر] LT'),
+            'Today + ' + i + ' days end of day'
+        );
+    }
+});
+
+test('calendar last week', function (assert) {
+    var i, m;
+
+    for (i = 2; i < 7; i++) {
+        m = moment().subtract({ d: i });
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [كاتژمێر] LT'),
+            'Today - ' + i + ' days current time'
+        );
+        m.hours(0).minutes(0).seconds(0).milliseconds(0);
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [كاتژمێر] LT'),
+            'Today - ' + i + ' days beginning of day'
+        );
+        m.hours(23).minutes(59).seconds(59).milliseconds(999);
+        assert.equal(
+            m.calendar(),
+            m.format('dddd [كاتژمێر] LT'),
+            'Today - ' + i + ' days end of day'
+        );
+    }
+});
+
+test('calendar all else', function (assert) {
+    var weeksAgo = moment().subtract({ w: 1 }),
+        weeksFromNow = moment().add({ w: 1 });
+
+    assert.equal(weeksAgo.calendar(), weeksAgo.format('L'), '1 week ago');
+    assert.equal(
+        weeksFromNow.calendar(),
+        weeksFromNow.format('L'),
+        'in 1 week'
+    );
+
+    weeksAgo = moment().subtract({ w: 2 });
+    weeksFromNow = moment().add({ w: 2 });
+
+    assert.equal(weeksAgo.calendar(), weeksAgo.format('L'), '2 weeks ago');
+    assert.equal(
+        weeksFromNow.calendar(),
+        weeksFromNow.format('L'),
+        'in 2 weeks'
+    );
+});
+
+test('weeks year starting sunday formatted', function (assert) {
+    assert.equal(
+        moment([2011, 11, 31]).format('w ww wo'),
+        '١ ٠١ ١',
+        'Dec 31 2011 should be week 1'
+    );
+    assert.equal(
+        moment([2012, 0, 6]).format('w ww wo'),
+        '١ ٠١ ١',
+        'Jan  6 2012 should be week 1'
+    );
+    assert.equal(
+        moment([2012, 0, 7]).format('w ww wo'),
+        '٢ ٠٢ ٢',
+        'Jan  7 2012 should be week 2'
+    );
+    assert.equal(
+        moment([2012, 0, 13]).format('w ww wo'),
+        '٢ ٠٢ ٢',
+        'Jan 13 2012 should be week 2'
+    );
+    assert.equal(
+        moment([2012, 0, 14]).format('w ww wo'),
+        '٣ ٠٣ ٣',
+        'Jan 14 2012 should be week 3'
+    );
+});
+
+// locale-specific
+test('ku strict mode parsing works', function (assert) {
+    var m, formattedDate;
+    m = moment().locale('ku');
+    formattedDate = m.format('l');
+    assert.equal(
+        moment.utc(formattedDate, 'l', 'ku', false).isValid(),
+        true,
+        'Non-strict parsing works'
+    );
+    assert.equal(
+        moment.utc(formattedDate, 'l', 'ku', true).isValid(),
+        true,
+        'Strict parsing must work'
+    );
+});


### PR DESCRIPTION
naming kurdish language **ku** only is a big issue we need to consider dialects for the language after a long discussion on ant design repo about invalid locale code this should be changed to **ckb-iq** and if we removed existing **ku** locale this would be a breaking change so we can make a duplicate copy of **ku** named **ckb-iq** in the future we would have **kmr-iq** which stands for kurdish kurmanji dialect for more info refer to this issue 
[https://github.com/ant-design/ant-design/issues/25778](https://github.com/ant-design/ant-design/issues/25778)