### PR TITLE
Italian days and months with capital letter

### DIFF
--- a/locale/it.js
+++ b/locale/it.js
@@ -14,15 +14,15 @@
     //! moment.js locale configuration
 
     var it = moment.defineLocale('it', {
-        months: 'gennaio_febbraio_marzo_aprile_maggio_giugno_luglio_agosto_settembre_ottobre_novembre_dicembre'.split(
+        months: 'Gennaio_Febbraio_Marzo_Aprile_Maggio_Giugno_Luglio_Agosto_Settembre_Ottobre_Novembre_Dicembre'.split(
             '_'
         ),
-        monthsShort: 'gen_feb_mar_apr_mag_giu_lug_ago_set_ott_nov_dic'.split('_'),
+        monthsShort: 'Gen_Feb_Mar_Apr_Mag_Giu_Lug_Ago_Set_Ott_Nov_Dic'.split('_'),
         weekdays: 'domenica_lunedì_martedì_mercoledì_giovedì_venerdì_sabato'.split(
             '_'
         ),
-        weekdaysShort: 'dom_lun_mar_mer_gio_ven_sab'.split('_'),
-        weekdaysMin: 'do_lu_ma_me_gi_ve_sa'.split('_'),
+        weekdaysShort: 'Dom_Lun_Mar_Mer_Gio_Ven_Sab'.split('_'),
+        weekdaysMin: 'Do_Lu_Ma_Me_Gi_Ve_Sa'.split('_'),
         longDateFormat: {
             LT: 'HH:mm',
             LTS: 'HH:mm:ss',


### PR DESCRIPTION
Other languages have days with capital letter, like Monday, Saturday etc.. in italian they were all lowercase.