### PR TITLE
[locale] fr-ca: Match fr for ordinals

### DIFF
--- a/locale/fr-ca.js
+++ b/locale/fr-ca.js
@@ -59,11 +59,16 @@
         dayOfMonthOrdinalParse: /\d{1,2}(er|e)/,
         ordinal: function (number, period) {
             switch (period) {
+                // TODO: Return 'e' when day of month > 1. Move this case inside
+                // block for masculine words below.
+                // See https://github.com/moment/moment/issues/3375
+                case 'D':
+                    return number + (number === 1 ? 'er' : '');
+
                 // Words with masculine grammatical gender: mois, trimestre, jour
                 default:
                 case 'M':
                 case 'Q':
-                case 'D':
                 case 'DDD':
                 case 'd':
                     return number + (number === 1 ? 'er' : 'e');

--- a/locale/fr-ca.js
+++ b/locale/fr-ca.js
@@ -56,7 +56,7 @@
             y: 'un an',
             yy: '%d ans',
         },
-        dayOfMonthOrdinalParse: /\d{1,2}(er|e)/,
+        dayOfMonthOrdinalParse: /\d{1,2}(er|)/,
         ordinal: function (number, period) {
             switch (period) {
                 // TODO: Return 'e' when day of month > 1. Move this case inside

--- a/src/locale/fr-ca.js
+++ b/src/locale/fr-ca.js
@@ -49,14 +49,19 @@ export default moment.defineLocale('fr-ca', {
         y: 'un an',
         yy: '%d ans',
     },
-    dayOfMonthOrdinalParse: /\d{1,2}(er|e)/,
+    dayOfMonthOrdinalParse: /\d{1,2}(er|)/,
     ordinal: function (number, period) {
         switch (period) {
+            // TODO: Return 'e' when day of month > 1. Move this case inside
+            // block for masculine words below.
+            // See https://github.com/moment/moment/issues/3375
+            case 'D':
+                return number + (number === 1 ? 'er' : '');
+
             // Words with masculine grammatical gender: mois, trimestre, jour
             default:
             case 'M':
             case 'Q':
-            case 'D':
             case 'DDD':
             case 'd':
                 return number + (number === 1 ? 'er' : 'e');

--- a/src/test/locale/fr-ca.js
+++ b/src/test/locale/fr-ca.js
@@ -50,12 +50,12 @@ test('format', function (assert) {
     var a = [
             [
                 'dddd, MMMM Do YYYY, h:mm:ss a',
-                'dimanche, février 14e 2010, 3:25:50 pm',
+                'dimanche, février 14 2010, 3:25:50 pm',
             ],
             ['ddd, hA', 'dim., 3PM'],
             ['M Mo MM MMMM MMM', '2 2e 02 février févr.'],
             ['YYYY YY', '2010 10'],
-            ['D Do DD', '14 14e 14'],
+            ['D Do DD', '14 14 14'],
             ['d do dddd ddd dd', '0 0e dimanche dim. di'],
             ['DDD DDDo DDDD', '45 45e 045'],
             ['w wo ww', '8 8e 08'],
@@ -64,7 +64,7 @@ test('format', function (assert) {
             ['m mm', '25 25'],
             ['s ss', '50 50'],
             ['a A', 'pm PM'],
-            ['[le] Do [jour du mois]', 'le 14e jour du mois'],
+            ['[le] Do [jour du mois]', 'le 14 jour du mois'],
             ['[le] DDDo [jour de l’année]', 'le 45e jour de l’année'],
             ['LTS', '15:25:50'],
             ['L', '2010-02-14'],
@@ -92,7 +92,7 @@ test('format ordinal', function (assert) {
     assert.equal(moment([2017, 3, 1]).format('Qo'), '2e', '2e');
 
     assert.equal(moment([2017, 0, 1]).format('Do'), '1er', '1er');
-    assert.equal(moment([2017, 0, 2]).format('Do'), '2e', '2e');
+    assert.equal(moment([2017, 0, 2]).format('Do'), '2', '2');
 
     assert.equal(moment([2011, 0, 1]).format('DDDo'), '1er', '1er');
     assert.equal(moment([2011, 0, 2]).format('DDDo'), '2e', '2e');


### PR DESCRIPTION
We say Samedi 1er avril, but not Dimanche 2e avril.
The correct for should be Dimanche 2 avril.

This has been fixed in `fr.json` but not in `fr-ca.json`.
Fix #3375