### PR TITLE
[misc] Specify length of toArray return type

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -585,7 +585,7 @@ declare namespace moment {
 
     diff(b: MomentInput, unitOfTime?: unitOfTime.Diff, precise?: boolean): number;
 
-    toArray(): number[];
+    toArray(): [number, number, number, number, number, number, number];
     toDate(): Date;
     toISOString(keepOffset?: boolean): string;
     inspect(): string;

--- a/moment.d.ts
+++ b/moment.d.ts
@@ -585,7 +585,7 @@ declare namespace moment {
 
     diff(b: MomentInput, unitOfTime?: unitOfTime.Diff, precise?: boolean): number;
 
-    toArray(): [number, number, number, number, number, number, number];
+    toArray(): number[];
     toDate(): Date;
     toISOString(keepOffset?: boolean): string;
     inspect(): string;

--- a/ts3.1-typing-tests/moment-tests.ts
+++ b/ts3.1-typing-tests/moment-tests.ts
@@ -161,6 +161,8 @@ var getMonth: number = moment().month();
 var getQuater: number = moment().quarter();
 var getYear: number = moment().year();
 
+var date: [number, number, number, number, number, number, number] = moment().toArray();
+
 moment().hours(0).minutes(0).seconds(0).milliseconds(0);
 
 var a3 = moment([2011, 0, 1, 8]);

--- a/ts3.1-typings/moment.d.ts
+++ b/ts3.1-typings/moment.d.ts
@@ -573,7 +573,7 @@ declare namespace moment {
 
     diff(b: MomentInput, unitOfTime?: unitOfTime.Diff, precise?: boolean): number;
 
-    toArray(): number[];
+    toArray(): [number, number, number, number, number, number, number];
     toDate(): Date;
     toISOString(keepOffset?: boolean): string;
     inspect(): string;


### PR DESCRIPTION
toArray will always return an array with seven numbers. This change is necessary to be able to do `new Date(...m.toArray())`. As just `number[]`, it complains with `Expected 0-7 arguments, but got 0 or more.`.