### PR TITLE
[locale] Update Sinhala (si) translations

### DIFF
--- a/src/locale/si.js
+++ b/src/locale/si.js
@@ -6,10 +6,10 @@ import moment from '../moment';
 
 /*jshint -W100*/
 export default moment.defineLocale('si', {
-    months: 'ජනවාරි_පෙබරවාරි_මාර්තු_අප්‍රේල්_මැයි_ජූනි_ජූලි_අගෝස්තු_සැප්තැම්බර්_ඔක්තෝබර්_නොවැම්බර්_දෙසැම්බර්'.split(
+    months: 'දුරුතු_නවම්_මැදින්_බක්_වෙසක්_පොසොන්_ඇසළ_නිකිණි_බිනර_වප්_ඉල්_උඳුවප්'.split(
         '_'
     ),
-    monthsShort: 'ජන_පෙබ_මාර්_අප්_මැයි_ජූනි_ජූලි_අගෝ_සැප්_ඔක්_නොවැ_දෙසැ'.split(
+    monthsShort: 'දුරුතු_නවම්_මැදින්_බක්_වෙසක්_පොසොන්_ඇසළ_නිකිණි_බිනර_වප්_ඉල්_උඳු'.split(
         '_'
     ),
     weekdays:
@@ -36,16 +36,16 @@ export default moment.defineLocale('si', {
         sameElse: 'L',
     },
     relativeTime: {
-        future: '%sකින්',
-        past: '%sකට පෙර',
+        future: '%s කින්',
+        past: '%s කට පෙර',
         s: 'තත්පර කිහිපය',
         ss: 'තත්පර %d',
-        m: 'මිනිත්තුව',
-        mm: 'මිනිත්තු %d',
+        m: 'විනාඩිය',
+        mm: 'විනාඩි %d',
         h: 'පැය',
         hh: 'පැය %d',
-        d: 'දිනය',
-        dd: 'දින %d',
+        d: 'දවස',
+        dd: 'දවස් %d',
         M: 'මාසය',
         MM: 'මාස %d',
         y: 'වසර',
@@ -55,15 +55,15 @@ export default moment.defineLocale('si', {
     ordinal: function (number) {
         return number + ' වැනි';
     },
-    meridiemParse: /පෙර වරු|පස් වරු|පෙ.ව|ප.ව./,
+    meridiemParse: /පෙරවරු|පස්වරු|පෙ.ව|ප.ව./,
     isPM: function (input) {
-        return input === 'ප.ව.' || input === 'පස් වරු';
+        return input === 'ප.ව.' || input === 'පස්වරු';
     },
     meridiem: function (hours, minutes, isLower) {
         if (hours > 11) {
-            return isLower ? 'ප.ව.' : 'පස් වරු';
+            return isLower ? 'ප.ව.' : 'පස්වරු';
         } else {
-            return isLower ? 'පෙ.ව.' : 'පෙර වරු';
+            return isLower ? 'පෙ.ව.' : 'පෙරවරු';
         }
     },
 });

--- a/src/test/locale/si.js
+++ b/src/test/locale/si.js
@@ -5,7 +5,7 @@ localeModule('si');
 
 test('parse', function (assert) {
     var tests =
-            'ජනවාරි ජන_පෙබරවාරි පෙබ_මාර්තු මාර්_අප්‍රේල් අප්_මැයි මැයි_ජූනි ජූනි_ජූලි ජූලි_අගෝස්තු අගෝ_සැප්තැම්බර් සැප්_ඔක්තෝබර් ඔක්_නොවැම්බර් නොවැ_දෙසැම්බර් දෙසැ'.split(
+            'දුරුතු දුරුතු_නවම් නවම්_මැදින් මැදින්_බක් බක්_වෙසක් වෙසක්_පොසොන් පොසොන්_ඇසළ ඇසළ_නිකිණි නිකිණි_බිනර බිනර_වප් වප්_ඉල් ඉල්_උඳුවප් උඳු'.split(
                 '_'
             ),
         i;
@@ -49,14 +49,14 @@ test('format', function (assert) {
     var a = [
             [
                 'YYYY MMMM Do dddd, a h:mm:ss',
-                '2010 පෙබරවාරි 14 වැනි ඉරිදා, ප.ව. 3:25:50',
+                '2010 නවම් 14 වැනි ඉරිදා, ප.ව. 3:25:50',
             ],
             [
                 'YYYY MMMM Do dddd, a h:mm:ss',
-                '2010 පෙබරවාරි 14 වැනි ඉරිදා, ප.ව. 3:25:50',
+                '2010 නවම් 14 වැනි ඉරිදා, ප.ව. 3:25:50',
             ],
-            ['ddd, A h', 'ඉරි, පස් වරු 3'],
-            ['M Mo MM MMMM MMM', '2 2 වැනි 02 පෙබරවාරි පෙබ'],
+            ['ddd, A h', 'ඉරි, පස්වරු 3'],
+            ['M Mo MM MMMM MMM', '2 2 වැනි 02 නවම් නවම්'],
             ['YYYY YY', '2010 10'],
             ['D Do DD', '14 14 වැනි 14'],
             ['d do dddd ddd dd', '0 0 වැනි ඉරිදා ඉරි ඉ'],
@@ -65,18 +65,18 @@ test('format', function (assert) {
             ['H HH', '15 15'],
             ['m mm', '25 25'],
             ['s ss', '50 50'],
-            ['a A', 'ප.ව. පස් වරු'],
-            ['[වසරේ] DDDo [දිනය]', 'වසරේ 45 වැනි දිනය'],
+            ['a A', 'ප.ව. පස්වරු'],
+            ['[වසරේ] DDDo [දවස]', 'වසරේ 45 වැනි දවස'],
             ['LTS', 'ප.ව. 3:25:50'],
             ['LT', 'ප.ව. 3:25'],
             ['L', '2010/02/14'],
-            ['LL', '2010 පෙබරවාරි 14'],
-            ['LLL', '2010 පෙබරවාරි 14, ප.ව. 3:25'],
-            ['LLLL', '2010 පෙබරවාරි 14 වැනි ඉරිදා, ප.ව. 3:25:50'],
+            ['LL', '2010 නවම් 14'],
+            ['LLL', '2010 නවම් 14, ප.ව. 3:25'],
+            ['LLLL', '2010 නවම් 14 වැනි ඉරිදා, ප.ව. 3:25:50'],
             ['l', '2010/2/14'],
-            ['ll', '2010 පෙබ 14'],
-            ['lll', '2010 පෙබ 14, ප.ව. 3:25'],
-            ['llll', '2010 පෙබ 14 වැනි ඉරි, ප.ව. 3:25:50'],
+            ['ll', '2010 නවම් 14'],
+            ['lll', '2010 නවම් 14, ප.ව. 3:25'],
+            ['llll', '2010 නවම් 14 වැනි ඉරි, ප.ව. 3:25:50'],
         ],
         b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
         i;
@@ -124,7 +124,7 @@ test('format ordinal', function (assert) {
 
 test('format month', function (assert) {
     var expected =
-            'ජනවාරි ජන_පෙබරවාරි පෙබ_මාර්තු මාර්_අප්‍රේල් අප්_මැයි මැයි_ජූනි ජූනි_ජූලි ජූලි_අගෝස්තු අගෝ_සැප්තැම්බර් සැප්_ඔක්තෝබර් ඔක්_නොවැම්බර් නොවැ_දෙසැම්බර් දෙසැ'.split(
+            'දුරුතු දුරුතු_නවම් නවම්_මැදින් මැදින්_බක් බක්_වෙසක් වෙසක්_පොසොන් පොසොන්_ඇසළ ඇසළ_නිකිණි නිකිණි_බිනර බිනර_වප් වප්_ඉල් ඉල්_උඳුවප් උඳු'.split(
                 '_'
             ),
         i;
@@ -161,22 +161,22 @@ test('from', function (assert) {
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ s: 45 }), true),
-        'මිනිත්තුව',
+        'විනාඩිය',
         '45 seconds = a minute'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ s: 89 }), true),
-        'මිනිත්තුව',
+        'විනාඩිය',
         '89 seconds = a minute'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ s: 90 }), true),
-        'මිනිත්තු 2',
+        'විනාඩි 2',
         '90 seconds = 2 minutes'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ m: 44 }), true),
-        'මිනිත්තු 44',
+        'විනාඩි 44',
         '44 minutes = 44 minutes'
     );
     assert.equal(
@@ -206,32 +206,32 @@ test('from', function (assert) {
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ h: 22 }), true),
-        'දිනය',
+        'දවස',
         '22 hours = a day'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ h: 35 }), true),
-        'දිනය',
+        'දවස',
         '35 hours = a day'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ h: 36 }), true),
-        'දින 2',
+        'දවස් 2',
         '36 hours = 2 days'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ d: 1 }), true),
