### PR TITLE
[locale] Rename ku to ckb

### DIFF
--- a/locale/ckb.js
+++ b/locale/ckb.js
@@ -1,5 +1,5 @@
 //! moment.js locale configuration
-//! locale : Kurdish [ku]
+//! locale : Sorani Kurdish [ckb]
 //! author : Shahram Mebashar : https://github.com/ShahramMebashar
 
 ;(function (global, factory) {


### PR DESCRIPTION
Renaming the current file from ku.js to ckb.js allow us publish ku.js cause that one isn't for general kurdish language it's for sorani speakers, not for kurmanji speakers neither for other dialects