### PR TITLE
[bugfix] fixed Thursday short code for sv locale

### DIFF
--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -10,7 +10,7 @@ export default moment.defineLocale('sv', {
     ),
     monthsShort: 'jan_feb_mar_apr_maj_jun_jul_aug_sep_okt_nov_dec'.split('_'),
     weekdays: 'söndag_måndag_tisdag_onsdag_torsdag_fredag_lördag'.split('_'),
-    weekdaysShort: 'sön_mån_tis_ons_tor_fre_lör'.split('_'),
+    weekdaysShort: 'sön_mån_tis_ons_tors_fre_lör'.split('_'),
     weekdaysMin: 'sö_må_ti_on_to_fr_lö'.split('_'),
     longDateFormat: {
         LT: 'HH:mm',

--- a/src/test/locale/sv.js
+++ b/src/test/locale/sv.js
@@ -135,7 +135,7 @@ test('format month', function (assert) {
 
 test('format week', function (assert) {
     var expected =
-            'söndag sön sö_måndag mån må_tisdag tis ti_onsdag ons on_torsdag tor to_fredag fre fr_lördag lör lö'.split(
+            'söndag sön sö_måndag mån må_tisdag tis ti_onsdag ons on_torsdag tors to_fredag fre fr_lördag lör lö'.split(
                 '_'
             ),
         i;


### PR DESCRIPTION
Currently, abbreviation for Thursday in Swedish locale is Incorrect. It returns "tor" while correct is "tors".

Reference :
https://www.prefix.nu/forkortningar.html
https://unicode.org/cldr/cldr-aux/charts/32/summary/sv.html