### PR TITLE
[locale] nl, nl-be: Fix erroneous regex anchoring

### DIFF
--- a/src/locale/nl-be.js
+++ b/src/locale/nl-be.js
@@ -12,7 +12,7 @@ var monthsShortWithDots =
     monthsParse = [
         /^jan/i,
         /^feb/i,
-        /^maart|mrt.?$/i,
+        /^(maart|mrt\.?)$/i,
         /^apr/i,
         /^mei$/i,
         /^jun[i.]?$/i,

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -12,7 +12,7 @@ var monthsShortWithDots =
     monthsParse = [
         /^jan/i,
         /^feb/i,
-        /^maart|mrt.?$/i,
+        /^(maart|mrt\.?)$/i,
         /^apr/i,
         /^mei$/i,
         /^jun[i.]?$/i,


### PR DESCRIPTION
Note: I do not speak Dutch.
Please let someone who does review this. cc @middagj @jorisroling

The issue has been found using code checks (this triggers a CodeQL warning).

The problem is that `/^maart|mrt.?$/i,` matches `FOOBARmrtX`, which is likely unexpected.

Changes introduced in this PR:
 * `mrt` now also must appear at the start of the string (consistent with `^jan`, `^feb` etc)
 * `maart` now must be a complete match, (`MAART` will match, `MAARTx` will not). 
    This is consistent with `/^jun[i.]?$/i` and `/^jul[i.]?$/i` below in the same array.
    See note below.
 * '.?' (any char) replaced with `\.` (dot), i.e. `mrtX` won't match, but `mrt.` will.
    This is consistent with `/^jun[i.]?$/i` and `/^jul[i.]?$/i` below in the same array.

I'm not certain if all of the above is correct, please recheck.

---

Also, it's unclear why `monthsParse` seems to be inconsistent with `monthsRegex` and other regexes below re: `$` anchoring.
E.g., `JULwhatever` will not match `monthsParse[6]` (as it's anchored at the end), but wll match `monthsRegex`

Also, in `monthsRegex`,
```regex
/^(januari|februari|maart|april|mei|ju[nl]i|augustus|september|oktober|november|december|jan\.?|feb\.?|mrt\.?|apr\.?|ju[nl]\.?|aug\.?|sep\.?|okt\.?|nov\.?|dec\.?)/i
```
is equivalent to
```regex
/^(maart|mei|jan|feb|mrt|apr|ju[nl]|aug|sep|okt|nov|dec)/i
```
e.g. `\.?` are effectively noops as it's not anchored at the end.
Perhaps it was meant to be anchored everywhere?

Those issues are not covered in this PR.