### PR TITLE
[misc] Add js extension to module imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,17 @@ Read before submitting Pull Requests
    `moment.js`, `locale/*.js`, `min/*.js`. Don't worry, we'll build them when
    we cut a release.
 
+Format Pull Requests
+====================
+
+Prefix the title of your pull request with  one of the following
+* [bugfix]
+* [feature]
+* [locale]
+* [misc]
+* [new locale]
+
+
 Code organization
 =================
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,6 @@ Read before submitting Pull Requests
    `moment.js`, `locale/*.js`, `min/*.js`. Don't worry, we'll build them when
    we cut a release.
 
-Format Pull Requests
-====================
-
-Prefix the title of your pull request with  one of the following
-* [bugfix]
-* [feature]
-* [locale]
-* [misc]
-* [new locale]
-
-
 Code organization
 =================
 

--- a/src/lib/create/check-overflow.js
+++ b/src/lib/create/check-overflow.js
@@ -1,4 +1,4 @@
-import { daysInMonth } from '../units/month';
+import { daysInMonth } from '../units/month.js';
 import {
     YEAR,
     MONTH,
@@ -9,8 +9,8 @@ import {
     MILLISECOND,
     WEEK,
     WEEKDAY,
-} from '../units/constants';
-import getParsingFlags from '../create/parsing-flags';
+} from '../units/constants.js';
+import getParsingFlags from '../create/parsing-flags.js';
 
 export default function checkOverflow(m) {
     var overflow,

--- a/src/lib/create/from-anything.js
+++ b/src/lib/create/from-anything.js
@@ -1,22 +1,22 @@
-import isArray from '../utils/is-array';
-import isObject from '../utils/is-object';
-import isObjectEmpty from '../utils/is-object-empty';
-import isUndefined from '../utils/is-undefined';
-import isNumber from '../utils/is-number';
-import isDate from '../utils/is-date';
-import map from '../utils/map';
-import { createInvalid } from './valid';
-import { Moment, isMoment } from '../moment/constructor';
-import { getLocale } from '../locale/locales';
-import { hooks } from '../utils/hooks';
-import checkOverflow from './check-overflow';
-import { isValid } from './valid';
+import isArray from '../utils/is-array.js';
+import isObject from '../utils/is-object.js';
+import isObjectEmpty from '../utils/is-object-empty.js';
+import isUndefined from '../utils/is-undefined.js';
+import isNumber from '../utils/is-number.js';
+import isDate from '../utils/is-date.js';
+import map from '../utils/map.js';
+import { createInvalid } from './valid.js';
+import { Moment, isMoment } from '../moment/constructor.js';
+import { getLocale } from '../locale/locales.js';
+import { hooks } from '../utils/hooks.js';
+import checkOverflow from './check-overflow.js';
+import { isValid } from './valid.js';
 
-import { configFromStringAndArray } from './from-string-and-array';
-import { configFromStringAndFormat } from './from-string-and-format';
-import { configFromString } from './from-string';
-import { configFromArray } from './from-array';
-import { configFromObject } from './from-object';
+import { configFromStringAndArray } from './from-string-and-array.js';
+import { configFromStringAndFormat } from './from-string-and-format.js';
+import { configFromString } from './from-string.js';
+import { configFromArray } from './from-array.js';
+import { configFromObject } from './from-object.js';
 
 function createFromConfig(config) {
     var res = new Moment(checkOverflow(prepareConfig(config)));

--- a/src/lib/create/from-array.js
+++ b/src/lib/create/from-array.js
@@ -1,11 +1,11 @@
-import { hooks } from '../utils/hooks';
-import { createDate, createUTCDate } from './date-from-array';
-import { daysInYear } from '../units/year';
+import { hooks } from '../utils/hooks.js';
+import { createDate, createUTCDate } from './date-from-array.js';
+import { daysInYear } from '../units/year.js';
 import {
     weekOfYear,
     weeksInYear,
     dayOfYearFromWeeks,
-} from '../units/week-calendar-utils';
+} from '../units/week-calendar-utils.js';
 import {
     YEAR,
     MONTH,
@@ -14,10 +14,10 @@ import {
     MINUTE,
     SECOND,
     MILLISECOND,
-} from '../units/constants';
-import { createLocal } from './local';
-import defaults from '../utils/defaults';
-import getParsingFlags from './parsing-flags';
+} from '../units/constants.js';
+import { createLocal } from './local.js';
+import defaults from '../utils/defaults.js';
+import getParsingFlags from './parsing-flags.js';
 
 function currentDateArray(config) {
     // hooks is actually the exported moment object

--- a/src/lib/create/from-object.js
+++ b/src/lib/create/from-object.js
@@ -1,6 +1,6 @@
-import { normalizeObjectUnits } from '../units/aliases';
-import { configFromArray } from './from-array';
-import map from '../utils/map';
+import { normalizeObjectUnits } from '../units/aliases.js';
+import { configFromArray } from './from-array.js';
+import map from '../utils/map.js';
 
 export function configFromObject(config) {
     if (config._d) {

--- a/src/lib/create/from-string-and-array.js
+++ b/src/lib/create/from-string-and-array.js
@@ -1,8 +1,8 @@
-import { copyConfig } from '../moment/constructor';
-import { configFromStringAndFormat } from './from-string-and-format';
-import getParsingFlags from './parsing-flags';
-import { isValid } from './valid';
-import extend from '../utils/extend';
+import { copyConfig } from '../moment/constructor.js';
+import { configFromStringAndFormat } from './from-string-and-format.js';
+import getParsingFlags from './parsing-flags.js';
+import { isValid } from './valid.js';
+import extend from '../utils/extend.js';
 
 // date from string and array of format strings
 export function configFromStringAndArray(config) {

--- a/src/lib/create/from-string-and-format.js
+++ b/src/lib/create/from-string-and-format.js
@@ -1,16 +1,16 @@
-import { configFromISO, configFromRFC2822 } from './from-string';
-import { configFromArray } from './from-array';
-import { getParseRegexForToken } from '../parse/regex';
-import { addTimeToArrayFromToken } from '../parse/token';
+import { configFromISO, configFromRFC2822 } from './from-string.js';
+import { configFromArray } from './from-array.js';
+import { getParseRegexForToken } from '../parse/regex.js';
+import { addTimeToArrayFromToken } from '../parse/token.js';
 import {
     expandFormat,
     formatTokenFunctions,
     formattingTokens,
-} from '../format/format';
-import checkOverflow from './check-overflow';
-import { YEAR, HOUR } from '../units/constants';
-import { hooks } from '../utils/hooks';
-import getParsingFlags from './parsing-flags';
+} from '../format/format.js';
+import checkOverflow from './check-overflow.js';
+import { YEAR, HOUR } from '../units/constants.js';
+import { hooks } from '../utils/hooks.js';
+import getParsingFlags from './parsing-flags.js';
 
 // constant that refers to the ISO standard
 hooks.ISO_8601 = function () {};

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -1,10 +1,10 @@
-import { configFromStringAndFormat } from './from-string-and-format';
-import { createUTCDate } from './date-from-array';
-import { hooks } from '../utils/hooks';
-import { deprecate } from '../utils/deprecate';
-import getParsingFlags from './parsing-flags';
-import { defaultLocaleMonthsShort } from '../units/month';
-import { defaultLocaleWeekdaysShort } from '../units/day-of-week';
+import { configFromStringAndFormat } from './from-string-and-format.js';
+import { createUTCDate } from './date-from-array.js';
+import { hooks } from '../utils/hooks.js';
+import { deprecate } from '../utils/deprecate.js';
+import getParsingFlags from './parsing-flags.js';
+import { defaultLocaleMonthsShort } from '../units/month.js';
+import { defaultLocaleWeekdaysShort } from '../units/day-of-week.js';
 
 // iso 8601 regex
 // 0000-00-00 0000-W00 or 0000-W00-0 + T + 00 or 00:00 or 00:00:00 or 00:00:00.000 + +00:00 or +0000 or +00)

--- a/src/lib/create/local.js
+++ b/src/lib/create/local.js
@@ -1,4 +1,4 @@
-import { createLocalOrUTC } from './from-anything';
+import { createLocalOrUTC } from './from-anything.js';
 
 export function createLocal(input, format, locale, strict) {
     return createLocalOrUTC(input, format, locale, strict, false);

--- a/src/lib/create/utc.js
+++ b/src/lib/create/utc.js
@@ -1,4 +1,4 @@
-import { createLocalOrUTC } from './from-anything';
+import { createLocalOrUTC } from './from-anything.js';
 
 export function createUTC(input, format, locale, strict) {
     return createLocalOrUTC(input, format, locale, strict, true).utc();

--- a/src/lib/create/valid.js
+++ b/src/lib/create/valid.js
@@ -1,7 +1,7 @@
-import extend from '../utils/extend';
-import { createUTC } from './utc';
-import getParsingFlags from '../create/parsing-flags';
-import some from '../utils/some';
+import extend from '../utils/extend.js';
+import { createUTC } from './utc.js';
+import getParsingFlags from '../create/parsing-flags.js';
+import some from '../utils/some.js';
 
 export function isValid(m) {
     if (m._isValid == null) {

--- a/src/lib/duration/add-subtract.js
+++ b/src/lib/duration/add-subtract.js
@@ -1,4 +1,4 @@
-import { createDuration } from './create';
+import { createDuration } from './create.js';
 
 function addSubtract(duration, input, value, direction) {
     var other = createDuration(input, value);

--- a/src/lib/duration/as.js
+++ b/src/lib/duration/as.js
@@ -1,6 +1,6 @@
-import { daysToMonths, monthsToDays } from './bubble';
-import { normalizeUnits } from '../units/aliases';
-import toInt from '../utils/to-int';
+import { daysToMonths, monthsToDays } from './bubble.js';
+import { normalizeUnits } from '../units/aliases.js';
+import toInt from '../utils/to-int.js';
 
 export function as(units) {
     if (!this.isValid()) {

--- a/src/lib/duration/bubble.js
+++ b/src/lib/duration/bubble.js
@@ -1,5 +1,5 @@
-import absFloor from '../utils/abs-floor';
-import absCeil from '../utils/abs-ceil';
+import absFloor from '../utils/abs-floor.js';
+import absCeil from '../utils/abs-ceil.js';
 
 export function bubble() {
     var milliseconds = this._milliseconds,

--- a/src/lib/duration/clone.js
+++ b/src/lib/duration/clone.js
@@ -1,4 +1,4 @@
-import { createDuration } from './create';
+import { createDuration } from './create.js';
 
 export function clone() {
     return createDuration(this);

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -1,6 +1,6 @@
 import { normalizeObjectUnits } from '../units/aliases';
 import { getLocale } from '../locale/locales';
-import isDurationValid from './valid.js';
+import isDurationValid from './valid';
 
 export function Duration(duration) {
     var normalizedInput = normalizeObjectUnits(duration),

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -1,6 +1,6 @@
-import { normalizeObjectUnits } from '../units/aliases';
-import { getLocale } from '../locale/locales';
-import isDurationValid from './valid';
+import { normalizeObjectUnits } from '../units/aliases.js';
+import { getLocale } from '../locale/locales.js';
+import isDurationValid from './valid.js';
 
 export function Duration(duration) {
     var normalizedInput = normalizeObjectUnits(duration),

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -1,12 +1,12 @@
-import { Duration, isDuration } from './constructor';
-import isNumber from '../utils/is-number';
-import toInt from '../utils/to-int';
-import absRound from '../utils/abs-round';
-import hasOwnProp from '../utils/has-own-prop';
-import { DATE, HOUR, MINUTE, SECOND, MILLISECOND } from '../units/constants';
-import { cloneWithOffset } from '../units/offset';
-import { createLocal } from '../create/local';
-import { createInvalid as invalid } from './valid';
+import { Duration, isDuration } from './constructor.js';
+import isNumber from '../utils/is-number.js';
+import toInt from '../utils/to-int.js';
+import absRound from '../utils/abs-round.js';
+import hasOwnProp from '../utils/has-own-prop.js';
+import { DATE, HOUR, MINUTE, SECOND, MILLISECOND } from '../units/constants.js';
+import { cloneWithOffset } from '../units/offset.js';
+import { createLocal } from '../create/local.js';
+import { createInvalid as invalid } from './valid.js';
 
 // ASP.NET json date format regex
 var aspNetRegex = /^(-|\+)?(?:(\d*)[. ])?(\d+):(\d+)(?::(\d+)(\.\d*)?)?$/,

--- a/src/lib/duration/duration.js
+++ b/src/lib/duration/duration.js
@@ -1,12 +1,12 @@
 // Side effect imports
-import './prototype';
+import './prototype.js';
 
-import { createDuration } from './create';
-import { isDuration } from './constructor';
+import { createDuration } from './create.js';
+import { isDuration } from './constructor.js';
 import {
     getSetRelativeTimeRounding,
     getSetRelativeTimeThreshold,
-} from './humanize';
+} from './humanize.js';
 
 export {
     createDuration,

--- a/src/lib/duration/get.js
+++ b/src/lib/duration/get.js
@@ -1,5 +1,5 @@
-import { normalizeUnits } from '../units/aliases';
-import absFloor from '../utils/abs-floor';
+import { normalizeUnits } from '../units/aliases.js';
+import absFloor from '../utils/abs-floor.js';
 
 export function get(units) {
     units = normalizeUnits(units);

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -1,4 +1,4 @@
-import { createDuration } from './create';
+import { createDuration } from './create.js';
 
 var round = Math.round,
     thresholds = {

--- a/src/lib/duration/iso-string.js
+++ b/src/lib/duration/iso-string.js
@@ -1,4 +1,4 @@
-import absFloor from '../utils/abs-floor';
+import absFloor from '../utils/abs-floor.js';
 var abs = Math.abs;
 
 function sign(x) {

--- a/src/lib/duration/prototype.js
+++ b/src/lib/duration/prototype.js
@@ -1,9 +1,9 @@
-import { Duration } from './constructor';
+import { Duration } from './constructor.js';
 
 var proto = Duration.prototype;
 
-import { abs } from './abs';
-import { add, subtract } from './add-subtract';
+import { abs } from './abs.js';
+import { add, subtract } from './add-subtract.js';
 import {
     as,
     asMilliseconds,
@@ -16,9 +16,9 @@ import {
     asQuarters,
     asYears,
     valueOf,
-} from './as';
-import { bubble } from './bubble';
-import { clone } from './clone';
+} from './as.js';
+import { bubble } from './bubble.js';
+import { clone } from './clone.js';
 import {
     get,
     milliseconds,
@@ -29,11 +29,11 @@ import {
     months,
     years,
     weeks,
-} from './get';
-import { humanize } from './humanize';
-import { toISOString } from './iso-string';
-import { lang, locale, localeData } from '../moment/locale';
-import { isValid } from './valid';
+} from './get.js';
+import { humanize } from './humanize.js';
+import { toISOString } from './iso-string.js';
+import { lang, locale, localeData } from '../moment/locale.js';
+import { isValid } from './valid.js';
 
 proto.isValid = isValid;
 proto.abs = abs;
@@ -69,7 +69,7 @@ proto.locale = locale;
 proto.localeData = localeData;
 
 // Deprecations
-import { deprecate } from '../utils/deprecate';
+import { deprecate } from '../utils/deprecate.js';
 
 proto.toIsoString = deprecate(
     'toIsoString() is deprecated. Please use toISOString() instead (notice the capitals)',

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -1,7 +1,7 @@
-import hasOwnProp from '../utils/has-own-prop';
-import toInt from '../utils/to-int';
-import indexOf from '../utils/index-of';
-import { createDuration } from './create';
+import hasOwnProp from '../utils/has-own-prop.js';
+import toInt from '../utils/to-int.js';
+import indexOf from '../utils/index-of.js';
+import { createDuration } from './create.js';
 
 var ordering = [
     'year',

--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -1,5 +1,5 @@
-import zeroFill from '../utils/zero-fill';
-import isFunction from '../utils/is-function';
+import zeroFill from '../utils/zero-fill.js';
+import isFunction from '../utils/is-function.js';
 
 var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g,
     localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g,

--- a/src/lib/locale/base-config.js
+++ b/src/lib/locale/base-config.js
@@ -1,24 +1,24 @@
-import { defaultCalendar } from './calendar';
-import { defaultLongDateFormat } from './formats';
-import { defaultInvalidDate } from './invalid';
-import { defaultOrdinal, defaultDayOfMonthOrdinalParse } from './ordinal';
-import { defaultRelativeTime } from './relative';
+import { defaultCalendar } from './calendar.js';
+import { defaultLongDateFormat } from './formats.js';
+import { defaultInvalidDate } from './invalid.js';
+import { defaultOrdinal, defaultDayOfMonthOrdinalParse } from './ordinal.js';
+import { defaultRelativeTime } from './relative.js';
 
 // months
-import { defaultLocaleMonths, defaultLocaleMonthsShort } from '../units/month';
+import { defaultLocaleMonths, defaultLocaleMonthsShort } from '../units/month.js';
 
 // week
-import { defaultLocaleWeek } from '../units/week';
+import { defaultLocaleWeek } from '../units/week.js';
 
 // weekdays
 import {
     defaultLocaleWeekdays,
     defaultLocaleWeekdaysMin,
     defaultLocaleWeekdaysShort,
-} from '../units/day-of-week';
+} from '../units/day-of-week.js';
 
 // meridiem
-import { defaultLocaleMeridiemParse } from '../units/hour';
+import { defaultLocaleMeridiemParse } from '../units/hour.js';
 
 export var baseConfig = {
     calendar: defaultCalendar,

--- a/src/lib/locale/calendar.js
+++ b/src/lib/locale/calendar.js
@@ -7,7 +7,7 @@ export var defaultCalendar = {
     sameElse: 'L',
 };
 
-import isFunction from '../utils/is-function';
+import isFunction from '../utils/is-function.js';
 
 export function calendar(key, mom, now) {
     var output = this._calendar[key] || this._calendar['sameElse'];

--- a/src/lib/locale/en.js
+++ b/src/lib/locale/en.js
@@ -1,6 +1,6 @@
-import './prototype';
-import { getSetGlobalLocale } from './locales';
-import toInt from '../utils/to-int';
+import './prototype.js';
+import { getSetGlobalLocale } from './locales.js';
+import toInt from '../utils/to-int.js';
 
 getSetGlobalLocale('en', {
     eras: [

--- a/src/lib/locale/formats.js
+++ b/src/lib/locale/formats.js
@@ -1,4 +1,4 @@
-import { formattingTokens } from '../format/format';
+import { formattingTokens } from '../format/format.js';
 
 export var defaultLongDateFormat = {
     LTS: 'h:mm:ss A',

--- a/src/lib/locale/lists.js
+++ b/src/lib/locale/lists.js
@@ -1,6 +1,6 @@
-import isNumber from '../utils/is-number';
-import { getLocale } from './locales';
-import { createUTC } from '../create/utc';
+import isNumber from '../utils/is-number.js';
+import { getLocale } from './locales.js';
+import { createUTC } from '../create/utc.js';
 
 function get(format, index, field, setter) {
     var locale = getLocale(),

--- a/src/lib/locale/locale.js
+++ b/src/lib/locale/locale.js
@@ -1,5 +1,5 @@
 // Side effect imports
-import './prototype';
+import './prototype.js';
 
 import {
     getSetGlobalLocale,
@@ -7,7 +7,7 @@ import {
     updateLocale,
     getLocale,
     listLocales,
-} from './locales';
+} from './locales.js';
 
 import {
     listMonths,
@@ -15,7 +15,7 @@ import {
     listWeekdays,
     listWeekdaysShort,
     listWeekdaysMin,
-} from './lists';
+} from './lists.js';
 
 export {
     getSetGlobalLocale,
@@ -30,8 +30,8 @@ export {
     listWeekdaysMin,
 };
 
-import { deprecate } from '../utils/deprecate';
-import { hooks } from '../utils/hooks';
+import { deprecate } from '../utils/deprecate.js';
+import { hooks } from '../utils/hooks.js';
 
 hooks.lang = deprecate(
     'moment.lang is deprecated. Use moment.locale instead.',
@@ -42,4 +42,4 @@ hooks.langData = deprecate(
     getLocale
 );
 
-import './en';
+import './en.js';

--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -1,11 +1,11 @@
-import isArray from '../utils/is-array';
-import isUndefined from '../utils/is-undefined';
-import { deprecateSimple } from '../utils/deprecate';
-import { mergeConfigs } from './set';
-import { Locale } from './constructor';
-import keys from '../utils/keys';
+import isArray from '../utils/is-array.js';
+import isUndefined from '../utils/is-undefined.js';
+import { deprecateSimple } from '../utils/deprecate.js';
+import { mergeConfigs } from './set.js';
+import { Locale } from './constructor.js';
+import keys from '../utils/keys.js';
 
-import { baseConfig } from './base-config';
+import { baseConfig } from './base-config.js';
 
 // internal storage for locale config files
 var locales = {},

--- a/src/lib/locale/prototype.js
+++ b/src/lib/locale/prototype.js
@@ -1,14 +1,14 @@
-import { Locale } from './constructor';
+import { Locale } from './constructor.js';
 
 var proto = Locale.prototype;
 
-import { calendar } from './calendar';
-import { longDateFormat } from './formats';
-import { invalidDate } from './invalid';
-import { ordinal } from './ordinal';
-import { preParsePostFormat } from './pre-post-format';
-import { relativeTime, pastFuture } from './relative';
-import { set } from './set';
+import { calendar } from './calendar.js';
+import { longDateFormat } from './formats.js';
+import { invalidDate } from './invalid.js';
+import { ordinal } from './ordinal.js';
+import { preParsePostFormat } from './pre-post-format.js';
+import { relativeTime, pastFuture } from './relative.js';
+import { set } from './set.js';
 
 proto.calendar = calendar;
 proto.longDateFormat = longDateFormat;
@@ -28,7 +28,7 @@ import {
     erasAbbrRegex,
     erasNameRegex,
     erasNarrowRegex,
-} from '../units/era';
+} from '../units/era.js';
 proto.eras = localeEras;
 proto.erasParse = localeErasParse;
 proto.erasConvertYear = localeErasConvertYear;
@@ -43,7 +43,7 @@ import {
     localeMonthsShort,
     monthsRegex,
     monthsShortRegex,
-} from '../units/month';
+} from '../units/month.js';
 
 proto.months = localeMonths;
 proto.monthsShort = localeMonthsShort;
@@ -56,7 +56,7 @@ import {
     localeWeek,
     localeFirstDayOfYear,
     localeFirstDayOfWeek,
-} from '../units/week';
+} from '../units/week.js';
 proto.week = localeWeek;
 proto.firstDayOfYear = localeFirstDayOfYear;
 proto.firstDayOfWeek = localeFirstDayOfWeek;
@@ -70,7 +70,7 @@ import {
     weekdaysRegex,
     weekdaysShortRegex,
     weekdaysMinRegex,
-} from '../units/day-of-week';
+} from '../units/day-of-week.js';
 
 proto.weekdays = localeWeekdays;
 proto.weekdaysMin = localeWeekdaysMin;
@@ -82,7 +82,7 @@ proto.weekdaysShortRegex = weekdaysShortRegex;
 proto.weekdaysMinRegex = weekdaysMinRegex;
 
 // Hours
-import { localeIsPM, localeMeridiem } from '../units/hour';
+import { localeIsPM, localeMeridiem } from '../units/hour.js';
 
 proto.isPM = localeIsPM;
 proto.meridiem = localeMeridiem;

--- a/src/lib/locale/relative.js
+++ b/src/lib/locale/relative.js
@@ -17,7 +17,7 @@ export var defaultRelativeTime = {
     yy: '%d years',
 };
 
-import isFunction from '../utils/is-function';
+import isFunction from '../utils/is-function.js';
 
 export function relativeTime(number, withoutSuffix, string, isFuture) {
     var output = this._relativeTime[string];

--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -1,7 +1,7 @@
-import isFunction from '../utils/is-function';
-import extend from '../utils/extend';
-import isObject from '../utils/is-object';
-import hasOwnProp from '../utils/has-own-prop';
+import isFunction from '../utils/is-function.js';
+import extend from '../utils/extend.js';
+import isObject from '../utils/is-object.js';
+import hasOwnProp from '../utils/has-own-prop.js';
 
 export function set(config) {
     var prop, i;

--- a/src/lib/moment/add-subtract.js
+++ b/src/lib/moment/add-subtract.js
@@ -1,9 +1,9 @@
-import { get, set } from './get-set';
-import { setMonth } from '../units/month';
-import { createDuration } from '../duration/create';
-import { deprecateSimple } from '../utils/deprecate';
-import { hooks } from '../utils/hooks';
-import absRound from '../utils/abs-round';
+import { get, set } from './get-set.js';
+import { setMonth } from '../units/month.js';
+import { createDuration } from '../duration/create.js';
+import { deprecateSimple } from '../utils/deprecate.js';
+import { hooks } from '../utils/hooks.js';
+import absRound from '../utils/abs-round.js';
 
 // TODO: remove 'name' arg after deprecation is removed
 function createAdder(direction, name) {

--- a/src/lib/moment/calendar.js
+++ b/src/lib/moment/calendar.js
@@ -1,9 +1,9 @@
-import { createLocal } from '../create/local';
-import { cloneWithOffset } from '../units/offset';
-import isFunction from '../utils/is-function';
-import { hooks } from '../utils/hooks';
-import { isMomentInput } from '../utils/is-moment-input';
-import isCalendarSpec from '../utils/is-calendar-spec';
+import { createLocal } from '../create/local.js';
+import { cloneWithOffset } from '../units/offset.js';
+import isFunction from '../utils/is-function.js';
+import { hooks } from '../utils/hooks.js';
+import { isMomentInput } from '../utils/is-moment-input.js';
+import isCalendarSpec from '../utils/is-calendar-spec.js';
 
 export function getCalendarFormat(myMoment, now) {
     var diff = myMoment.diff(now, 'days', true);

--- a/src/lib/moment/clone.js
+++ b/src/lib/moment/clone.js
@@ -1,4 +1,4 @@
-import { Moment } from './constructor';
+import { Moment } from './constructor.js';
 
 export function clone() {
     return new Moment(this);

--- a/src/lib/moment/compare.js
+++ b/src/lib/moment/compare.js
@@ -1,6 +1,6 @@
-import { isMoment } from './constructor';
-import { normalizeUnits } from '../units/aliases';
-import { createLocal } from '../create/local';
+import { isMoment } from './constructor.js';
+import { normalizeUnits } from '../units/aliases.js';
+import { createLocal } from '../create/local.js';
 
 export function isAfter(input, units) {
     var localInput = isMoment(input) ? input : createLocal(input);

--- a/src/lib/moment/constructor.js
+++ b/src/lib/moment/constructor.js
@@ -1,6 +1,6 @@
-import { hooks } from '../utils/hooks';
-import isUndefined from '../utils/is-undefined';
-import getParsingFlags from '../create/parsing-flags';
+import { hooks } from '../utils/hooks.js';
+import isUndefined from '../utils/is-undefined.js';
+import getParsingFlags from '../create/parsing-flags.js';
 
 // Plugins that add properties should also add the key here (null value),
 // so we can properly clone ourselves.

--- a/src/lib/moment/diff.js
+++ b/src/lib/moment/diff.js
@@ -1,6 +1,6 @@
-import absFloor from '../utils/abs-floor';
-import { cloneWithOffset } from '../units/offset';
-import { normalizeUnits } from '../units/aliases';
+import absFloor from '../utils/abs-floor.js';
+import { cloneWithOffset } from '../units/offset.js';
+import { normalizeUnits } from '../units/aliases.js';
 
 export function diff(input, units, asFloat) {
     var that, zoneDelta, output;

--- a/src/lib/moment/format.js
+++ b/src/lib/moment/format.js
@@ -1,6 +1,6 @@
-import { formatMoment } from '../format/format';
-import { hooks } from '../utils/hooks';
-import isFunction from '../utils/is-function';
+import { formatMoment } from '../format/format.js';
+import { hooks } from '../utils/hooks.js';
+import isFunction from '../utils/is-function.js';
 
 hooks.defaultFormat = 'YYYY-MM-DDTHH:mm:ssZ';
 hooks.defaultFormatUtc = 'YYYY-MM-DDTHH:mm:ss[Z]';

--- a/src/lib/moment/from.js
+++ b/src/lib/moment/from.js
@@ -1,6 +1,6 @@
-import { createDuration } from '../duration/create';
-import { createLocal } from '../create/local';
-import { isMoment } from '../moment/constructor';
+import { createDuration } from '../duration/create.js';
+import { createLocal } from '../create/local.js';
+import { isMoment } from '../moment/constructor.js';
 
 export function from(time, withoutSuffix) {
     if (

--- a/src/lib/moment/get-set.js
+++ b/src/lib/moment/get-set.js
@@ -1,10 +1,10 @@
-import { normalizeUnits, normalizeObjectUnits } from '../units/aliases';
-import { getPrioritizedUnits } from '../units/priorities';
-import { hooks } from '../utils/hooks';
-import isFunction from '../utils/is-function';
-import { daysInMonth } from '../units/month';
-import { isLeapYear } from '../utils/is-leap-year';
-import toInt from '../utils/to-int';
+import { normalizeUnits, normalizeObjectUnits } from '../units/aliases.js';
+import { getPrioritizedUnits } from '../units/priorities.js';
+import { hooks } from '../utils/hooks.js';
+import isFunction from '../utils/is-function.js';
+import { daysInMonth } from '../units/month.js';
+import { isLeapYear } from '../utils/is-leap-year.js';
+import toInt from '../utils/to-int.js';
 
 export function makeGetSet(unit, keepTime) {
     return function (value) {

--- a/src/lib/moment/locale.js
+++ b/src/lib/moment/locale.js
@@ -1,5 +1,5 @@
-import { getLocale } from '../locale/locales';
-import { deprecate } from '../utils/deprecate';
+import { getLocale } from '../locale/locales.js';
+import { deprecate } from '../utils/deprecate.js';
 
 // If passed a locale key, it will set the locale for this
 // instance.  Otherwise, it will return the locale configuration

--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -1,7 +1,7 @@
-import { deprecate } from '../utils/deprecate';
-import isArray from '../utils/is-array';
-import { createLocal } from '../create/local';
-import { createInvalid } from '../create/valid';
+import { deprecate } from '../utils/deprecate.js';
+import isArray from '../utils/is-array.js';
+import { createLocal } from '../create/local.js';
+import { createInvalid } from '../create/valid.js';
 
 export var prototypeMin = deprecate(
         'moment().min is deprecated, use moment.max instead. http://momentjs.com/guides/#/warnings/min-max/',

--- a/src/lib/moment/moment.js
+++ b/src/lib/moment/moment.js
@@ -1,10 +1,10 @@
-import { createLocal } from '../create/local';
-import { createUTC } from '../create/utc';
-import { createInvalid } from '../create/valid';
-import { isMoment } from './constructor';
-import { min, max } from './min-max';
-import { now } from './now';
-import momentPrototype from './prototype';
+import { createLocal } from '../create/local.js';
+import { createUTC } from '../create/utc.js';
+import { createInvalid } from '../create/valid.js';
+import { isMoment } from './constructor.js';
+import { min, max } from './min-max.js';
+import { now } from './now.js';
+import momentPrototype from './prototype.js';
 
 function createUnix(input) {
     return createLocal(input * 1000);

--- a/src/lib/moment/prototype.js
+++ b/src/lib/moment/prototype.js
@@ -1,10 +1,10 @@
-import { Moment } from './constructor';
+import { Moment } from './constructor.js';
 
 var proto = Moment.prototype;
 
-import { add, subtract } from './add-subtract';
-import { calendar } from './calendar';
-import { clone } from './clone';
+import { add, subtract } from './add-subtract.js';
+import { calendar } from './calendar.js';
+import { clone } from './clone.js';
 import {
     isBefore,
     isBetween,
@@ -12,18 +12,18 @@ import {
     isAfter,
     isSameOrAfter,
     isSameOrBefore,
-} from './compare';
-import { diff } from './diff';
-import { format, toString, toISOString, inspect } from './format';
-import { from, fromNow } from './from';
-import { to, toNow } from './to';
-import { stringGet, stringSet } from './get-set';
-import { locale, localeData, lang } from './locale';
-import { prototypeMin, prototypeMax } from './min-max';
-import { startOf, endOf } from './start-end-of';
-import { valueOf, toDate, toArray, toObject, toJSON, unix } from './to-type';
-import { isValid, parsingFlags, invalidAt } from './valid';
-import { creationData } from './creation-data';
+} from './compare.js';
+import { diff } from './diff.js';
+import { format, toString, toISOString, inspect } from './format.js';
+import { from, fromNow } from './from.js';
+import { to, toNow } from './to.js';
+import { stringGet, stringSet } from './get-set.js';
+import { locale, localeData, lang } from './locale.js';
+import { prototypeMin, prototypeMax } from './min-max.js';
+import { startOf, endOf } from './start-end-of.js';
+import { valueOf, toDate, toArray, toObject, toJSON, unix } from './to-type.js';
+import { isValid, parsingFlags, invalidAt } from './valid.js';
+import { creationData } from './creation-data.js';
 
 proto.add = add;
 proto.calendar = calendar;
@@ -70,14 +70,14 @@ proto.valueOf = valueOf;
 proto.creationData = creationData;
 
 // Era
-import { getEraName, getEraNarrow, getEraAbbr, getEraYear } from '../units/era';
+import { getEraName, getEraNarrow, getEraAbbr, getEraYear } from '../units/era.js';
 proto.eraName = getEraName;
 proto.eraNarrow = getEraNarrow;
 proto.eraAbbr = getEraAbbr;
 proto.eraYear = getEraYear;
 
 // Year
-import { getSetYear, getIsLeapYear } from '../units/year';
+import { getSetYear, getIsLeapYear } from '../units/year.js';
 proto.year = getSetYear;
 proto.isLeapYear = getIsLeapYear;
 
@@ -89,21 +89,21 @@ import {
     getWeeksInWeekYear,
     getISOWeeksInYear,
     getISOWeeksInISOWeekYear,
-} from '../units/week-year';
+} from '../units/week-year.js';
 proto.weekYear = getSetWeekYear;
 proto.isoWeekYear = getSetISOWeekYear;
 
 // Quarter
-import { getSetQuarter } from '../units/quarter';
+import { getSetQuarter } from '../units/quarter.js';
 proto.quarter = proto.quarters = getSetQuarter;
 
 // Month
-import { getSetMonth, getDaysInMonth } from '../units/month';
+import { getSetMonth, getDaysInMonth } from '../units/month.js';
 proto.month = getSetMonth;
 proto.daysInMonth = getDaysInMonth;
 
 // Week
-import { getSetWeek, getSetISOWeek } from '../units/week';
+import { getSetWeek, getSetISOWeek } from '../units/week.js';
 proto.week = proto.weeks = getSetWeek;
 proto.isoWeek = proto.isoWeeks = getSetISOWeek;
 proto.weeksInYear = getWeeksInYear;
@@ -112,13 +112,13 @@ proto.isoWeeksInYear = getISOWeeksInYear;
 proto.isoWeeksInISOWeekYear = getISOWeeksInISOWeekYear;
 
 // Day
-import { getSetDayOfMonth } from '../units/day-of-month';
+import { getSetDayOfMonth } from '../units/day-of-month.js';
 import {
     getSetDayOfWeek,
     getSetISODayOfWeek,
     getSetLocaleDayOfWeek,
-} from '../units/day-of-week';
-import { getSetDayOfYear } from '../units/day-of-year';
+} from '../units/day-of-week.js';
+import { getSetDayOfYear } from '../units/day-of-year.js';
 proto.date = getSetDayOfMonth;
 proto.day = proto.days = getSetDayOfWeek;
 proto.weekday = getSetLocaleDayOfWeek;
@@ -126,19 +126,19 @@ proto.isoWeekday = getSetISODayOfWeek;
 proto.dayOfYear = getSetDayOfYear;
 
 // Hour
-import { getSetHour } from '../units/hour';
+import { getSetHour } from '../units/hour.js';
 proto.hour = proto.hours = getSetHour;
 
 // Minute
-import { getSetMinute } from '../units/minute';
+import { getSetMinute } from '../units/minute.js';
 proto.minute = proto.minutes = getSetMinute;
 
 // Second
-import { getSetSecond } from '../units/second';
+import { getSetSecond } from '../units/second.js';
 proto.second = proto.seconds = getSetSecond;
 
 // Millisecond
-import { getSetMillisecond } from '../units/millisecond';
+import { getSetMillisecond } from '../units/millisecond.js';
 proto.millisecond = proto.milliseconds = getSetMillisecond;
 
 // Offset
@@ -154,7 +154,7 @@ import {
     isLocal,
     isUtcOffset,
     isUtc,
-} from '../units/offset';
+} from '../units/offset.js';
 proto.utcOffset = getSetOffset;
 proto.utc = setOffsetToUTC;
 proto.local = setOffsetToLocal;
@@ -167,12 +167,12 @@ proto.isUtc = isUtc;
 proto.isUTC = isUtc;
 
 // Timezone
-import { getZoneAbbr, getZoneName } from '../units/timezone';
+import { getZoneAbbr, getZoneName } from '../units/timezone.js';
 proto.zoneAbbr = getZoneAbbr;
 proto.zoneName = getZoneName;
 
 // Deprecations
-import { deprecate } from '../utils/deprecate';
+import { deprecate } from '../utils/deprecate.js';
 proto.dates = deprecate(
     'dates accessor is deprecated. Use date instead.',
     getSetDayOfMonth

--- a/src/lib/moment/start-end-of.js
+++ b/src/lib/moment/start-end-of.js
@@ -1,5 +1,5 @@
-import { normalizeUnits } from '../units/aliases';
-import { hooks } from '../utils/hooks';
+import { normalizeUnits } from '../units/aliases.js';
+import { hooks } from '../utils/hooks.js';
 
 var MS_PER_SECOND = 1000,
     MS_PER_MINUTE = 60 * MS_PER_SECOND,

--- a/src/lib/moment/to.js
+++ b/src/lib/moment/to.js
@@ -1,6 +1,6 @@
-import { createDuration } from '../duration/create';
-import { createLocal } from '../create/local';
-import { isMoment } from '../moment/constructor';
+import { createDuration } from '../duration/create.js';
+import { createLocal } from '../create/local.js';
+import { isMoment } from '../moment/constructor.js';
 
 export function to(time, withoutSuffix) {
     if (

--- a/src/lib/moment/valid.js
+++ b/src/lib/moment/valid.js
@@ -1,6 +1,6 @@
-import { isValid as _isValid } from '../create/valid';
-import extend from '../utils/extend';
-import getParsingFlags from '../create/parsing-flags';
+import { isValid as _isValid } from '../create/valid.js';
+import extend from '../utils/extend.js';
+import getParsingFlags from '../create/parsing-flags.js';
 
 export function isValid() {
     return _isValid(this);

--- a/src/lib/parse/regex.js
+++ b/src/lib/parse/regex.js
@@ -39,8 +39,8 @@ export {
     matchWord,
 };
 
-import hasOwnProp from '../utils/has-own-prop';
-import isFunction from '../utils/is-function';
+import hasOwnProp from '../utils/has-own-prop.js';
+import isFunction from '../utils/is-function.js';
 
 regexes = {};
 

--- a/src/lib/parse/token.js
+++ b/src/lib/parse/token.js
@@ -1,6 +1,6 @@
-import hasOwnProp from '../utils/has-own-prop';
-import isNumber from '../utils/is-number';
-import toInt from '../utils/to-int';
+import hasOwnProp from '../utils/has-own-prop.js';
+import isNumber from '../utils/is-number.js';
+import toInt from '../utils/to-int.js';
 
 var tokens = {};
 

--- a/src/lib/units/aliases.js
+++ b/src/lib/units/aliases.js
@@ -1,4 +1,4 @@
-import hasOwnProp from '../utils/has-own-prop';
+import hasOwnProp from '../utils/has-own-prop.js';
 
 var aliases = {};
 

--- a/src/lib/units/day-of-month.js
+++ b/src/lib/units/day-of-month.js
@@ -1,11 +1,11 @@
-import { makeGetSet } from '../moment/get-set';
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { DATE } from './constants';
-import toInt from '../utils/to-int';
+import { makeGetSet } from '../moment/get-set.js';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
+import { addRegexToken, match1to2, match2 } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { DATE } from './constants.js';
+import toInt from '../utils/to-int.js';
 
 // FORMATTING
 

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -1,19 +1,19 @@
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
 import {
     addRegexToken,
     match1to2,
     matchWord,
     regexEscape,
-} from '../parse/regex';
-import { addWeekParseToken } from '../parse/token';
-import toInt from '../utils/to-int';
-import isArray from '../utils/is-array';
-import indexOf from '../utils/index-of';
-import hasOwnProp from '../utils/has-own-prop';
-import { createUTC } from '../create/utc';
-import getParsingFlags from '../create/parsing-flags';
+} from '../parse/regex.js';
+import { addWeekParseToken } from '../parse/token.js';
+import toInt from '../utils/to-int.js';
+import isArray from '../utils/is-array.js';
+import indexOf from '../utils/index-of.js';
+import hasOwnProp from '../utils/has-own-prop.js';
+import { createUTC } from '../create/utc.js';
+import getParsingFlags from '../create/parsing-flags.js';
 
 // FORMATTING
 

--- a/src/lib/units/day-of-year.js
+++ b/src/lib/units/day-of-year.js
@@ -1,9 +1,9 @@
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
-import { addRegexToken, match3, match1to3 } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import toInt from '../utils/to-int';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
+import { addRegexToken, match3, match1to3 } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import toInt from '../utils/to-int.js';
 
 // FORMATTING
 

--- a/src/lib/units/era.js
+++ b/src/lib/units/era.js
@@ -1,11 +1,11 @@
-import { addFormatToken } from '../format/format';
-import { addRegexToken, matchUnsigned, regexEscape } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { YEAR } from './constants';
-import { hooks as moment } from '../utils/hooks';
-import { getLocale } from '../locale/locales';
-import getParsingFlags from '../create/parsing-flags';
-import hasOwnProp from '../utils/has-own-prop';
+import { addFormatToken } from '../format/format.js';
+import { addRegexToken, matchUnsigned, regexEscape } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { YEAR } from './constants.js';
+import { hooks as moment } from '../utils/hooks.js';
+import { getLocale } from '../locale/locales.js';
+import getParsingFlags from '../create/parsing-flags.js';
+import hasOwnProp from '../utils/has-own-prop.js';
 
 addFormatToken('N', 0, 0, 'eraAbbr');
 addFormatToken('NN', 0, 0, 'eraAbbr');

--- a/src/lib/units/hour.js
+++ b/src/lib/units/hour.js
@@ -1,19 +1,19 @@
-import { makeGetSet } from '../moment/get-set';
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
+import { makeGetSet } from '../moment/get-set.js';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
 import {
     addRegexToken,
     match1to2,
     match2,
     match3to4,
     match5to6,
-} from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { HOUR, MINUTE, SECOND } from './constants';
-import toInt from '../utils/to-int';
-import zeroFill from '../utils/zero-fill';
-import getParsingFlags from '../create/parsing-flags';
+} from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { HOUR, MINUTE, SECOND } from './constants.js';
+import toInt from '../utils/to-int.js';
+import zeroFill from '../utils/zero-fill.js';
+import getParsingFlags from '../create/parsing-flags.js';
 
 // FORMATTING
 

--- a/src/lib/units/millisecond.js
+++ b/src/lib/units/millisecond.js
@@ -1,7 +1,7 @@
-import { makeGetSet } from '../moment/get-set';
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
+import { makeGetSet } from '../moment/get-set.js';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
 import {
     addRegexToken,
     match1,
@@ -9,10 +9,10 @@ import {
     match3,
     match1to3,
     matchUnsigned,
-} from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { MILLISECOND } from './constants';
-import toInt from '../utils/to-int';
+} from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { MILLISECOND } from './constants.js';
+import toInt from '../utils/to-int.js';
 
 // FORMATTING
 

--- a/src/lib/units/minute.js
+++ b/src/lib/units/minute.js
@@ -1,10 +1,10 @@
-import { makeGetSet } from '../moment/get-set';
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { MINUTE } from './constants';
+import { makeGetSet } from '../moment/get-set.js';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
+import { addRegexToken, match1to2, match2 } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { MINUTE } from './constants.js';
 
 // FORMATTING
 

--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -1,26 +1,26 @@
-import { get } from '../moment/get-set';
-import hasOwnProp from '../utils/has-own-prop';
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
+import { get } from '../moment/get-set.js';
+import hasOwnProp from '../utils/has-own-prop.js';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
 import {
     addRegexToken,
     match1to2,
     match2,
     matchWord,
     regexEscape,
-} from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { hooks } from '../utils/hooks';
-import { MONTH } from './constants';
-import toInt from '../utils/to-int';
-import isArray from '../utils/is-array';
-import isNumber from '../utils/is-number';
-import mod from '../utils/mod';
-import indexOf from '../utils/index-of';
-import { createUTC } from '../create/utc';
-import getParsingFlags from '../create/parsing-flags';
-import { isLeapYear } from '../utils/is-leap-year';
+} from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { hooks } from '../utils/hooks.js';
+import { MONTH } from './constants.js';
+import toInt from '../utils/to-int.js';
+import isArray from '../utils/is-array.js';
+import isNumber from '../utils/is-number.js';
+import mod from '../utils/mod.js';
+import indexOf from '../utils/index-of.js';
+import { createUTC } from '../create/utc.js';
+import getParsingFlags from '../create/parsing-flags.js';
+import { isLeapYear } from '../utils/is-leap-year.js';
 
 export function daysInMonth(year, month) {
     if (isNaN(year) || isNaN(month)) {

--- a/src/lib/units/offset.js
+++ b/src/lib/units/offset.js
@@ -1,18 +1,18 @@
-import zeroFill from '../utils/zero-fill';
-import { createDuration } from '../duration/create';
-import { addSubtract } from '../moment/add-subtract';
-import { isMoment, copyConfig } from '../moment/constructor';
-import { addFormatToken } from '../format/format';
-import { addRegexToken, matchOffset, matchShortOffset } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { createLocal } from '../create/local';
-import { prepareConfig } from '../create/from-anything';
-import { createUTC } from '../create/utc';
-import isDate from '../utils/is-date';
-import toInt from '../utils/to-int';
-import isUndefined from '../utils/is-undefined';
-import compareArrays from '../utils/compare-arrays';
-import { hooks } from '../utils/hooks';
+import zeroFill from '../utils/zero-fill.js';
+import { createDuration } from '../duration/create.js';
+import { addSubtract } from '../moment/add-subtract.js';
+import { isMoment, copyConfig } from '../moment/constructor.js';
+import { addFormatToken } from '../format/format.js';
+import { addRegexToken, matchOffset, matchShortOffset } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { createLocal } from '../create/local.js';
+import { prepareConfig } from '../create/from-anything.js';
+import { createUTC } from '../create/utc.js';
+import isDate from '../utils/is-date.js';
+import toInt from '../utils/to-int.js';
+import isUndefined from '../utils/is-undefined.js';
+import compareArrays from '../utils/compare-arrays.js';
+import { hooks } from '../utils/hooks.js';
 
 // FORMATTING
 

--- a/src/lib/units/priorities.js
+++ b/src/lib/units/priorities.js
@@ -1,4 +1,4 @@
-import hasOwnProp from '../utils/has-own-prop';
+import hasOwnProp from '../utils/has-own-prop.js';
 
 var priorities = {};
 

--- a/src/lib/units/quarter.js
+++ b/src/lib/units/quarter.js
@@ -1,10 +1,10 @@
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
-import { addRegexToken, match1 } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { MONTH } from './constants';
-import toInt from '../utils/to-int';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
+import { addRegexToken, match1 } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { MONTH } from './constants.js';
+import toInt from '../utils/to-int.js';
 
 // FORMATTING
 

--- a/src/lib/units/second.js
+++ b/src/lib/units/second.js
@@ -1,10 +1,10 @@
-import { makeGetSet } from '../moment/get-set';
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { SECOND } from './constants';
+import { makeGetSet } from '../moment/get-set.js';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
+import { addRegexToken, match1to2, match2 } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { SECOND } from './constants.js';
 
 // FORMATTING
 

--- a/src/lib/units/timestamp.js
+++ b/src/lib/units/timestamp.js
@@ -1,7 +1,7 @@
-import { addFormatToken } from '../format/format';
-import { addRegexToken, matchTimestamp, matchSigned } from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import toInt from '../utils/to-int';
+import { addFormatToken } from '../format/format.js';
+import { addRegexToken, matchTimestamp, matchSigned } from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import toInt from '../utils/to-int.js';
 
 // FORMATTING
 

--- a/src/lib/units/timezone.js
+++ b/src/lib/units/timezone.js
@@ -1,4 +1,4 @@
-import { addFormatToken } from '../format/format';
+import { addFormatToken } from '../format/format.js';
 
 // FORMATTING
 

--- a/src/lib/units/units.js
+++ b/src/lib/units/units.js
@@ -1,20 +1,20 @@
 // Side effect imports
-import './day-of-month';
-import './day-of-week';
-import './day-of-year';
-import './hour';
-import './millisecond';
-import './minute';
-import './month';
-import './offset';
-import './quarter';
-import './second';
-import './timestamp';
-import './timezone';
-import './week-year';
-import './week';
-import './year';
+import './day-of-month.js';
+import './day-of-week.js';
+import './day-of-year.js';
+import './hour.js';
+import './millisecond.js';
+import './minute.js';
+import './month.js';
+import './offset.js';
+import './quarter.js';
+import './second.js';
+import './timestamp.js';
+import './timezone.js';
+import './week-year.js';
+import './week.js';
+import './year.js';
 
-import { normalizeUnits } from './aliases';
+import { normalizeUnits } from './aliases.js';
 
 export { normalizeUnits };

--- a/src/lib/units/week-calendar-utils.js
+++ b/src/lib/units/week-calendar-utils.js
@@ -1,5 +1,5 @@
-import { daysInYear } from './year';
-import { createUTCDate } from '../create/date-from-array';
+import { daysInYear } from './year.js';
+import { createUTCDate } from '../create/date-from-array.js';
 
 // start-of-first-week - start-of-year
 function firstWeekOffset(year, dow, doy) {

--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -1,6 +1,6 @@
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
 import {
     addRegexToken,
     match1to2,
@@ -10,16 +10,16 @@ import {
     match4,
     match6,
     matchSigned,
-} from '../parse/regex';
-import { addWeekParseToken } from '../parse/token';
+} from '../parse/regex.js';
+import { addWeekParseToken } from '../parse/token.js';
 import {
     weekOfYear,
     weeksInYear,
     dayOfYearFromWeeks,
-} from './week-calendar-utils';
-import toInt from '../utils/to-int';
-import { hooks } from '../utils/hooks';
-import { createUTCDate } from '../create/date-from-array';
+} from './week-calendar-utils.js';
+import toInt from '../utils/to-int.js';
+import { hooks } from '../utils/hooks.js';
+import { createUTCDate } from '../create/date-from-array.js';
 
 // FORMATTING
 

--- a/src/lib/units/week.js
+++ b/src/lib/units/week.js
@@ -1,10 +1,10 @@
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
-import { addRegexToken, match1to2, match2 } from '../parse/regex';
-import { addWeekParseToken } from '../parse/token';
-import toInt from '../utils/to-int';
-import { weekOfYear } from './week-calendar-utils';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
+import { addRegexToken, match1to2, match2 } from '../parse/regex.js';
+import { addWeekParseToken } from '../parse/token.js';
+import toInt from '../utils/to-int.js';
+import { weekOfYear } from './week-calendar-utils.js';
 
 // FORMATTING
 

--- a/src/lib/units/year.js
+++ b/src/lib/units/year.js
@@ -1,7 +1,7 @@
-import { makeGetSet } from '../moment/get-set';
-import { addFormatToken } from '../format/format';
-import { addUnitAlias } from './aliases';
-import { addUnitPriority } from './priorities';
+import { makeGetSet } from '../moment/get-set.js';
+import { addFormatToken } from '../format/format.js';
+import { addUnitAlias } from './aliases.js';
+import { addUnitPriority } from './priorities.js';
 import {
     addRegexToken,
     match1to2,
@@ -11,13 +11,13 @@ import {
     match4,
     match6,
     matchSigned,
-} from '../parse/regex';
-import { addParseToken } from '../parse/token';
-import { isLeapYear } from '../utils/is-leap-year';
-import { hooks } from '../utils/hooks';
-import { YEAR } from './constants';
-import toInt from '../utils/to-int';
-import zeroFill from '../utils/zero-fill';
+} from '../parse/regex.js';
+import { addParseToken } from '../parse/token.js';
+import { isLeapYear } from '../utils/is-leap-year.js';
+import { hooks } from '../utils/hooks.js';
+import { YEAR } from './constants.js';
+import toInt from '../utils/to-int.js';
+import zeroFill from '../utils/zero-fill.js';
 
 // FORMATTING
 

--- a/src/lib/utils/compare-arrays.js
+++ b/src/lib/utils/compare-arrays.js
@@ -1,4 +1,4 @@
-import toInt from './to-int';
+import toInt from './to-int.js';
 
 // compare two arrays, return the number of differences
 export default function compareArrays(array1, array2, dontConvert) {

--- a/src/lib/utils/deprecate.js
+++ b/src/lib/utils/deprecate.js
@@ -1,6 +1,6 @@
-import extend from './extend';
-import { hooks } from './hooks';
-import hasOwnProp from './has-own-prop';
+import extend from './extend.js';
+import { hooks } from './hooks.js';
+import hasOwnProp from './has-own-prop.js';
 
 function warn(msg) {
     if (

--- a/src/lib/utils/extend.js
+++ b/src/lib/utils/extend.js
@@ -1,4 +1,4 @@
-import hasOwnProp from './has-own-prop';
+import hasOwnProp from './has-own-prop.js';
 
 export default function extend(a, b) {
     for (var i in b) {

--- a/src/lib/utils/is-calendar-spec.js
+++ b/src/lib/utils/is-calendar-spec.js
@@ -1,6 +1,6 @@
-import isObjectEmpty from './is-object-empty';
-import hasOwnProp from './has-own-prop';
-import isObject from './is-object';
+import isObjectEmpty from './is-object-empty.js';
+import hasOwnProp from './has-own-prop.js';
+import isObject from './is-object.js';
 
 export default function isCalendarSpec(input) {
     var objectTest = isObject(input) && !isObjectEmpty(input),

--- a/src/lib/utils/is-moment-input.js
+++ b/src/lib/utils/is-moment-input.js
@@ -1,11 +1,11 @@
-import isObjectEmpty from './is-object-empty';
-import hasOwnProp from './has-own-prop';
-import isObject from './is-object';
-import isDate from './is-date';
-import isNumber from './is-number';
-import isString from './is-string';
-import { isMoment } from '../moment/constructor';
-import isArray from './is-array';
+import isObjectEmpty from './is-object-empty.js';
+import hasOwnProp from './has-own-prop.js';
+import isObject from './is-object.js';
+import isDate from './is-date.js';
+import isNumber from './is-number.js';
+import isString from './is-string.js';
+import { isMoment } from '../moment/constructor.js';
+import isArray from './is-array.js';
 
 // type MomentInput = Moment | Date | string | number | (number | string)[] | MomentInputObject | void; // null | undefined
 export function isMomentInput(input) {

--- a/src/lib/utils/is-object-empty.js
+++ b/src/lib/utils/is-object-empty.js
@@ -1,4 +1,4 @@
-import hasOwnProp from './has-own-prop';
+import hasOwnProp from './has-own-prop.js';
 
 export default function isObjectEmpty(obj) {
     if (Object.getOwnPropertyNames) {

--- a/src/lib/utils/keys.js
+++ b/src/lib/utils/keys.js
@@ -1,4 +1,4 @@
-import hasOwnProp from './has-own-prop';
+import hasOwnProp from './has-own-prop.js';
 
 var keys;
 

--- a/src/lib/utils/to-int.js
+++ b/src/lib/utils/to-int.js
@@ -1,4 +1,4 @@
-import absFloor from './abs-floor';
+import absFloor from './abs-floor.js';
 
 export default function toInt(argumentForCoercion) {
     var coercedNumber = +argumentForCoercion,

--- a/src/locale/af.js
+++ b/src/locale/af.js
@@ -2,7 +2,7 @@
 //! locale : Afrikaans [af]
 //! author : Werner Mollentze : https://github.com/wernerm
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('af', {
     months: 'Januarie_Februarie_Maart_April_Mei_Junie_Julie_Augustus_September_Oktober_November_Desember'.split(

--- a/src/locale/ar-dz.js
+++ b/src/locale/ar-dz.js
@@ -6,7 +6,7 @@
 //! author : forabi https://github.com/forabi
 //! author : Noureddine LOUAHEDJ : https://github.com/noureddinem
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var pluralForm = function (n) {
         return n === 0

--- a/src/locale/ar-kw.js
+++ b/src/locale/ar-kw.js
@@ -2,7 +2,7 @@
 //! locale : Arabic (Kuwait) [ar-kw]
 //! author : Nusret Parlak: https://github.com/nusretparlak
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ar-kw', {
     months: 'يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر'.split(

--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -2,7 +2,7 @@
 //! locale : Arabic (Lybia) [ar-ly]
 //! author : Ali Hmer: https://github.com/kikoanis
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '1',

--- a/src/locale/ar-ma.js
+++ b/src/locale/ar-ma.js
@@ -3,7 +3,7 @@
 //! author : ElFadili Yassine : https://github.com/ElFadiliY
 //! author : Abdel Said : https://github.com/abdelsaid
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ar-ma', {
     months: 'يناير_فبراير_مارس_أبريل_ماي_يونيو_يوليوز_غشت_شتنبر_أكتوبر_نونبر_دجنبر'.split(

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -2,7 +2,7 @@
 //! locale : Arabic (Saudi Arabia) [ar-sa]
 //! author : Suhail Alkowaileet : https://github.com/xsoh
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '١',

--- a/src/locale/ar-tn.js
+++ b/src/locale/ar-tn.js
@@ -2,7 +2,7 @@
 //! locale  :  Arabic (Tunisia) [ar-tn]
 //! author : Nader Toukabri : https://github.com/naderio
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ar-tn', {
     months: 'جانفي_فيفري_مارس_أفريل_ماي_جوان_جويلية_أوت_سبتمبر_أكتوبر_نوفمبر_ديسمبر'.split(

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -4,7 +4,7 @@
 //! author : Ahmed Elkhatib
 //! author : forabi https://github.com/forabi
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '١',

--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -2,7 +2,7 @@
 //! locale : Azerbaijani [az]
 //! author : topchiyev : https://github.com/topchiyev
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var suffixes = {
     1: '-inci',

--- a/src/locale/be.js
+++ b/src/locale/be.js
@@ -4,7 +4,7 @@
 //! author: Praleska: http://praleska.pro/
 //! Author : Menelion Elensúle : https://github.com/Oire
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function plural(word, num) {
     var forms = word.split('_');

--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -2,7 +2,7 @@
 //! locale : Bulgarian [bg]
 //! author : Krasen Borisov : https://github.com/kraz
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('bg', {
     months: 'януари_февруари_март_април_май_юни_юли_август_септември_октомври_ноември_декември'.split(

--- a/src/locale/bm.js
+++ b/src/locale/bm.js
@@ -3,7 +3,7 @@
 //! author : Estelle Comment : https://github.com/estellecomment
 // Language contact person : Abdoufata Kane : https://github.com/abdoufata
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('bm', {
     months: 'Zanwuyekalo_Fewuruyekalo_Marisikalo_Awirilikalo_Mɛkalo_Zuwɛnkalo_Zuluyekalo_Utikalo_Sɛtanburukalo_ɔkutɔburukalo_Nowanburukalo_Desanburukalo'.split(

--- a/src/locale/bn.js
+++ b/src/locale/bn.js
@@ -2,7 +2,7 @@
 //! locale : Bengali [bn]
 //! author : Kaushik Gandhi : https://github.com/kaushikgandhi
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '১',

--- a/src/locale/bo.js
+++ b/src/locale/bo.js
@@ -2,7 +2,7 @@
 //! locale : Tibetan [bo]
 //! author : Thupten N. Chakrishar : https://github.com/vajradog
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '༡',

--- a/src/locale/br.js
+++ b/src/locale/br.js
@@ -2,7 +2,7 @@
 //! locale : Breton [br]
 //! author : Jean-Baptiste Le Duigou : https://github.com/jbleduigou
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function relativeTimeWithMutation(number, withoutSuffix, key) {
     var format = {

--- a/src/locale/bs.js
+++ b/src/locale/bs.js
@@ -3,7 +3,7 @@
 //! author : Nedim Cholich : https://github.com/frontyard
 //! based on (hr) translation by Bojan Marković
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function translate(number, withoutSuffix, key) {
     var result = number + ' ';

--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -2,7 +2,7 @@
 //! locale : Catalan [ca]
 //! author : Juan G. Hurtado : https://github.com/juanghurtado
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ca', {
     months: {

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -2,7 +2,7 @@
 //! locale : Czech [cs]
 //! author : petrbela : https://github.com/petrbela
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var months = 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split(
         '_'

--- a/src/locale/cv.js
+++ b/src/locale/cv.js
@@ -2,7 +2,7 @@
 //! locale : Chuvash [cv]
 //! author : Anatoly Mironov : https://github.com/mirontoli
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('cv', {
     months: 'кӑрлач_нарӑс_пуш_ака_май_ҫӗртме_утӑ_ҫурла_авӑн_юпа_чӳк_раштав'.split(

--- a/src/locale/cy.js
+++ b/src/locale/cy.js
@@ -3,7 +3,7 @@
 //! author : Robert Allen : https://github.com/robgallen
 //! author : https://github.com/ryangreaves
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('cy', {
     months: 'Ionawr_Chwefror_Mawrth_Ebrill_Mai_Mehefin_Gorffennaf_Awst_Medi_Hydref_Tachwedd_Rhagfyr'.split(

--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -2,7 +2,7 @@
 //! locale : Danish [da]
 //! author : Ulrik Nielsen : https://github.com/mrbase
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('da', {
     months: 'januar_februar_marts_april_maj_juni_juli_august_september_oktober_november_december'.split(

--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -5,7 +5,7 @@
 //! author : Martin Groller : https://github.com/MadMG
 //! author : Mikolaj Dadela : https://github.com/mik01aj
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -4,7 +4,7 @@
 
 // based on: https://www.bk.admin.ch/dokumentation/sprachen/04915/05016/index.html?lang=de#
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -4,7 +4,7 @@
 //! author: Menelion Elensúle: https://github.com/Oire
 //! author : Mikolaj Dadela : https://github.com/mik01aj
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/dv.js
+++ b/src/locale/dv.js
@@ -2,7 +2,7 @@
 //! locale : Maldivian [dv]
 //! author : Jawish Hameed : https://github.com/jawish
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var months = [
         'ޖެނުއަރީ',

--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -2,7 +2,7 @@
 //! locale : Greek [el]
 //! author : Aggelos Karalias : https://github.com/mehiel
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function isFunction(input) {
     return (

--- a/src/locale/en-au.js
+++ b/src/locale/en-au.js
@@ -2,7 +2,7 @@
 //! locale : English (Australia) [en-au]
 //! author : Jared Morse : https://github.com/jarcoal
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-au', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/en-ca.js
+++ b/src/locale/en-ca.js
@@ -2,7 +2,7 @@
 //! locale : English (Canada) [en-ca]
 //! author : Jonathan Abourbih : https://github.com/jonbca
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-ca', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/en-gb.js
+++ b/src/locale/en-gb.js
@@ -2,7 +2,7 @@
 //! locale : English (United Kingdom) [en-gb]
 //! author : Chris Gedrim : https://github.com/chrisgedrim
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-gb', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/en-ie.js
+++ b/src/locale/en-ie.js
@@ -2,7 +2,7 @@
 //! locale : English (Ireland) [en-ie]
 //! author : Chris Cartlidge : https://github.com/chriscartlidge
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-ie', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/en-il.js
+++ b/src/locale/en-il.js
@@ -2,7 +2,7 @@
 //! locale : English (Israel) [en-il]
 //! author : Chris Gedrim : https://github.com/chrisgedrim
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-il', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/en-in.js
+++ b/src/locale/en-in.js
@@ -2,7 +2,7 @@
 //! locale : English (India) [en-in]
 //! author : Jatin Agrawal : https://github.com/jatinag22
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-in', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/en-nz.js
+++ b/src/locale/en-nz.js
@@ -2,7 +2,7 @@
 //! locale : English (New Zealand) [en-nz]
 //! author : Luke McGregor : https://github.com/lukemcgregor
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-nz', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/en-sg.js
+++ b/src/locale/en-sg.js
@@ -2,7 +2,7 @@
 //! locale : English (Singapore) [en-sg]
 //! author : Matthew Castrillon-Madrigal : https://github.com/techdimension
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('en-sg', {
     months: 'January_February_March_April_May_June_July_August_September_October_November_December'.split(

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -5,7 +5,7 @@
 //! comment : miestasmia corrected the translation by colindean
 //! comment : Vivakvo corrected the translation by colindean and miestasmia
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('eo', {
     months: 'januaro_februaro_marto_aprilo_majo_junio_julio_aŭgusto_septembro_oktobro_novembro_decembro'.split(

--- a/src/locale/es-do.js
+++ b/src/locale/es-do.js
@@ -1,7 +1,7 @@
 //! moment.js locale configuration
 //! locale : Spanish (Dominican Republic) [es-do]
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split(
         '_'

--- a/src/locale/es-us.js
+++ b/src/locale/es-us.js
@@ -3,7 +3,7 @@
 //! author : bustta : https://github.com/bustta
 //! author : chrisrodz : https://github.com/chrisrodz
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split(
         '_'

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -2,7 +2,7 @@
 //! locale : Spanish [es]
 //! author : Julio Napurí : https://github.com/julionc
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsShortDot = 'ene._feb._mar._abr._may._jun._jul._ago._sep._oct._nov._dic.'.split(
         '_'

--- a/src/locale/et.js
+++ b/src/locale/et.js
@@ -3,7 +3,7 @@
 //! author : Henry Kehlmann : https://github.com/madhenry
 //! improvements : Illimar Tambek : https://github.com/ragulka
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/eu.js
+++ b/src/locale/eu.js
@@ -2,7 +2,7 @@
 //! locale : Basque [eu]
 //! author : Eneko Illarramendi : https://github.com/eillarra
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('eu', {
     months: 'urtarrila_otsaila_martxoa_apirila_maiatza_ekaina_uztaila_abuztua_iraila_urria_azaroa_abendua'.split(

--- a/src/locale/fa.js
+++ b/src/locale/fa.js
@@ -2,7 +2,7 @@
 //! locale : Persian [fa]
 //! author : Ebrahim Byagowi : https://github.com/ebraminio
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '۱',

--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -2,7 +2,7 @@
 //! locale : Finnish [fi]
 //! author : Tarmo Aidantausta : https://github.com/bleadof
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var numbersPast = 'nolla yksi kaksi kolme neljä viisi kuusi seitsemän kahdeksan yhdeksän'.split(
         ' '

--- a/src/locale/fil.js
+++ b/src/locale/fil.js
@@ -3,7 +3,7 @@
 //! author : Dan Hagman : https://github.com/hagmandan
 //! author : Matthew Co : https://github.com/matthewdeeco
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('fil', {
     months: 'Enero_Pebrero_Marso_Abril_Mayo_Hunyo_Hulyo_Agosto_Setyembre_Oktubre_Nobyembre_Disyembre'.split(

--- a/src/locale/fo.js
+++ b/src/locale/fo.js
@@ -3,7 +3,7 @@
 //! author : Ragnar Johannesen : https://github.com/ragnar123
 //! author : Kristian Sakarisson : https://github.com/sakarisson
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('fo', {
     months: 'januar_februar_mars_apríl_mai_juni_juli_august_september_oktober_november_desember'.split(

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -2,7 +2,7 @@
 //! locale : French (Canada) [fr-ca]
 //! author : Jonathan Abourbih : https://github.com/jonbca
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('fr-ca', {
     months: 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split(

--- a/src/locale/fr-ch.js
+++ b/src/locale/fr-ch.js
@@ -2,7 +2,7 @@
 //! locale : French (Switzerland) [fr-ch]
 //! author : Gaspard Bucher : https://github.com/gaspard
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('fr-ch', {
     months: 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'.split(

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -2,7 +2,7 @@
 //! locale : French [fr]
 //! author : John Fischer : https://github.com/jfroffice
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsStrictRegex = /^(janvier|février|mars|avril|mai|juin|juillet|août|septembre|octobre|novembre|décembre)/i,
     monthsShortStrictRegex = /(janv\.?|févr\.?|mars|avr\.?|mai|juin|juil\.?|août|sept\.?|oct\.?|nov\.?|déc\.?)/i,

--- a/src/locale/fy.js
+++ b/src/locale/fy.js
@@ -2,7 +2,7 @@
 //! locale : Frisian [fy]
 //! author : Robin van der Vliet : https://github.com/robin0van0der0v
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsShortWithDots = 'jan._feb._mrt._apr._mai_jun._jul._aug._sep._okt._nov._des.'.split(
         '_'

--- a/src/locale/ga.js
+++ b/src/locale/ga.js
@@ -2,7 +2,7 @@
 //! locale : Irish or Irish Gaelic [ga]
 //! author : André Silva : https://github.com/askpt
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var months = [
         'Eanáir',

--- a/src/locale/gd.js
+++ b/src/locale/gd.js
@@ -2,7 +2,7 @@
 //! locale : Scottish Gaelic [gd]
 //! author : Jon Ashdown : https://github.com/jonashdown
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var months = [
         'Am Faoilleach',

--- a/src/locale/gl.js
+++ b/src/locale/gl.js
@@ -2,7 +2,7 @@
 //! locale : Galician [gl]
 //! author : Juan G. Hurtado : https://github.com/juanghurtado
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('gl', {
     months: 'xaneiro_febreiro_marzo_abril_maio_xuño_xullo_agosto_setembro_outubro_novembro_decembro'.split(

--- a/src/locale/gom-deva.js
+++ b/src/locale/gom-deva.js
@@ -2,7 +2,7 @@
 //! locale : Konkani Devanagari script [gom-deva]
 //! author : The Discoverer : https://github.com/WikiDiscoverer
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/gom-latn.js
+++ b/src/locale/gom-latn.js
@@ -2,7 +2,7 @@
 //! locale : Konkani Latin script [gom-latn]
 //! author : The Discoverer : https://github.com/WikiDiscoverer
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/gu.js
+++ b/src/locale/gu.js
@@ -2,7 +2,7 @@
 //! locale : Gujarati [gu]
 //! author : Kaushik Thanki : https://github.com/Kaushik1987
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '૧',

--- a/src/locale/he.js
+++ b/src/locale/he.js
@@ -4,7 +4,7 @@
 //! author : Moshe Simantov : https://github.com/DevelopmentIL
 //! author : Tal Ater : https://github.com/TalAter
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('he', {
     months: 'ינואר_פברואר_מרץ_אפריל_מאי_יוני_יולי_אוגוסט_ספטמבר_אוקטובר_נובמבר_דצמבר'.split(

--- a/src/locale/hi.js
+++ b/src/locale/hi.js
@@ -2,7 +2,7 @@
 //! locale : Hindi [hi]
 //! author : Mayank Singhal : https://github.com/mayanksinghal
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '१',

--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -2,7 +2,7 @@
 //! locale : Croatian [hr]
 //! author : Bojan Marković : https://github.com/bmarkovic
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function translate(number, withoutSuffix, key) {
     var result = number + ' ';

--- a/src/locale/hu.js
+++ b/src/locale/hu.js
@@ -2,7 +2,7 @@
 //! locale : Hungarian [hu]
 //! author : Adam Brunner : https://github.com/adambrunner
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var weekEndings = 'vasárnap hétfőn kedden szerdán csütörtökön pénteken szombaton'.split(
     ' '

--- a/src/locale/hy-am.js
+++ b/src/locale/hy-am.js
@@ -2,7 +2,7 @@
 //! locale : Armenian [hy-am]
 //! author : Armendarabyan : https://github.com/armendarabyan
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('hy-am', {
     months: {

--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -3,7 +3,7 @@
 //! author : Mohammad Satrio Utomo : https://github.com/tyok
 //! reference: http://id.wikisource.org/wiki/Pedoman_Umum_Ejaan_Bahasa_Indonesia_yang_Disempurnakan
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('id', {
     months: 'Januari_Februari_Maret_April_Mei_Juni_Juli_Agustus_September_Oktober_November_Desember'.split(

--- a/src/locale/is.js
+++ b/src/locale/is.js
@@ -2,7 +2,7 @@
 //! locale : Icelandic [is]
 //! author : Hinrik Örn Sigurðsson : https://github.com/hinrik
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function plural(n) {
     if (n % 100 === 11) {

--- a/src/locale/it-ch.js
+++ b/src/locale/it-ch.js
@@ -2,7 +2,7 @@
 //! locale : Italian (Switzerland) [it-ch]
 //! author : xfh : https://github.com/xfh
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('it-ch', {
     months: 'gennaio_febbraio_marzo_aprile_maggio_giugno_luglio_agosto_settembre_ottobre_novembre_dicembre'.split(

--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -4,7 +4,7 @@
 //! author: Mattia Larentis: https://github.com/nostalgiaz
 //! author: Marco : https://github.com/Manfre98
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('it', {
     months: 'gennaio_febbraio_marzo_aprile_maggio_giugno_luglio_agosto_settembre_ottobre_novembre_dicembre'.split(

--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -2,7 +2,7 @@
 //! locale : Japanese [ja]
 //! author : LI Long : https://github.com/baryon
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ja', {
     eras: [

--- a/src/locale/jv.js
+++ b/src/locale/jv.js
@@ -3,7 +3,7 @@
 //! author : Rony Lantip : https://github.com/lantip
 //! reference: http://jv.wikipedia.org/wiki/Basa_Jawa
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('jv', {
     months: 'Januari_Februari_Maret_April_Mei_Juni_Juli_Agustus_September_Oktober_Nopember_Desember'.split(

--- a/src/locale/ka.js
+++ b/src/locale/ka.js
@@ -2,7 +2,7 @@
 //! locale : Georgian [ka]
 //! author : Irakli Janiashvili : https://github.com/IrakliJani
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ka', {
     months: 'იანვარი_თებერვალი_მარტი_აპრილი_მაისი_ივნისი_ივლისი_აგვისტო_სექტემბერი_ოქტომბერი_ნოემბერი_დეკემბერი'.split(

--- a/src/locale/kk.js
+++ b/src/locale/kk.js
@@ -2,7 +2,7 @@
 //! locale : Kazakh [kk]
 //! authors : Nurlan Rakhimzhanov : https://github.com/nurlan
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var suffixes = {
     0: '-ші',

--- a/src/locale/km.js
+++ b/src/locale/km.js
@@ -2,7 +2,7 @@
 //! locale : Cambodian [km]
 //! author : Kruy Vanna : https://github.com/kruyvanna
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '១',

--- a/src/locale/kn.js
+++ b/src/locale/kn.js
@@ -2,7 +2,7 @@
 //! locale : Kannada [kn]
 //! author : Rajeev Naik : https://github.com/rajeevnaikte
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '೧',

--- a/src/locale/ko.js
+++ b/src/locale/ko.js
@@ -3,7 +3,7 @@
 //! author : Kyungwook, Park : https://github.com/kyungw00k
 //! author : Jeeeyul Lee <jeeeyul@gmail.com>
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ko', {
     months: '1월_2월_3월_4월_5월_6월_7월_8월_9월_10월_11월_12월'.split('_'),

--- a/src/locale/ku.js
+++ b/src/locale/ku.js
@@ -2,7 +2,7 @@
 //! locale : Kurdish [ku]
 //! author : Shahram Mebashar : https://github.com/ShahramMebashar
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '١',

--- a/src/locale/ky.js
+++ b/src/locale/ky.js
@@ -2,7 +2,7 @@
 //! locale : Kyrgyz [ky]
 //! author : Chyngyz Arystan uulu : https://github.com/chyngyz
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var suffixes = {
     0: '-чү',

--- a/src/locale/lb.js
+++ b/src/locale/lb.js
@@ -3,7 +3,7 @@
 //! author : mweimerskirch : https://github.com/mweimerskirch
 //! author : David Raison : https://github.com/kwisatz
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {

--- a/src/locale/lo.js
+++ b/src/locale/lo.js
@@ -2,7 +2,7 @@
 //! locale : Lao [lo]
 //! author : Ryan Hart : https://github.com/ryanhart2
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('lo', {
     months: 'ມັງກອນ_ກຸມພາ_ມີນາ_ເມສາ_ພຶດສະພາ_ມິຖຸນາ_ກໍລະກົດ_ສິງຫາ_ກັນຍາ_ຕຸລາ_ພະຈິກ_ທັນວາ'.split(

--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -2,7 +2,7 @@
 //! locale : Lithuanian [lt]
 //! author : Mindaugas Mozūras : https://github.com/mmozuras
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var units = {
     ss: 'sekundė_sekundžių_sekundes',

--- a/src/locale/lv.js
+++ b/src/locale/lv.js
@@ -3,7 +3,7 @@
 //! author : Kristaps Karlsons : https://github.com/skakri
 //! author : Jānis Elmeris : https://github.com/JanisE
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var units = {
     ss: 'sekundes_sekundēm_sekunde_sekundes'.split('_'),

--- a/src/locale/me.js
+++ b/src/locale/me.js
@@ -2,7 +2,7 @@
 //! locale : Montenegrin [me]
 //! author : Miodrag Nikač <miodrag@restartit.me> : https://github.com/miodragnikac
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var translator = {
     words: {

--- a/src/locale/mi.js
+++ b/src/locale/mi.js
@@ -2,7 +2,7 @@
 //! locale : Maori [mi]
 //! author : John Corrigan <robbiecloset@gmail.com> : https://github.com/johnideal
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('mi', {
     months: 'Kohi-tāte_Hui-tanguru_Poutū-te-rangi_Paenga-whāwhā_Haratua_Pipiri_Hōngoingoi_Here-turi-kōkā_Mahuru_Whiringa-ā-nuku_Whiringa-ā-rangi_Hakihea'.split(

--- a/src/locale/mk.js
+++ b/src/locale/mk.js
@@ -2,7 +2,7 @@
 //! locale : Macedonian [mk]
 //! author : Borislav Mickov : https://github.com/B0k0
 //! author : Sashko Todorov : https://github.com/bkyceh
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('mk', {
     months: 'јануари_февруари_март_април_мај_јуни_јули_август_септември_октомври_ноември_декември'.split(

--- a/src/locale/ml.js
+++ b/src/locale/ml.js
@@ -2,7 +2,7 @@
 //! locale : Malayalam [ml]
 //! author : Floyd Pink : https://github.com/floydpink
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ml', {
     months: 'ജനുവരി_ഫെബ്രുവരി_മാർച്ച്_ഏപ്രിൽ_മേയ്_ജൂൺ_ജൂലൈ_ഓഗസ്റ്റ്_സെപ്റ്റംബർ_ഒക്ടോബർ_നവംബർ_ഡിസംബർ'.split(

--- a/src/locale/mn.js
+++ b/src/locale/mn.js
@@ -2,7 +2,7 @@
 //! locale : Mongolian [mn]
 //! author : Javkhlantugs Nyamdorj : https://github.com/javkhaanj7
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function translate(number, withoutSuffix, key, isFuture) {
     switch (key) {

--- a/src/locale/mr.js
+++ b/src/locale/mr.js
@@ -3,7 +3,7 @@
 //! author : Harshad Kale : https://github.com/kalehv
 //! author : Vivek Athalye : https://github.com/vnathalye
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '१',

--- a/src/locale/ms-my.js
+++ b/src/locale/ms-my.js
@@ -3,7 +3,7 @@
 //! note : DEPRECATED, the correct one is [ms]
 //! author : Weldan Jamili : https://github.com/weldan
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ms-my', {
     months: 'Januari_Februari_Mac_April_Mei_Jun_Julai_Ogos_September_Oktober_November_Disember'.split(

--- a/src/locale/ms.js
+++ b/src/locale/ms.js
@@ -2,7 +2,7 @@
 //! locale : Malay [ms]
 //! author : Weldan Jamili : https://github.com/weldan
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ms', {
     months: 'Januari_Februari_Mac_April_Mei_Jun_Julai_Ogos_September_Oktober_November_Disember'.split(

--- a/src/locale/mt.js
+++ b/src/locale/mt.js
@@ -2,7 +2,7 @@
 //! locale : Maltese (Malta) [mt]
 //! author : Alessandro Maruccia : https://github.com/alesma
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('mt', {
     months: 'Jannar_Frar_Marzu_April_Mejju_Ġunju_Lulju_Awwissu_Settembru_Ottubru_Novembru_Diċembru'.split(

--- a/src/locale/my.js
+++ b/src/locale/my.js
@@ -4,7 +4,7 @@
 //! author : David Rossellat : https://github.com/gholadr
 //! author : Tin Aung Lin : https://github.com/thanyawzinmin
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '၁',

--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -4,7 +4,7 @@
 //!           Sigurd Gartmann : https://github.com/sigurdga
 //!           Stephen Ramthun : https://github.com/stephenramthun
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('nb', {
     months: 'januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember'.split(

--- a/src/locale/ne.js
+++ b/src/locale/ne.js
@@ -2,7 +2,7 @@
 //! locale : Nepalese [ne]
 //! author : suvash : https://github.com/suvash
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '१',

--- a/src/locale/nl-be.js
+++ b/src/locale/nl-be.js
@@ -3,7 +3,7 @@
 //! author : Joris Röling : https://github.com/jorisroling
 //! author : Jacob Middag : https://github.com/middagj
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsShortWithDots = 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split(
         '_'

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -3,7 +3,7 @@
 //! author : Joris Röling : https://github.com/jorisroling
 //! author : Jacob Middag : https://github.com/middagj
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsShortWithDots = 'jan._feb._mrt._apr._mei_jun._jul._aug._sep._okt._nov._dec.'.split(
         '_'

--- a/src/locale/nn.js
+++ b/src/locale/nn.js
@@ -3,7 +3,7 @@
 //! authors : https://github.com/mechuwind
 //!           Stephen Ramthun : https://github.com/stephenramthun
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('nn', {
     months: 'januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember'.split(

--- a/src/locale/oc-lnc.js
+++ b/src/locale/oc-lnc.js
@@ -2,7 +2,7 @@
 //! locale : Occitan, lengadocian dialecte [oc-lnc]
 //! author : Quentin PAGÈS : https://github.com/Quenty31
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('oc-lnc', {
     months: {

--- a/src/locale/pa-in.js
+++ b/src/locale/pa-in.js
@@ -2,7 +2,7 @@
 //! locale : Punjabi (India) [pa-in]
 //! author : Harpreet Singh : https://github.com/harpreetkhalsagtbit
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '੧',

--- a/src/locale/pl.js
+++ b/src/locale/pl.js
@@ -2,7 +2,7 @@
 //! locale : Polish [pl]
 //! author : Rafal Hirsz : https://github.com/evoL
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var monthsNominative = 'styczeń_luty_marzec_kwiecień_maj_czerwiec_lipiec_sierpień_wrzesień_październik_listopad_grudzień'.split(
         '_'

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -2,7 +2,7 @@
 //! locale : Portuguese (Brazil) [pt-br]
 //! author : Caio Ribeiro Pereira : https://github.com/caio-ribeiro-pereira
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('pt-br', {
     months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split(

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -2,7 +2,7 @@
 //! locale : Portuguese [pt]
 //! author : Jefferson : https://github.com/jalex79
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('pt', {
     months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split(

--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -4,7 +4,7 @@
 //! author : Valentin Agachi : https://github.com/avaly
 //! author : Emanuel Cepoi : https://github.com/cepem
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function relativeTimeWithPlural(number, withoutSuffix, key) {
     var format = {

--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -4,7 +4,7 @@
 //! author : Menelion Elensúle : https://github.com/Oire
 //! author : Коренберг Марк : https://github.com/socketpair
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function plural(word, num) {
     var forms = word.split('_');

--- a/src/locale/sd.js
+++ b/src/locale/sd.js
@@ -2,7 +2,7 @@
 //! locale : Sindhi [sd]
 //! author : Narain Sagar : https://github.com/narainsagar
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var months = [
         'جنوري',

--- a/src/locale/se.js
+++ b/src/locale/se.js
@@ -2,7 +2,7 @@
 //! locale : Northern Sami [se]
 //! authors : Bård Rolstad Henriksen : https://github.com/karamell
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('se', {
     months: 'ođđajagemánnu_guovvamánnu_njukčamánnu_cuoŋománnu_miessemánnu_geassemánnu_suoidnemánnu_borgemánnu_čakčamánnu_golggotmánnu_skábmamánnu_juovlamánnu'.split(

--- a/src/locale/si.js
+++ b/src/locale/si.js
@@ -2,7 +2,7 @@
 //! locale : Sinhalese [si]
 //! author : Sampath Sitinamaluwa : https://github.com/sampathsris
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 /*jshint -W100*/
 export default moment.defineLocale('si', {

--- a/src/locale/sk.js
+++ b/src/locale/sk.js
@@ -3,7 +3,7 @@
 //! author : Martin Minka : https://github.com/k2s
 //! based on work of petrbela : https://github.com/petrbela
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var months = 'január_február_marec_apríl_máj_jún_júl_august_september_október_november_december'.split(
         '_'

--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -2,7 +2,7 @@
 //! locale : Slovenian [sl]
 //! author : Robert Sedovšek : https://github.com/sedovsek
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var result = number + ' ';

--- a/src/locale/sq.js
+++ b/src/locale/sq.js
@@ -4,7 +4,7 @@
 //! author : Menelion Elensúle : https://github.com/Oire
 //! author : Oerd Cukalla : https://github.com/oerd
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('sq', {
     months: 'Janar_Shkurt_Mars_Prill_Maj_Qershor_Korrik_Gusht_Shtator_Tetor_Nëntor_Dhjetor'.split(

--- a/src/locale/sr-cyrl.js
+++ b/src/locale/sr-cyrl.js
@@ -2,7 +2,7 @@
 //! locale : Serbian Cyrillic [sr-cyrl]
 //! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var translator = {
     words: {

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -2,7 +2,7 @@
 //! locale : Serbian [sr]
 //! author : Milan Janačković<milanjanackovic@gmail.com> : https://github.com/milan-j
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var translator = {
     words: {

--- a/src/locale/ss.js
+++ b/src/locale/ss.js
@@ -2,7 +2,7 @@
 //! locale : siSwati [ss]
 //! author : Nicolai Davies<mail@nicolai.io> : https://github.com/nicolaidavies
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ss', {
     months: "Bhimbidvwane_Indlovana_Indlov'lenkhulu_Mabasa_Inkhwekhweti_Inhlaba_Kholwane_Ingci_Inyoni_Imphala_Lweti_Ingongoni".split(

--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -2,7 +2,7 @@
 //! locale : Swedish [sv]
 //! author : Jens Alm : https://github.com/ulmus
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('sv', {
     months: 'januari_februari_mars_april_maj_juni_juli_augusti_september_oktober_november_december'.split(

--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -2,7 +2,7 @@
 //! locale : Swahili [sw]
 //! author : Fahad Kassim : https://github.com/fadsel
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('sw', {
     months: 'Januari_Februari_Machi_Aprili_Mei_Juni_Julai_Agosti_Septemba_Oktoba_Novemba_Desemba'.split(

--- a/src/locale/ta.js
+++ b/src/locale/ta.js
@@ -2,7 +2,7 @@
 //! locale : Tamil [ta]
 //! author : Arjunkumar Krishnamoorthy : https://github.com/tk120404
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var symbolMap = {
         '1': '௧',

--- a/src/locale/te.js
+++ b/src/locale/te.js
@@ -2,7 +2,7 @@
 //! locale : Telugu [te]
 //! author : Krishna Chaitanya Thota : https://github.com/kcthota
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('te', {
     months: 'జనవరి_ఫిబ్రవరి_మార్చి_ఏప్రిల్_మే_జూన్_జులై_ఆగస్టు_సెప్టెంబర్_అక్టోబర్_నవంబర్_డిసెంబర్'.split(

--- a/src/locale/tet.js
+++ b/src/locale/tet.js
@@ -4,7 +4,7 @@
 //! author : Onorio De J. Afonso : https://github.com/marobo
 //! author : Sonia Simoes : https://github.com/soniasimoes
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('tet', {
     months: 'Janeiru_Fevereiru_Marsu_Abril_Maiu_Juñu_Jullu_Agustu_Setembru_Outubru_Novembru_Dezembru'.split(

--- a/src/locale/tg.js
+++ b/src/locale/tg.js
@@ -2,7 +2,7 @@
 //! locale : Tajik [tg]
 //! author : Orif N. Jr. : https://github.com/orif-jr
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var suffixes = {
     0: '-ум',

--- a/src/locale/th.js
+++ b/src/locale/th.js
@@ -2,7 +2,7 @@
 //! locale : Thai [th]
 //! author : Kridsada Thanabulpong : https://github.com/sirn
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('th', {
     months: 'มกราคม_กุมภาพันธ์_มีนาคม_เมษายน_พฤษภาคม_มิถุนายน_กรกฎาคม_สิงหาคม_กันยายน_ตุลาคม_พฤศจิกายน_ธันวาคม'.split(

--- a/src/locale/tk.js
+++ b/src/locale/tk.js
@@ -2,7 +2,7 @@
 //! locale : Turkmen [tk]
 //! author : Atamyrat Abdyrahmanov : https://github.com/atamyratabdy
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var suffixes = {
     1: "'inji",

--- a/src/locale/tl-ph.js
+++ b/src/locale/tl-ph.js
@@ -2,7 +2,7 @@
 //! locale : Tagalog (Philippines) [tl-ph]
 //! author : Dan Hagman : https://github.com/hagmandan
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('tl-ph', {
     months: 'Enero_Pebrero_Marso_Abril_Mayo_Hunyo_Hulyo_Agosto_Setyembre_Oktubre_Nobyembre_Disyembre'.split(

--- a/src/locale/tlh.js
+++ b/src/locale/tlh.js
@@ -2,7 +2,7 @@
 //! locale : Klingon [tlh]
 //! author : Dominika Kruk : https://github.com/amaranthrose
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var numbersNouns = 'pagh_wa’_cha’_wej_loS_vagh_jav_Soch_chorgh_Hut'.split('_');
 

--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -3,7 +3,7 @@
 //! authors : Erhan Gundogan : https://github.com/erhangundogan,
 //!           Burak Yiğit Kaya: https://github.com/BYK
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var suffixes = {
     1: "'inci",

--- a/src/locale/tzl.js
+++ b/src/locale/tzl.js
@@ -3,7 +3,7 @@
 //! author : Robin van der Vliet : https://github.com/robin0van0der0v
 //! author : Iustì Canun
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 // After the year there should be a slash and the amount of years since December 26, 1979 in Roman numerals.
 // This is currently too difficult (maybe even impossible) to add.

--- a/src/locale/tzm-latn.js
+++ b/src/locale/tzm-latn.js
@@ -2,7 +2,7 @@
 //! locale : Central Atlas Tamazight Latin [tzm-latn]
 //! author : Abdel Said : https://github.com/abdelsaid
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('tzm-latn', {
     months: 'innayr_brˤayrˤ_marˤsˤ_ibrir_mayyw_ywnyw_ywlywz_ɣwšt_šwtanbir_ktˤwbrˤ_nwwanbir_dwjnbir'.split(

--- a/src/locale/tzm.js
+++ b/src/locale/tzm.js
@@ -2,7 +2,7 @@
 //! locale : Central Atlas Tamazight [tzm]
 //! author : Abdel Said : https://github.com/abdelsaid
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('tzm', {
     months: 'ⵉⵏⵏⴰⵢⵔ_ⴱⵕⴰⵢⵕ_ⵎⴰⵕⵚ_ⵉⴱⵔⵉⵔ_ⵎⴰⵢⵢⵓ_ⵢⵓⵏⵢⵓ_ⵢⵓⵍⵢⵓⵣ_ⵖⵓⵛⵜ_ⵛⵓⵜⴰⵏⴱⵉⵔ_ⴽⵟⵓⴱⵕ_ⵏⵓⵡⴰⵏⴱⵉⵔ_ⴷⵓⵊⵏⴱⵉⵔ'.split(

--- a/src/locale/ug-cn.js
+++ b/src/locale/ug-cn.js
@@ -2,7 +2,7 @@
 //! locale : Uyghur (China) [ug-cn]
 //! author: boyaq : https://github.com/boyaq
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('ug-cn', {
     months: 'يانۋار_فېۋرال_مارت_ئاپرېل_ماي_ئىيۇن_ئىيۇل_ئاۋغۇست_سېنتەبىر_ئۆكتەبىر_نويابىر_دېكابىر'.split(

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -3,7 +3,7 @@
 //! author : zemlanin : https://github.com/zemlanin
 //! Author : Menelion Elensúle : https://github.com/Oire
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 function plural(word, num) {
     var forms = word.split('_');

--- a/src/locale/ur.js
+++ b/src/locale/ur.js
@@ -3,7 +3,7 @@
 //! author : Sawood Alam : https://github.com/ibnesayeed
 //! author : Zack : https://github.com/ZackVision
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 var months = [
         'جنوری',

--- a/src/locale/uz-latn.js
+++ b/src/locale/uz-latn.js
@@ -2,7 +2,7 @@
 //! locale : Uzbek Latin [uz-latn]
 //! author : Rasulbek Mirzayev : github.com/Rasulbeeek
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('uz-latn', {
     months: 'Yanvar_Fevral_Mart_Aprel_May_Iyun_Iyul_Avgust_Sentabr_Oktabr_Noyabr_Dekabr'.split(

--- a/src/locale/uz.js
+++ b/src/locale/uz.js
@@ -2,7 +2,7 @@
 //! locale : Uzbek [uz]
 //! author : Sardor Muminov : https://github.com/muminoff
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('uz', {
     months: 'январ_феврал_март_апрел_май_июн_июл_август_сентябр_октябр_ноябр_декабр'.split(

--- a/src/locale/vi.js
+++ b/src/locale/vi.js
@@ -3,7 +3,7 @@
 //! author : Bang Nguyen : https://github.com/bangnk
 //! author : Chien Kira : https://github.com/chienkira
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('vi', {
     months: 'tháng 1_tháng 2_tháng 3_tháng 4_tháng 5_tháng 6_tháng 7_tháng 8_tháng 9_tháng 10_tháng 11_tháng 12'.split(

--- a/src/locale/x-pseudo.js
+++ b/src/locale/x-pseudo.js
@@ -2,7 +2,7 @@
 //! locale : Pseudo [x-pseudo]
 //! author : Andrew Hood : https://github.com/andrewhood125
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('x-pseudo', {
     months: 'J~áñúá~rý_F~ébrú~árý_~Márc~h_Áp~ríl_~Máý_~Júñé~_Júl~ý_Áú~gúst~_Sép~témb~ér_Ó~ctób~ér_Ñ~óvém~bér_~Décé~mbér'.split(

--- a/src/locale/yo.js
+++ b/src/locale/yo.js
@@ -2,7 +2,7 @@
 //! locale : Yoruba Nigeria [yo]
 //! author : Atolagbe Abisoye : https://github.com/andela-batolagbe
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('yo', {
     months: 'Sẹ́rẹ́_Èrèlè_Ẹrẹ̀nà_Ìgbé_Èbibi_Òkùdu_Agẹmo_Ògún_Owewe_Ọ̀wàrà_Bélú_Ọ̀pẹ̀̀'.split(

--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -4,7 +4,7 @@
 //! author : Zeno Zeng : https://github.com/zenozeng
 //! author : uu109 : https://github.com/uu109
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('zh-cn', {
     months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split(

--- a/src/locale/zh-hk.js
+++ b/src/locale/zh-hk.js
@@ -5,7 +5,7 @@
 //! author : Konstantin : https://github.com/skfd
 //! author : Anthony : https://github.com/anthonylau
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('zh-hk', {
     months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split(

--- a/src/locale/zh-mo.js
+++ b/src/locale/zh-mo.js
@@ -4,7 +4,7 @@
 //! author : Chris Lam : https://github.com/hehachris
 //! author : Tan Yuanhong : https://github.com/le0tan
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('zh-mo', {
     months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split(

--- a/src/locale/zh-tw.js
+++ b/src/locale/zh-tw.js
@@ -3,7 +3,7 @@
 //! author : Ben : https://github.com/ben-lin
 //! author : Chris Lam : https://github.com/hehachris
 
-import moment from '../moment';
+import moment from '../moment.js';
 
 export default moment.defineLocale('zh-tw', {
     months: '一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月'.split(

--- a/src/moment.js
+++ b/src/moment.js
@@ -4,7 +4,7 @@
 //! license : MIT
 //! momentjs.com
 
-import { hooks as moment, setHookCallback } from './lib/utils/hooks';
+import { hooks as moment, setHookCallback } from './lib/utils/hooks.js';
 
 moment.version = '2.27.0';
 
@@ -19,9 +19,9 @@ import {
     createLocal as local,
     createInvalid as invalid,
     createInZone as parseZone,
-} from './lib/moment/moment';
+} from './lib/moment/moment.js';
 
-import { getCalendarFormat } from './lib/moment/calendar';
+import { getCalendarFormat } from './lib/moment/calendar.js';
 
 import {
     defineLocale,
@@ -34,18 +34,18 @@ import {
     listWeekdays as weekdays,
     listWeekdaysMin as weekdaysMin,
     listWeekdaysShort as weekdaysShort,
-} from './lib/locale/locale';
+} from './lib/locale/locale.js';
 
 import {
     isDuration,
     createDuration as duration,
     getSetRelativeTimeRounding as relativeTimeRounding,
     getSetRelativeTimeThreshold as relativeTimeThreshold,
-} from './lib/duration/duration';
+} from './lib/duration/duration.js';
 
-import { normalizeUnits } from './lib/units/units';
+import { normalizeUnits } from './lib/units/units.js';
 
-import isDate from './lib/utils/is-date';
+import isDate from './lib/utils/is-date.js';
 
 setHookCallback(local);
 


### PR DESCRIPTION
Adding the js extension to import statements would allow others to use es6 modules directly from /src in their projects (including files in /src/lib and /src/locale).

`import moment from './js/libraries/moment/moment.js`

And use the library

`console.log(`today is ${moment()}`)`

_Note that I have a commit to remove the js extension from the 'valid' import in /src/lib/duration/constructor.js because it was the only import to use an extension and I wanted my regular expression to get everything in a single go. _
