### PR TITLE
Add ckb locale

### DIFF
--- a/component.json
+++ b/component.json
@@ -23,6 +23,7 @@
     "locale/br.js",
     "locale/bs.js",
     "locale/ca.js",
+    "locale/ckb.js",
     "locale/cs.js",
     "locale/cv.js",
     "locale/cy.js",

--- a/locale/ckb.js
+++ b/locale/ckb.js
@@ -1,0 +1,130 @@
+//! moment.js locale configuration
+//! locale : Central Kurdish [ckb]
+//! author : Shahram Mebashar : https://github.com/ShahramMebashar
+//! author : AlanD20 : https://github.com/AlanD20
+
+;(function (global, factory) {
+   typeof exports === 'object' && typeof module !== 'undefined'
+       && typeof require === 'function' ? factory(require('../moment')) :
+   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
+   factory(global.moment)
+}(this, (function (moment) { 'use strict';
+
+    //! moment.js locale configuration
+
+    var symbolMap = {
+            1: '١',
+            2: '٢',
+            3: '٣',
+            4: '٤',
+            5: '٥',
+            6: '٦',
+            7: '٧',
+            8: '٨',
+            9: '٩',
+            0: '٠',
+        },
+        numberMap = {
+            '١': '1',
+            '٢': '2',
+            '٣': '3',
+            '٤': '4',
+            '٥': '5',
+            '٦': '6',
+            '٧': '7',
+            '٨': '8',
+            '٩': '9',
+            '٠': '0',
+        },
+        months = [
+            'کانونی دووەم',
+            'شوبات',
+            'ئازار',
+            'نیسان',
+            'ئایار',
+            'حوزەیران',
+            'تەمموز',
+            'ئاب',
+            'ئەیلوول',
+            'تشرینی یەكەم',
+            'تشرینی دووەم',
+            'كانونی یەکەم',
+        ];
+
+    var ckb = moment.defineLocale('ckb', {
+        months: months,
+        monthsShort: months,
+        weekdays:
+            'یه‌كشه‌ممه‌_دووشه‌ممه‌_سێشه‌ممه‌_چوارشه‌ممه‌_پێنجشه‌ممه‌_هه‌ینی_شه‌ممه‌'.split(
+                '_'
+            ),
+        weekdaysShort:
+            'یه‌كشه‌م_دووشه‌م_سێشه‌م_چوارشه‌م_پێنجشه‌م_هه‌ینی_شه‌ممه‌'.split('_'),
+        weekdaysMin: 'ی_د_س_چ_پ_ه_ش'.split('_'),
+        weekdaysParseExact: true,
+        longDateFormat: {
+            LT: 'HH:mm',
+            LTS: 'HH:mm:ss',
+            L: 'DD/MM/YYYY',
+            LL: 'D MMMM YYYY',
+            LLL: 'D MMMM YYYY HH:mm',
+            LLLL: 'dddd, D MMMM YYYY HH:mm',
+        },
+        meridiemParse: /ئێواره‌|به‌یانی/,
+        isPM: function (input) {
+            return /ئێواره‌/.test(input);
+        },
+        meridiem: function (hour, minute, isLower) {
+            if (hour < 12) {
+                return 'به‌یانی';
+            } else {
+                return 'ئێواره‌';
+            }
+        },
+        calendar: {
+            sameDay: '[ئه‌مرۆ كاتژمێر] LT',
+            nextDay: '[به‌یانی كاتژمێر] LT',
+            nextWeek: 'dddd [كاتژمێر] LT',
+            lastDay: '[دوێنێ كاتژمێر] LT',
+            lastWeek: 'dddd [كاتژمێر] LT',
+            sameElse: 'L',
+        },
+        relativeTime: {
+            future: 'له‌ %s',
+            past: '%s',
+            s: 'چه‌ند چركه‌یه‌ك',
+            ss: 'چركه‌ %d',
+            m: 'یه‌ك خوله‌ك',
+            mm: '%d خوله‌ك',
+            h: 'یه‌ك كاتژمێر',
+            hh: '%d كاتژمێر',
+            d: 'یه‌ك ڕۆژ',
+            dd: '%d ڕۆژ',
+            M: 'یه‌ك مانگ',
+            MM: '%d مانگ',
+            y: 'یه‌ك ساڵ',
+            yy: '%d ساڵ',
+        },
+        preparse: function (string) {
+            return string
+                .replace(/[١٢٣٤٥٦٧٨٩٠]/g, function (match) {
+                    return numberMap[match];
+                })
+                .replace(/،/g, ',');
+        },
+        postformat: function (string) {
+            return string
+                .replace(/\d/g, function (match) {
+                    return symbolMap[match];
+                })
+                .replace(/,/g, '،');
+        },
+        week: {
+            dow: 6, // Saturday is the first day of the week.
+            doy: 12, // The week that contains Jan 12th is the first week of the year.
+        },
+    });
+
+    return ckb;
+
+})));


### PR DESCRIPTION
Hey there!

I'm opening this PR to add `ckb` locale to the list of supported locales.

**Why?**
The Kurdish language has a variety of dialects, leading to inconsistencies in many packages. The `ku` locale, for instance, might represent Central Kurdish translation in one package, but in another package, it could be Northern or Southern Kurdish. These dialect differences are significant and could result in unintentional selection of the locale.

Therefore, this pull request proposes a consistent [CLDR](https://cldr.unicode.org/index) locale code by duplicating the existing `ku` locale, which represents Central Kurdish translation, into its own designated locale code.

Note: I chose to not delete `ku` locale since some people might still use this in their projects. But in the future, people could reserve this locale for another Kurdish dialect translation.

Thank you!

**References:**

- [Picking the right language identifier by Unicode CLDR](https://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code)
- [CKB in Glottolog](https://glottolog.org/resource/languoid/id/cent1972)
- [CKB in Ethnologue](https://www.ethnologue.com/language/ckb/)
- [CKB in ISO 639-3](https://iso639-3.sil.org/code/ckb)