### PR TITLE
[bugfix] Fix redos in preprocessRFC2822 regex

### DIFF
--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -151,7 +151,7 @@ function untruncateYear(yearStr) {
 function preprocessRFC2822(s) {
     // Remove comments and folding whitespace and replace multiple-spaces with a single space
     return s
-        .replace(/\((?:(?!\().)*\)|[\n\t]/gs, ' ')
+        .replace(/\([^()]*\)|[\n\t]/g, ' ')
         .replace(/(\s\s+)/g, ' ')
         .replace(/^\s\s*/, '')
         .replace(/\s\s*$/, '');

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -151,7 +151,7 @@ function untruncateYear(yearStr) {
 function preprocessRFC2822(s) {
     // Remove comments and folding whitespace and replace multiple-spaces with a single space
     return s
-        .replace(/\([a-zA-Z0-9\s]*\)|[\n\t]/g, ' ')
+        .replace(/\((?:(?!\().)*\)|[\n\t]/gs, ' ')
         .replace(/(\s\s+)/g, ' ')
         .replace(/^\s\s*/, '')
         .replace(/\s\s*$/, '');

--- a/src/lib/create/from-string.js
+++ b/src/lib/create/from-string.js
@@ -151,7 +151,7 @@ function untruncateYear(yearStr) {
 function preprocessRFC2822(s) {
     // Remove comments and folding whitespace and replace multiple-spaces with a single space
     return s
-        .replace(/\([^)]*\)|[\n\t]/g, ' ')
+        .replace(/\([a-zA-Z0-9\s]*\)|[\n\t]/g, ' ')
         .replace(/(\s\s+)/g, ' ')
         .replace(/^\s\s*/, '')
         .replace(/\s\s*$/, '');


### PR DESCRIPTION
Fixes: [#6012](https://github.com/moment/moment/issues/6012)

Using the "look-ahead" mechanism regex in `preprocessRFC2822()` to resolve the problem [Regular Expression Denial of Service (ReDoS)#6012](https://github.com/moment/moment/issues/6012)