### PR TITLE
[misc] Update dep message to reflect project status

### DIFF
--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -247,8 +247,7 @@ export function configFromString(config) {
 hooks.createFromInputFallback = deprecate(
     'value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), ' +
         'which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are ' +
-        'discouraged and will be removed in an upcoming major release. Please refer to ' +
-        'http://momentjs.com/guides/#/warnings/js-date/ for more info.',
+        'discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.',
     function (config) {
         config._d = new Date(config._i + (config._useUTC ? ' UTC' : ''));
     }


### PR DESCRIPTION
If moment is now in maintenance mode, there won't be a major release that removes support for Non RFC2822/ISO date formats.

Given that I've updated the deprecation message to be more accurate. (It may be worth considering not even having the message, given now this behavior will technically be supported by moment forever?)