### PR TITLE
[locale] ar-ly: fix locale name

### DIFF
--- a/src/locale/ar-ly.js
+++ b/src/locale/ar-ly.js
@@ -1,5 +1,5 @@
 //! moment.js locale configuration
-//! locale : Arabic (Lybia) [ar-ly]
+//! locale : Arabic (Libya) [ar-ly]
 //! author : Ali Hmer: https://github.com/kikoanis
 
 import moment from '../moment';


### PR DESCRIPTION
The country's English name is [_Libya_](https://en.wikipedia.org/wiki/Libya), not _Lybia_.