### PR TITLE
[bugfix] undefined-locale-name

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -63,8 +63,9 @@ function chooseLocale(names) {
 }
 
 function isLocaleNameSane(name) {
+    // Validate that locale name is defined
     // Prevent names that look like filesystem paths, i.e contain '/' or '\'
-    return name.match('^[^/\\\\]*$') != null;
+    return name && name.match('^[^/\\\\]*$') != null;
 }
 
 function loadLocale(name) {


### PR DESCRIPTION
There is an edge case  in isLocaleNameSane function.
this happens if you pass an undefined value as locale name to a function which uses loadLocale
the function throws an error
"cannot read property match of undefined".
Added a validation of the locale name for this case.