### PR TITLE
[locale] ro: Improve past tense

### DIFF
--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -52,7 +52,7 @@ export default moment.defineLocale('ro', {
     },
     relativeTime: {
         future: 'peste %s',
-        past: '%s în urmă',
+        past: 'în urmă cu %s',
         s: 'câteva secunde',
         ss: relativeTimeWithPlural,
         m: 'un minut',

--- a/src/test/locale/ro.js
+++ b/src/test/locale/ro.js
@@ -331,13 +331,13 @@ test('from', function (assert) {
 
 test('suffix', function (assert) {
     assert.equal(moment(30000).from(0), 'peste câteva secunde', 'prefix');
-    assert.equal(moment(0).from(30000), 'câteva secunde în urmă', 'suffix');
+    assert.equal(moment(0).from(30000), 'în urmă cu câteva secunde', 'suffix');
 });
 
 test('now from now', function (assert) {
     assert.equal(
         moment().fromNow(),
-        'câteva secunde în urmă',
+        'în urmă cu câteva secunde',
         'now from now should display as in the past'
     );
 });


### PR DESCRIPTION
add better wording for past relative time