### PR TITLE
Fix czech months (format and standalone swap)

### DIFF
--- a/locale/cs.js
+++ b/locale/cs.js
@@ -12,11 +12,11 @@
     //! moment.js locale configuration
 
     var months = {
-            format: 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split(
+            format: 'ledna_února_března_dubna_května_června_července_srpna_září_října_listopadu_prosince'.split(
                 '_'
             ),
             standalone:
-                'ledna_února_března_dubna_května_června_července_srpna_září_října_listopadu_prosince'.split(
+                'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split(
                     '_'
                 ),
         },


### PR DESCRIPTION
Signed-off-by: Martin Mayer martin.kelly.mayer@gmail.com

Format and standalone month names are swapped.
e.g. 1.12.2023 should be "1. prosince 2023", not "1. prosinec 2023"
and 12.2023 should be "prosinec 2023", not "prosince 2023"