-        'දිනය',
+        'දවස',
         '1 day = a day'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ d: 5 }), true),
-        'දින 5',
+        'දවස් 5',
         '5 days = 5 days'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ d: 25 }), true),
-        'දින 25',
+        'දවස් 25',
         '25 days = 25 days'
     );
     assert.equal(
@@ -315,7 +315,7 @@ test('fromNow', function (assert) {
         'තත්පර කිහිපයකින්',
         'in a few seconds'
     );
-    assert.equal(moment().add({ d: 5 }).fromNow(), 'දින 5කින්', 'in 5 days');
+    assert.equal(moment().add({ d: 5 }).fromNow(), 'දවස් 5 කින්', 'in 5 days');
 });
 
 test('calendar day', function (assert) {
@@ -323,32 +323,32 @@ test('calendar day', function (assert) {
 
     assert.equal(
         moment(a).calendar(),
-        'අද ප.ව. 12:00ට',
+        'අද ප.ව. 12:00 ට',
         'today at the same time'
     );
     assert.equal(
         moment(a).add({ m: 25 }).calendar(),
-        'අද ප.ව. 12:25ට',
+        'අද ප.ව. 12:25 ට',
         'Now plus 25 min'
     );
     assert.equal(
         moment(a).add({ h: 1 }).calendar(),
-        'අද ප.ව. 1:00ට',
+        'අද ප.ව. 1:00 ට',
         'Now plus 1 hour'
     );
     assert.equal(
         moment(a).add({ d: 1 }).calendar(),
-        'හෙට ප.ව. 12:00ට',
+        'හෙට ප.ව. 12:00 ට',
         'tomorrow at the same time'
     );
     assert.equal(
         moment(a).subtract({ h: 1 }).calendar(),
-        'අද පෙ.ව. 11:00ට',
+        'අද පෙ.ව. 11:00 ට',
         'Now minus 1 hour'
     );
     assert.equal(
         moment(a).subtract({ d: 1 }).calendar(),
-        'ඊයේ ප.ව. 12:00ට',
+        'ඊයේ ප.ව. 12:00 ට',
         'yesterday at the same time'
     );
 });


### PR DESCRIPTION
From https://github.com/moment/moment/pull/5877

- Added correct translations for month names
e.g. ජනවාරි (pron. Janawaari) is a loan word.
See https://si.wikipedia.org/wiki/චන්ද්‍ර_මාස
See https://masteranylanguage.com/c/b/o9ly878fJ/98-Sinhala-MonthsOfYear-Learn-Step-By-Step

Note: We don't have short words for month names and I noticed that three letters are used to abbreviate month names in English [locale/en-gb.js](https://github.com/moment/moment/blob/develop/src/locale/en-gb.js). So i decided to keep three letters. (otherwise දුරු = cummin, නව = new, ඇස = eye)

- Corrected the translation of the word "minute"
මිනිත්තුව (pron. miniththuwa) is a loan word.
- Fixed - දිනය / දින (Date / Dates) -> දවස / දවස් (Day / Days)