### PR TITLE
Fix Georgian Long ('L') Date format.

### DIFF
--- a/dist/locale/ka.js
+++ b/dist/locale/ka.js
@@ -24,7 +24,7 @@ export default moment.defineLocale('ka', {
     longDateFormat: {
         LT: 'HH:mm',
         LTS: 'HH:mm:ss',
-        L: 'DD/MM/YYYY',
+        L: 'DD.MM.YYYY',
         LL: 'D MMMM YYYY',
         LLL: 'D MMMM YYYY HH:mm',
         LLLL: 'dddd, D MMMM YYYY HH:mm',

--- a/locale/ka.js
+++ b/locale/ka.js
@@ -31,7 +31,7 @@
         longDateFormat: {
             LT: 'HH:mm',
             LTS: 'HH:mm:ss',
-            L: 'DD/MM/YYYY',
+            L: 'DD.MM.YYYY',
             LL: 'D MMMM YYYY',
             LLL: 'D MMMM YYYY HH:mm',
             LLLL: 'dddd, D MMMM YYYY HH:mm',

--- a/src/locale/ka.js
+++ b/src/locale/ka.js
@@ -24,7 +24,7 @@ export default moment.defineLocale('ka', {
     longDateFormat: {
         LT: 'HH:mm',
         LTS: 'HH:mm:ss',
-        L: 'DD/MM/YYYY',
+        L: 'DD.MM.YYYY',
         LL: 'D MMMM YYYY',
         LLL: 'D MMMM YYYY HH:mm',
         LLLL: 'dddd, D MMMM YYYY HH:mm',


### PR DESCRIPTION
According to wikipedia, the correct date format is 'DD.MM.YYYY': https://en.wikipedia.org/wiki/List_of_date_formats_by_country.

Fixed that to conform the general used format.