### PR TITLE
[locale] ca.js: replace straight quotes with curly quotes

### DIFF
--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -10,7 +10,7 @@ export default moment.defineLocale('ca', {
             'gener_febrer_març_abril_maig_juny_juliol_agost_setembre_octubre_novembre_desembre'.split(
                 '_'
             ),
-        format: "de gener_de febrer_de març_d'abril_de maig_de juny_de juliol_d'agost_de setembre_d'octubre_de novembre_de desembre".split(
+        format: "de gener_de febrer_de març_d’abril_de maig_de juny_de juliol_d’agost_de setembre_d’octubre_de novembre_de desembre".split(
             '_'
         ),
         isFormat: /D[oD]?(\s)+MMMM/,

--- a/src/test/locale/ca.js
+++ b/src/test/locale/ca.js
@@ -81,6 +81,31 @@ test('format', function (assert) {
     }
 });
 
+test('format apostrophed prepositions', function (assert) {
+    const examples = [
+        {
+            date: [2025, 3, 4],
+            format: 'LL',
+            want: '4 d’abril de 2025',
+        },
+        {
+            date: [2025, 7, 8],
+            format: 'LL',
+            want: '8 d’agost de 2025',
+        },
+        {
+            date: [2025, 9, 10],
+            format: 'LL',
+            want: '10 d’octubre de 2025',
+        }
+    ]
+
+    examples.forEach(({ date, format, want }) => {
+        const got = moment(date).format(format);
+        assert.equal(got, want, `${date}, ${format}: got ${got}, want ${want}`);
+    })
+});
+
 test('format ordinal', function (assert) {
     assert.equal(moment([2011, 0, 1]).format('DDDo'), '1r', '1r');
     assert.equal(moment([2011, 0, 2]).format('DDDo'), '2n', '2n');
@@ -470,6 +495,6 @@ test('weeks year starting sunday formatted', function (assert) {
 
 test('day and month', function (assert) {
     assert.equal(moment([2012, 1, 15]).format('D MMMM'), '15 de febrer');
-    assert.equal(moment([2012, 9, 15]).format('D MMMM'), "15 d'octubre");
+    assert.equal(moment([2012, 9, 15]).format('D MMMM'), "15 d’octubre");
     assert.equal(moment([2012, 9, 15]).format('MMMM, D'), 'octubre, 15');
 });


### PR DESCRIPTION
This PR adopts curly quotes in the Catalan localization.

I’ll quote (pun intended) typographer [Matthew Butterick](https://practicaltypography.com/straight-and-curly-quotes.html):

> _Curly quotes_ are the quo­ta­tion marks used in good ty­pog­ra­phy. (...)
> 
> Straight quotes are a [type­writer habit](https://practicaltypography.com/typewriter-habits.html). In tra­di­tional print­ing, all quo­ta­tion marks were curly. But type­writer char­ac­ter sets were lim­ited by me­chan­i­cal con­straints and phys­i­cal space. By re­plac­ing the curly open­ing and clos­ing quotes with am­bidex­trous straight quotes, two slots be­came avail­able for other characters. 
>
> Word proces­sors are not lim­ited in this way. You can al­ways get curly quotes. Com­pared to straight quotes, curly quotes are more leg­i­ble on the page and match the other char­ac­ters bet­ter. *There­fore, straight quotes should never, ever ap­pear in your documents.*

For those of us who care about typography, straight quotes in user-facing code are akin to a bug.

I’ve included a few focused tests and adjusted an existing one.

Would you consider this, @juanghurtado?

Thank you so much in advance!