### PR TITLE
Correct month subjective in PL

### DIFF
--- a/locale/pl.js
+++ b/locale/pl.js
@@ -62,7 +62,7 @@
         months: function (momentToFormat, format) {
             if (!momentToFormat) {
                 return monthsNominative;
-            } else if (/D MMMM/.test(format)) {
+            } else if (/D\.? MMMM/.test(format)) {
                 return monthsSubjective[momentToFormat.month()];
             } else {
                 return monthsNominative[momentToFormat.month()];


### PR DESCRIPTION
If the Date format is D. MMMM the wrong Case is used.

I made the . (Dot) optional, so it will still match in both cases