### PR TITLE
[bugfix] Access default year month date from moment instance

### DIFF
--- a/src/lib/create/from-array.js
+++ b/src/lib/create/from-array.js
@@ -29,7 +29,10 @@ function currentDateArray(config) {
             nowValue.getUTCDate(),
         ];
     }
-    return [nowValue.getFullYear(), nowValue.getMonth(), nowValue.getDate()];
+
+    const now = hooks();
+
+    return [now.year(), now.month(), now.date()];
 }
 
 // convert an array to a date.


### PR DESCRIPTION
When timezone is setted, moment.date() may be different from  Date().getDate()