### PR TITLE
[locale] Fix minor variables in Bulgarian locale (bg)

### DIFF
--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -52,7 +52,7 @@ export default moment.defineLocale('bg', {
         h: 'час',
         hh: '%d часа',
         d: 'ден',
-        dd: '%d дена',
+        dd: '%d дни',
         w: 'седмица',
         ww: '%d седмици',
         M: 'месец',


### PR DESCRIPTION
The plural of ден must be дни according to Bulgarian language rules.