### PR TITLE
[bugfix] Expose es bundle as "module" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     ],
     "main": "./moment.js",
     "jsnext:main": "./dist/moment.js",
+    "module": "./dist/moment.js",
     "typings": "./moment.d.ts",
     "typesVersions": {
         ">=3.1": {


### PR DESCRIPTION
Fixes issues with rollup node-resolve plugin that looks at the "module" entry to resolve packages (instead of jsnext:main)
https://github.com/rollup/plugins/blob/master/packages/node-resolve/src/util.js#L36

Might also fix issues where Typescript compiler cannot resolve properly