### PR TITLE
[locale] Kazakh does not follow conventions

### DIFF
--- a/locale/kk.js
+++ b/locale/kk.js
@@ -47,10 +47,10 @@
         longDateFormat: {
             LT: 'HH:mm',
             LTS: 'HH:mm:ss',
-            L: 'YYYY.DD.MM',
-            LL: 'YYYY [ж] D MMMM',
-            LLL: 'YYYY [ж] D MMMM HH:mm',
-            LLLL: 'YYYY [ж] D MMMM, dddd HH:mm',
+            L: 'DD.MM.YYYY',
+            LL: 'D MMMM YYYY',
+            LLL: 'D MMMM YYYY HH:mm',
+            LLLL: 'dddd, D MMMM YYYY HH:mm',
         },
         calendar: {
             sameDay: '[Бүгін сағат] LT',

--- a/locale/kk.js
+++ b/locale/kk.js
@@ -47,10 +47,10 @@
         longDateFormat: {
             LT: 'HH:mm',
             LTS: 'HH:mm:ss',
-            L: 'DD.MM.YYYY',
-            LL: 'D MMMM YYYY',
-            LLL: 'D MMMM YYYY HH:mm',
-            LLLL: 'dddd, D MMMM YYYY HH:mm',
+            L: 'YYYY.DD.MM',
+            LL: 'YYYY [ж] D MMMM',
+            LLL: 'YYYY [ж] D MMMM HH:mm',
+            LLLL: 'YYYY [ж] D MMMM, dddd HH:mm',
         },
         calendar: {
             sameDay: '[Бүгін сағат] LT',

--- a/src/locale/kk.js
+++ b/src/locale/kk.js
@@ -40,10 +40,10 @@ export default moment.defineLocale('kk', {
     longDateFormat: {
         LT: 'HH:mm',
         LTS: 'HH:mm:ss',
-        L: 'DD.MM.YYYY',
-        LL: 'D MMMM YYYY',
-        LLL: 'D MMMM YYYY HH:mm',
-        LLLL: 'dddd, D MMMM YYYY HH:mm',
+        L: 'YYYY.DD.MM',
+        LL: 'YYYY [ж] D MMMM',
+        LLL: 'YYYY [ж] D MMMM HH:mm',
+        LLLL: 'YYYY [ж] D MMMM, dddd HH:mm',
     },
     calendar: {
         sameDay: '[Бүгін сағат] LT',


### PR DESCRIPTION
I am not a native Kazakh speaker, but I work for a company that recently translated our platform into Kazakh. We received feedback from our partner in Kazakhstan regarding date conventions:
“Usually, the convention is to use the format: year [ж] day month.”
For reference, please see the source from another library: [DateTime/Locale/kk_KZ.pod](https://metacpan.org/dist/DateTime-Locale/view/lib/DateTime/Locale/kk_KZ.pod).
