### PR TITLE
Fix sk locale (relative future time)

### DIFF
--- a/locale/sk.js
+++ b/locale/sk.js
@@ -127,7 +127,7 @@
             sameElse: 'L',
         },
         relativeTime: {
-            future: 'za %s',
+            future: 'o %s',
             past: 'pred %s',
             s: translate,
             ss: translate,

--- a/src/locale/sk.js
+++ b/src/locale/sk.js
@@ -120,7 +120,7 @@ export default moment.defineLocale('sk', {
         sameElse: 'L',
     },
     relativeTime: {
-        future: 'za %s',
+        future: 'o %s',
         past: 'pred %s',
         s: translate,
         ss: translate,

--- a/src/test/locale/sk.js
+++ b/src/test/locale/sk.js
@@ -293,7 +293,7 @@ test('from', function (assert) {
 });
 
 test('suffix', function (assert) {
-    assert.equal(moment(30000).from(0), 'za pár sekúnd', 'prefix');
+    assert.equal(moment(30000).from(0), 'o pár sekúnd', 'prefix');
     assert.equal(moment(0).from(30000), 'pred pár sekundami', 'suffix');
 });
 
@@ -308,46 +308,46 @@ test('now from now', function (assert) {
 test('fromNow (future)', function (assert) {
     assert.equal(
         moment().add({ s: 30 }).fromNow(),
-        'za pár sekúnd',
+        'o pár sekúnd',
         'in a few seconds'
     );
-    assert.equal(moment().add({ m: 1 }).fromNow(), 'za minútu', 'in a minute');
+    assert.equal(moment().add({ m: 1 }).fromNow(), 'o minútu', 'in a minute');
     assert.equal(
         moment().add({ m: 3 }).fromNow(),
-        'za 3 minúty',
+        'o 3 minúty',
         'in 3 minutes'
     );
     assert.equal(
         moment().add({ m: 10 }).fromNow(),
-        'za 10 minút',
+        'o 10 minút',
         'in 10 minutes'
     );
-    assert.equal(moment().add({ h: 1 }).fromNow(), 'za hodinu', 'in an hour');
-    assert.equal(moment().add({ h: 3 }).fromNow(), 'za 3 hodiny', 'in 3 hours');
+    assert.equal(moment().add({ h: 1 }).fromNow(), 'o hodinu', 'in an hour');
+    assert.equal(moment().add({ h: 3 }).fromNow(), 'o 3 hodiny', 'in 3 hours');
     assert.equal(
         moment().add({ h: 10 }).fromNow(),
-        'za 10 hodín',
+        'o 10 hodín',
         'in 10 hours'
     );
-    assert.equal(moment().add({ d: 1 }).fromNow(), 'za deň', 'in a day');
-    assert.equal(moment().add({ d: 3 }).fromNow(), 'za 3 dni', 'in 3 days');
-    assert.equal(moment().add({ d: 10 }).fromNow(), 'za 10 dní', 'in 10 days');
-    assert.equal(moment().add({ M: 1 }).fromNow(), 'za mesiac', 'in a month');
+    assert.equal(moment().add({ d: 1 }).fromNow(), 'o deň', 'in a day');
+    assert.equal(moment().add({ d: 3 }).fromNow(), 'o 3 dni', 'in 3 days');
+    assert.equal(moment().add({ d: 10 }).fromNow(), 'o 10 dní', 'in 10 days');
+    assert.equal(moment().add({ M: 1 }).fromNow(), 'o mesiac', 'in a month');
     assert.equal(
         moment().add({ M: 3 }).fromNow(),
-        'za 3 mesiace',
+        'o 3 mesiace',
         'in 3 months'
     );
     assert.equal(
         moment().add({ M: 10 }).fromNow(),
-        'za 10 mesiacov',
+        'o 10 mesiacov',
         'in 10 months'
     );
-    assert.equal(moment().add({ y: 1 }).fromNow(), 'za rok', 'in a year');
-    assert.equal(moment().add({ y: 3 }).fromNow(), 'za 3 roky', 'in 3 years');
+    assert.equal(moment().add({ y: 1 }).fromNow(), 'o rok', 'in a year');
+    assert.equal(moment().add({ y: 3 }).fromNow(), 'o 3 roky', 'in 3 years');
     assert.equal(
         moment().add({ y: 10 }).fromNow(),
-        'za 10 rokov',
+        'o 10 rokov',
         'in 10 years'
     );
 });
@@ -596,7 +596,7 @@ test('humanize duration', function (assert) {
     );
     assert.equal(
         moment.duration(1, 'minutes').humanize(true),
-        'za minútu',
+        'o minútu',
         'in a minute'
     );
     assert.equal(


### PR DESCRIPTION
A proposition "za" is grammatically incorrect in the most of cases when talking about a future event.

Slovak language has two propositions for such cases: "za" and "o" but they have slightly different meanings.
"za 5 minút" - an event which is already happening is coming to its end in 5 minutes, e.g. "It is done in 5 minutes."
"o 5 minút" => an event is going to happen in 5 minutes, e.g. "It is going to be released in 5 minutes."