### PR TITLE
Render Czech (cs) month-names correctly with numerals

### DIFF
--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -5,13 +5,14 @@
 import moment from '../moment';
 
 var months = {
-        format: 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split(
+        standalone: 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split(
             '_'
         ),
-        standalone:
+        format:
             'ledna_února_března_dubna_května_června_července_srpna_září_října_listopadu_prosince'.split(
                 '_'
             ),
+        isFormat: /DD?[o.]?(\[[^\[\]]*\]|\s)+MMMM/,
     },
     monthsShort = 'led_úno_bře_dub_kvě_čvn_čvc_srp_zář_říj_lis_pro'.split('_'),
     monthsParse = [

--- a/src/test/locale/cs.js
+++ b/src/test/locale/cs.js
@@ -52,9 +52,9 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss', 'neděle, února 14. 2010, 3:25:50'],
+            ['dddd, Do MMMM YYYY, h:mm:ss', 'neděle, 14. února 2010, 3:25:50'],
             ['ddd, h', 'ne, 3'],
-            ['M Mo MM MMMM MMM', '2 2. 02 února úno'],
+            ['M Mo MM MMMM MMM', '2 2. 02 únor úno'],
             ['YYYY YY', '2010 10'],
             ['D Do DD', '14 14. 14'],
             ['d do dddd ddd dd', '0 0. neděle ne ne'],
@@ -122,7 +122,7 @@ test('format ordinal', function (assert) {
 
 test('format month', function (assert) {
     var expected =
-            'ledna led_února úno_března bře_dubna dub_května kvě_června čvn_července čvc_srpna srp_září zář_října říj_listopadu lis_prosince pro'.split(
+            'leden led_únor úno_březen bře_duben dub_květen kvě_červen čvn_červenec čvc_srpen srp_září zář_říjen říj_listopad lis_prosinec pro'.split(
                 '_'
             ),
         i;
@@ -137,11 +137,11 @@ test('format month', function (assert) {
 
 test('format month case', function (assert) {
     var months = {
-            nominative:
+            accusative:
                 'ledna_února_března_dubna_května_června_července_srpna_září_října_listopadu_prosince'.split(
                     '_'
                 ),
-            accusative:
+            nominative:
                 'leden_únor_březen_duben_květen_červen_červenec_srpen_září_říjen_listopad_prosinec'.split(
                     '_'
                 ),


### PR DESCRIPTION
According to local knowledge the month-names need to be rendered using the format-version when a numeral is added to them.

This is now handled by adding the appropriate isFormat regex.

This should provide a more elegant solution to the problem of broken czech month-names than #6185 and #6063 as it fixes the root cause and does not simply swap month-names which then breaks other tests

The main change is swapping the numeral and the format strings but also modifying the tests to properly resemble local date and time formats.

The dot (.) is used  instead of th,nd, rd or th and is tuerefore added to the regex as equal to the `o`.

That makes sure that the `L`,variants get rendered correctly as they use `D.` in their format string which would otherwise not match for the monthname.

Also the date always comes before the month in czech. So it's `1. April` and not `April 1st`. Therefore I have changed the format in the test on line 53 to match that similar to the german locale file.

This should now make sure that all possible options are correctly spelled.