### PR TITLE
Fixed a typo in locale/az.js

### DIFF
--- a/locale/az.js
+++ b/locale/az.js
@@ -62,7 +62,7 @@
         relativeTime: {
             future: '%s sonra',
             past: '%s əvvəl',
-            s: 'birneçə saniyə',
+            s: 'bir neçə saniyə',
             ss: '%d saniyə',
             m: 'bir dəqiqə',
             mm: '%d dəqiqə',


### PR DESCRIPTION
In Azeri, the word 'bir neçə' should be written separately. Here are some references:

// Wiktionary
https://en.wiktionary.org/wiki/bir_ne%C3%A7%C9%99

// Obastan
https://obastan.com/bir%20ne%C3%A7%C9%99/1010367/?l=az

// Azleks
https://www.azleks.az/online-dictionary/bir+ne%C3%A7%C9%99?s=undefined
