### PR TITLE
[bugfix] fix redos in preprocessRFC2822 regex

### DIFF
--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -151,7 +151,7 @@ function untruncateYear(yearStr) {
 function preprocessRFC2822(s) {
     // Remove comments and folding whitespace and replace multiple-spaces with a single space
     return s
-        .replace(/\([^)]*\)|[\n\t]/g, ' ')
+        .replace(/\([a-zA-Z0-9\s]*\)|[\n\t]/g, ' ')
         .replace(/(\s\s+)/g, ' ')
         .replace(/^\s\s*/, '')
         .replace(/\s\s*$/, '');


### PR DESCRIPTION
Fixes: [#6012](https://github.com/moment/moment/issues/6012)

Directly match the comment tokens in preprocessRFC2822 regex to resolve the problem [Regular Expression Denial of Service (ReDoS)#6012](https://github.com/moment/moment/issues/6012)