### PR TITLE
Update src/locale/es.js

### DIFF
--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -25,7 +25,7 @@ var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic
     monthsRegex = /^(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene\.?|feb\.?|mar\.?|abr\.?|may\.?|jun\.?|jul\.?|ago\.?|sep\.?|oct\.?|nov\.?|dic\.?)/i;
 
 export default moment.defineLocale('es', {
-    months: 'enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre'.split(
+    months: 'Enero_Febrero_Marzo_Abril_Mayo_Junio_Julio_Agosto_Septiembre_Octubre_Noviembre_Diciembre'.split(
         '_'
     ),
     monthsShort: function (m, format) {


### PR DESCRIPTION
set months names to capital letters in locale/es.js because months in Spanish follow the same rules as names