### PR TITLE
[locale] az: fix a word

### DIFF
--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -55,7 +55,7 @@ export default moment.defineLocale('az', {
     relativeTime: {
         future: '%s sonra',
         past: '%s əvvəl',
-        s: 'birneçə saniyə',
+        s: 'bir neçə saniyə',
         ss: '%d saniyə',
         m: 'bir dəqiqə',
         mm: '%d dəqiqə',

--- a/src/test/locale/az.js
+++ b/src/test/locale/az.js
@@ -162,7 +162,7 @@ test('from', function (assert) {
     var start = moment([2007, 1, 28]);
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ s: 44 }), true),
-        'birneçə saniyə',
+        'bir neçə saniyə',
         '44 seconds = a few seconds'
     );
     assert.equal(
@@ -298,14 +298,14 @@ test('from', function (assert) {
 });
 
 test('suffix', function (assert) {
-    assert.equal(moment(30000).from(0), 'birneçə saniyə sonra', 'prefix');
-    assert.equal(moment(0).from(30000), 'birneçə saniyə əvvəl', 'suffix');
+    assert.equal(moment(30000).from(0), 'bir neçə saniyə sonra', 'prefix');
+    assert.equal(moment(0).from(30000), 'bir neçə saniyə əvvəl', 'suffix');
 });
 
 test('now from now', function (assert) {
     assert.equal(
         moment().fromNow(),
-        'birneçə saniyə əvvəl',
+        'bir neçə saniyə əvvəl',
         'now from now should display as in the past'
     );
 });
@@ -313,7 +313,7 @@ test('now from now', function (assert) {
 test('fromNow', function (assert) {
     assert.equal(
         moment().add({ s: 30 }).fromNow(),
-        'birneçə saniyə sonra',
+        'bir neçə saniyə sonra',
         'in a few seconds'
     );
     assert.equal(moment().add({ d: 5 }).fromNow(), '5 gün sonra', 'in 5 days');


### PR DESCRIPTION
@topchiyev 

In Azeri, the word 'bir neçə' should be written separately. Here are some references:

// Wiktionary
https://en.wiktionary.org/wiki/bir_ne%C3%A7%C9%99

// Obastan
https://obastan.com/bir%20ne%C3%A7%C9%99/1010367/?l=az

// Azleks
https://www.azleks.az/online-dictionary/bir+ne%C3%A7%C9%99?s=undefined