### PR TITLE
[bugfix] Issue #5267 - moment("2019-08-30 23:59:59").from(moment("2019-10-25 12:00:00")) is '54.50001157407407 days ago' (should be 55.500... days ago)

### DIFF
--- a/src/lib/duration/as.js
+++ b/src/lib/duration/as.js
@@ -23,6 +23,25 @@ export function as(units) {
             case 'year':
                 return months / 12;
         }
+    } else if (this._totalMilliseconds !== undefined) {
+        // if _totalMilliseconds is provided return a more precise value (issue #5267)
+        days = this._totalMilliseconds / 864e5;
+        switch (units) {
+            case 'week':
+                return days / 7;
+            case 'day':
+                return days;
+            case 'hour':
+                return days * 24;
+            case 'minute':
+                return days * 1440;
+            case 'second':
+                return days * 86400;
+            case 'millisecond':
+                return this._totalMilliseconds;
+            default:
+                throw new Error('Unknown unit ' + units);
+        }
     } else {
         // handle milliseconds separately because of floating point math errors (issue #1867)
         days = this._days + Math.round(monthsToDays(this._months));

--- a/src/lib/duration/constructor.js
+++ b/src/lib/duration/constructor.js
@@ -12,7 +12,8 @@ export function Duration(duration) {
         hours = normalizedInput.hour || 0,
         minutes = normalizedInput.minute || 0,
         seconds = normalizedInput.second || 0,
-        milliseconds = normalizedInput.millisecond || 0;
+        milliseconds = normalizedInput.millisecond || 0,
+        totalMilliseconds = normalizedInput.totalMilliseconds || undefined;
 
     this._isValid = isDurationValid(normalizedInput);
 
@@ -29,6 +30,8 @@ export function Duration(duration) {
     // which months you are are talking about, so we have to store
     // it separately.
     this._months = +months + quarters * 3 + years * 12;
+
+    this._totalMilliseconds = +totalMilliseconds || undefined;
 
     this._data = {};
 

--- a/src/lib/duration/create.js
+++ b/src/lib/duration/create.js
@@ -72,6 +72,7 @@ export function createDuration(input, key) {
         duration = {};
         duration.ms = diffRes.milliseconds;
         duration.M = diffRes.months;
+        duration.total_ms = diffRes.totalMilliseconds;
     }
 
     ret = new Duration(duration);
@@ -109,6 +110,7 @@ function positiveMomentsDifference(base, other) {
     }
 
     res.milliseconds = +other - +base.clone().add(res.months, 'M');
+    res.totalMilliseconds = +other - +base;
 
     return res;
 }
@@ -126,6 +128,7 @@ function momentsDifference(base, other) {
         res = positiveMomentsDifference(other, base);
         res.milliseconds = -res.milliseconds;
         res.months = -res.months;
+        res.totalMilliseconds = -res.totalMilliseconds;
     }
 
     return res;

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -46,7 +46,7 @@ function relativeTime(posNegDuration, withoutSuffix, thresholds, locale) {
         (months < thresholds.M && ['MM', months]) ||
         (years <= 1 && ['y']) || ['yy', years];
 
-    // if possible a more precise duration should be calculated using _totalMilliseconds if possible
+    // should utilize _totalMilliseconds for more precise calculation for units other than months and years
     if (
         a[0] !== 'M' &&
         a[0] !== 'MM' &&

--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -46,6 +46,31 @@ function relativeTime(posNegDuration, withoutSuffix, thresholds, locale) {
         (months < thresholds.M && ['MM', months]) ||
         (years <= 1 && ['y']) || ['yy', years];
 
+    // if possible a more precise duration should be calculated using _totalMilliseconds if possible
+    if (
+        a[0] !== 'M' &&
+        a[0] !== 'MM' &&
+        a[0] !== 'y' &&
+        a[0] !== 'yy' &&
+        months > 1 &&
+        posNegDuration._totalMilliseconds !== undefined
+    ) {
+        duration = createDuration(posNegDuration._totalMilliseconds).abs();
+        seconds = round(duration.as('s'));
+        minutes = round(duration.as('m'));
+        hours = round(duration.as('h'));
+        days = round(duration.as('d'));
+        a =
+            (seconds <= thresholds.ss && ['s', seconds]) ||
+            (seconds < thresholds.s && ['ss', seconds]) ||
+            (minutes <= 1 && ['m']) ||
+            (minutes < thresholds.m && ['mm', minutes]) ||
+            (hours <= 1 && ['h']) ||
+            (hours < thresholds.h && ['hh', hours]) ||
+            (days <= 1 && ['d']) ||
+            (days < thresholds.d && ['dd', days]);
+    }
+
     a[2] = withoutSuffix;
     a[3] = +posNegDuration > 0;
     a[4] = locale;

--- a/src/lib/duration/valid.js
+++ b/src/lib/duration/valid.js
@@ -13,6 +13,7 @@ var ordering = [
     'minute',
     'second',
     'millisecond',
+    'totalMilliseconds',
 ];
 
 export default function isDurationValid(m) {

--- a/src/lib/units/millisecond.js
+++ b/src/lib/units/millisecond.js
@@ -47,6 +47,7 @@ addFormatToken(0, ['SSSSSSSSS', 9], 0, function () {
 // ALIASES
 
 addUnitAlias('millisecond', 'ms');
+addUnitAlias('totalMilliseconds', 'total_ms');
 
 // PRIORITY
 

--- a/src/test/moment/duration_from_moments.js
+++ b/src/test/moment/duration_from_moments.js
@@ -36,6 +36,20 @@ test('day diff, separate months', function (assert) {
     assert.equal(d.as('days'), 29);
 });
 
+test('day diff, seperated by >= 2 months', function (assert) {
+    var m1 = moment('2020-12-13T00:00:00.000Z'),
+        m2 = moment('2020-10-19T00:00:00.000Z'),
+        d = moment.duration({ to: m1, from: m2 });
+
+    assert.equal(d.as('days'), 55);
+
+    m1 = moment('2019-08-30T23:59:59.999Z');
+    m2 = moment('2019-10-25T12:00:00.000Z');
+    d = moment.duration({ from: m1, to: m2 });
+
+    assert.equal(d.as('days'), 55.50000001157407)
+});
+
 test('hour diff', function (assert) {
     var m1 = moment('2012-01-15T17:00:00.000Z'),
         m2 = moment('2012-01-16T03:00:00.000Z'),

--- a/src/test/moment/relative_time.js
+++ b/src/test/moment/relative_time.js
@@ -156,7 +156,9 @@ test('default thresholds toNow', function (assert) {
 });
 
 test('custom thresholds', function (assert) {
-    var a, dd;
+    var a,
+        dd,
+        roundingDefault = moment.relativeTimeRounding();
 
     // including weeks
     moment.relativeTimeThreshold('w', 4);
@@ -324,6 +326,30 @@ test('custom thresholds', function (assert) {
         'a few seconds ago',
         'After setting s relative time threshold'
     );
+
+    moment.relativeTimeThreshold('d', 365);
+    a = moment('2020-12-13 12:00:00');
+    assert.equal(
+        a.from(a.clone().subtract(55, 'days'), true),
+        '55 days',
+        '55 days = 55 days'
+    );
+
+    moment.relativeTimeRounding((x) => x.toFixed(1));
+    assert.equal(
+        moment('2019-08-30 23:59:59').from(moment('2019-10-25 12:00:00'), true),
+        '55.5 days',
+        '55.5 days = 55.5 days'
+    );
+    moment.relativeTimeRounding(roundingDefault);
+
+    assert.equal(
+        moment('2019-02-19 17:25:05').from(moment('2019-05-16 17:25:05'), true),
+        '86 days',
+        '86 days = 86 days'
+    );
+
+    moment.relativeTimeThreshold('d', 26);
     moment.relativeTimeThreshold('ss', 44);
     moment.relativeTimeThreshold('s', 45);
 });


### PR DESCRIPTION
**Description**
When using a relativeTimeThreshold for 'd' greater than 31 days, and calculating the duration between 2 dates, occasionally moment would return a value of days that was off by 0.5 or greater (I have a test case demonstrating it could be up to 2 days off when Febuary was involved). 

This was due to the way duration was calculated in `positiveMomentsDifference`. It would first calculate the months, then the remaining milliseconds between 2 dates. The problem was when humanizing the duration, months would be converted back into days using the average days in a month (~30.4). 

When the `to` and `from` dates fell in months that were >= 2 apart, like October 19 and December 13 then October 19 - November 19 was calculated as 1 month and November 19 - December 13 was calculated precisely in milliseconds. When humanizing the duration, the 1 month was converted into days, it became 30.4 days + 24 days (the milliseconds between the Nov 19 and Dec 13) giving us a value of 54.4 days rounded down to 54 days. But 1 month between October 19 and November 19 is actually 31 days so our day value should be 55.

The patch is written in a way that preserves how durations were calculated before with default time thresholds. The added method of duration calculation only happens when the relative time threshold is raised and a potential incorrect day, hour, or second value could be returned.

**Related Issue**
[#5267](https://github.com/moment/moment/issues/5267)

**Changes**
- Calculate and return total millisecond difference between 2 dates in `positiveMomentsDifference` and return it with previously calculated values (months + milliseconds).
- Store `_totalMilliseconds` in `Duration` object
- Use `_totalMilliseconds` when calling `humanize(...)` or `as(...)` when returning days, hours, or seconds for more precise responses 
- Added tests to verify issues from [#5267](https://github.com/moment/moment/issues/5267) are fixed as well as some other cases