### PR TITLE
[bugfix] weekyear setter handle dow

### DIFF
--- a/src/lib/units/week-year.js
+++ b/src/lib/units/week-year.js
@@ -69,7 +69,7 @@ export function getSetWeekYear(input) {
         this,
         input,
         this.week(),
-        this.weekday(),
+        this.weekday() + this.localeData()._week.dow,
         this.localeData()._week.dow,
         this.localeData()._week.doy
     );

--- a/src/test/moment/week_year.js
+++ b/src/test/moment/week_year.js
@@ -62,6 +62,14 @@ test('week year', function (assert) {
     assert.equal(moment([2008, 11, 29]).weekYear(), 2009);
     assert.equal(moment([2009, 11, 27]).weekYear(), 2009);
     assert.equal(moment([2009, 11, 28]).weekYear(), 2010);
+
+    moment.locale('dow:1 doy:4', { week: { dow: 1, doy: 4 } });
+    assert.equal(moment([2015, 11, 27]).locale('dow:1 doy:4').weekYear(), 2015);
+    assert.equal(
+        moment([2015, 11, 27]).locale('dow:1 doy:4').weekYear(2015).date(),
+        27
+    );
+    moment.defineLocale('dow:1 doy:4', null);
 });
 
 // Verifies that the week number, week day computation is correct for all dow, doy combinations


### PR DESCRIPTION
Fixes #3944

The semantics of "locale weekday" are a bit iffy, but I guess it boils down to -- `locale_weekday - dow` is 0-6 (Mon-Sun).

The parser logic is a bit more involved and does it this way, so it makes more sense to obey it and fix the weekYear setter (instead of changing the semantics of weekday inside the rest of the (internal) code).