### PR TITLE
[locale] Change Saat to Saa in dist/locale/sw.js

### DIFF
--- a/dist/locale/sw.js
+++ b/dist/locale/sw.js
@@ -27,9 +27,9 @@ export default moment.defineLocale('sw', {
     calendar: {
         sameDay: '[leo saa] LT',
         nextDay: '[kesho saa] LT',
-        nextWeek: '[wiki ijayo] dddd [saat] LT',
+        nextWeek: '[wiki ijayo] dddd [saa] LT',
         lastDay: '[jana] LT',
-        lastWeek: '[wiki iliyopita] dddd [saat] LT',
+        lastWeek: '[wiki iliyopita] dddd [saa] LT',
         sameElse: 'L',
     },
     relativeTime: {


### PR DESCRIPTION
Typing error, in swahili time is "Saa" and not "Saat"