### PR TITLE
[bugfix] Remove const usage (fixes #5989, #5996)

### DIFF
--- a/src/locale/sr-cyrl.js
+++ b/src/locale/sr-cyrl.js
@@ -39,7 +39,7 @@ var translator = {
             return isFuture || withoutSuffix ? wordKey[0] : wordKey[1];
         }
 
-        const word = translator.correctGrammaticalCase(number, wordKey);
+        var word = translator.correctGrammaticalCase(number, wordKey);
         // Nominativ
         if (key === 'yy' && withoutSuffix && word === 'годину') {
             return number + ' година';

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -39,7 +39,7 @@ var translator = {
             return isFuture || withoutSuffix ? wordKey[0] : wordKey[1];
         }
 
-        const word = translator.correctGrammaticalCase(number, wordKey);
+        var word = translator.correctGrammaticalCase(number, wordKey);
         // Nominativ
         if (key === 'yy' && withoutSuffix && word === 'godinu') {
             return number + ' godina';

--- a/src/test/locale/es-mx.js
+++ b/src/test/locale/es-mx.js
@@ -463,7 +463,7 @@ test('weeks year starting sunday formatted', function (assert) {
 
 // Concrete test for Locale#weekdaysMin
 test('Weekdays sort by locale', function (assert) {
-    const weekdays = 'domingo_lunes_martes_miércoles_jueves_viernes_sábado',
+    var weekdays = 'domingo_lunes_martes_miércoles_jueves_viernes_sábado',
         weekdaysShort = 'dom._lun._mar._mié._jue._vie._sáb.',
         weekdaysMin = 'do_lu_ma_mi_ju_vi_sá';
 


### PR DESCRIPTION
PR #5742 added `const` usage that is creating dist files containing ES6 syntax, possibly breaking some environments.

First "bugged" version is 2.29.2. Last working version is 2.29.1.