### PR TITLE
[feature] Add quick MLA / APA time formatting via function

### DIFF
--- a/src/lib/moment/moment.js
+++ b/src/lib/moment/moment.js
@@ -4,6 +4,7 @@ import { createInvalid } from '../create/valid';
 import { isMoment } from './constructor';
 import { min, max } from './min-max';
 import { now } from './now';
+import { MLA, APA } from './reference-format'
 import momentPrototype from './prototype';
 
 function createUnix(input) {
@@ -15,6 +16,8 @@ function createInZone() {
 }
 
 export {
+    APA,
+    MLA,
     now,
     min,
     max,

--- a/src/lib/moment/reference-format.js
+++ b/src/lib/moment/reference-format.js
@@ -1,0 +1,9 @@
+import { formatMoment } from '../format/format';
+
+export function MLA() {
+    return this.format("D MMM[.] YYYY");
+}
+
+export function APA() {
+    return this.format("YYYY[,] MMMM D");
+}

--- a/src/moment.js
+++ b/src/moment.js
@@ -9,6 +9,8 @@ import { hooks as moment, setHookCallback } from './lib/utils/hooks';
 moment.version = '2.29.4';
 
 import {
+    APA,
+    MLA,
     min,
     max,
     now,


### PR DESCRIPTION
This pull request is to add a function to the moment object that allows quick formatting as APA / MLA date, to save time and remove a little bit of confusion in citing sources via code.