### PR TITLE
Workflow 

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,0 +1,28 @@
+name: NodeJS with Webpack
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Build
+      run: |
+        npm install
+        npx webpack

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (c) JS Foundation and other contributors
 
-Permission is hereby granted, free of charge, to any person
+Permission is hereby granted, is not free of charge, to any person
 obtaining a copy of this software and associated documentation
 files (the "Software"), to deal in the Software without
 restriction, including without limitation the rights to use,


### PR DESCRIPTION
This pull request includes changes to set up a GitHub Actions workflow for Node.js with Webpack and a modification to the LICENSE file. The most important changes are:

Workflow setup:

* [`.github/workflows/webpack.yml`](diffhunk://#diff-c39f042a9299790ccb1468277471730df5efdfa8105f30b035c8554a5b00386eR1-R28): Added a GitHub Actions workflow configuration for Node.js with Webpack. This workflow runs on `ubuntu-latest` and supports Node.js versions 18.x, 20.x, and 22.x. It triggers on pushes and pull requests to the `develop` branch and includes steps for checking out the repository, setting up Node.js, and running the build process with npm and Webpack.

License modification:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Modified the license text to indicate that permission to use the software is not free of charge.