### PR TITLE
fixed Thursday short code for se-sv locale

### DIFF
--- a/locale/sv.js
+++ b/locale/sv.js
@@ -17,7 +17,7 @@
         ),
         monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec'.split('_'),
         weekdays: 'söndag_måndag_tisdag_onsdag_torsdag_fredag_lördag'.split('_'),
-        weekdaysShort: 'sön_mån_tis_ons_tor_fre_lör'.split('_'),
+        weekdaysShort: 'sön_mån_tis_ons_tors_fre_lör'.split('_'),
         weekdaysMin: 'sö_må_ti_on_to_fr_lö'.split('_'),
         longDateFormat: {
             LT: 'HH:mm',


### PR DESCRIPTION
Currently, abbreviation for Thursday in Swedish locale is Incorrect. It returns "tor" while correct is "tors".

Reference :
https://www.prefix.nu/forkortningar.html
https://unicode.org/cldr/cldr-aux/charts/32/summary/sv.html