### PR TITLE
[locale] Update dow for Konkani locales

### DIFF
--- a/src/locale/gom-deva.js
+++ b/src/locale/gom-deva.js
@@ -90,8 +90,8 @@ export default moment.defineLocale('gom-deva', {
         }
     },
     week: {
-        dow: 1, // Monday is the first day of the week.
-        doy: 4, // The week that contains Jan 4th is the first week of the year.
+        dow: 0, // Sunday is the first day of the week
+        doy: 3, // The week that contains Jan 4th is the first week of the year (7 + 0 - 4)
     },
     meridiemParse: /राती|सकाळीं|दनपारां|सांजे/,
     meridiemHour: function (hour, meridiem) {

--- a/src/locale/gom-latn.js
+++ b/src/locale/gom-latn.js
@@ -90,8 +90,8 @@ export default moment.defineLocale('gom-latn', {
         }
     },
     week: {
-        dow: 1, // Monday is the first day of the week.
-        doy: 4, // The week that contains Jan 4th is the first week of the year.
+        dow: 0, // Sunday is the first day of the week
+        doy: 3, // The week that contains Jan 4th is the first week of the year (7 + 0 - 4)
     },
     meridiemParse: /rati|sokallim|donparam|sanje/,
     meridiemHour: function (hour, meridiem) {

--- a/src/test/locale/gom-deva.js
+++ b/src/test/locale/gom-deva.js
@@ -42,7 +42,7 @@ test('format', function (assert) {
             ['D Do DD', '14 14वेर 14'],
             ['d do dddd ddd dd', '0 0 आयतार आयत. आ'],
             ['DDD DDDo DDDD', '45 45 045'],
-            ['w wo ww', '6 6 06'],
+            ['w wo ww', '7 7 07'],
             ['h hh', '3 03'],
             ['H HH', '15 15'],
             ['m mm', '25 25'],

--- a/src/test/locale/gom-deva.js
+++ b/src/test/locale/gom-deva.js
@@ -419,8 +419,8 @@ test('calendar all else', function (assert) {
 test('weeks year starting sunday format', function (assert) {
     assert.equal(
         moment([2012, 0, 1]).format('w ww wo'),
-        '52 52 52',
-        'Jan  1 2012 should be week 52'
+        '1 01 1',
+        'Jan  1 2012 should be week 1'
     );
     assert.equal(
         moment([2012, 0, 2]).format('w ww wo'),
@@ -429,8 +429,8 @@ test('weeks year starting sunday format', function (assert) {
     );
     assert.equal(
         moment([2012, 0, 8]).format('w ww wo'),
-        '1 01 1',
-        'Jan  8 2012 should be week 1'
+        '2 02 2',
+        'Jan  8 2012 should be week 2'
     );
     assert.equal(
         moment([2012, 0, 14]).format('w ww wo'),
@@ -439,7 +439,7 @@ test('weeks year starting sunday format', function (assert) {
     );
     assert.equal(
         moment([2012, 0, 15]).format('w ww wo'),
-        '2 02 2',
-        'Jan 15 2012 should be week 2'
+        '3 03 3',
+        'Jan 15 2012 should be week 3'
     );
 });

--- a/src/test/locale/gom-latn.js
+++ b/src/test/locale/gom-latn.js
@@ -433,8 +433,8 @@ test('calendar all else', function (assert) {
 test('weeks year starting sunday format', function (assert) {
     assert.equal(
         moment([2012, 0, 1]).format('w ww wo'),
-        '52 52 52',
-        'Jan  1 2012 should be week 52'
+        '1 01 1',
+        'Jan  1 2012 should be week 1'
     );
     assert.equal(
         moment([2012, 0, 2]).format('w ww wo'),
@@ -443,8 +443,8 @@ test('weeks year starting sunday format', function (assert) {
     );
     assert.equal(
         moment([2012, 0, 8]).format('w ww wo'),
-        '1 01 1',
-        'Jan  8 2012 should be week 1'
+        '2 02 2',
+        'Jan  8 2012 should be week 2'
     );
     assert.equal(
         moment([2012, 0, 14]).format('w ww wo'),
@@ -453,7 +453,7 @@ test('weeks year starting sunday format', function (assert) {
     );
     assert.equal(
         moment([2012, 0, 15]).format('w ww wo'),
-        '2 02 2',
-        'Jan 15 2012 should be week 2'
+        '3 03 3',
+        'Jan 15 2012 should be week 3'
     );
 });

--- a/src/test/locale/gom-latn.js
+++ b/src/test/locale/gom-latn.js
@@ -56,7 +56,7 @@ test('format', function (assert) {
             ['D Do DD', '14 14er 14'],
             ['d do dddd ddd dd', '0 0 Aitar Ait. Ai'],
             ['DDD DDDo DDDD', '45 45 045'],
-            ['w wo ww', '6 6 06'],
+            ['w wo ww', '7 7 07'],
             ['h hh', '3 03'],
             ['H HH', '15 15'],
             ['m mm', '25 25'],


### PR DESCRIPTION
Change dow to 0 for Konkani locales to be in line with other Indian locales like en-in and hi, while keeping doy in accordance with ISO 8601.