### PR TITLE
[feature] add toDateString and toDateTimeString helper methods #6312

### DIFF
--- a/src/lib/moment/prototype.js
+++ b/src/lib/moment/prototype.js
@@ -193,5 +193,13 @@ proto.isDSTShifted = deprecate(
     'isDSTShifted is deprecated. See http://momentjs.com/guides/#/warnings/dst-shifted/ for more information',
     isDaylightSavingTimeShifted
 );
+// -- Added helper methods --
+proto.toDateString = function () {
+    return this.format('YYYY-MM-DD');
+};
+
+proto.toDateTimeString = function () {
+    return this.format('YYYY-MM-DD HH:mm:ss');
+};
 
 export default proto;

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -949,3 +949,13 @@ test('does not modify original moment instance', function (assert) {
         'issue #5681 regression'
     );
 });
+
+test('toDateString returns correct format', function (assert) {
+    var m = moment('2025-06-27T18:12:45');
+    assert.equal(m.toDateString(), '2025-06-27');
+});
+
+test('toDateTimeString returns correct format', function (assert) {
+    var m = moment('2025-06-27T18:12:45');
+    assert.equal(m.toDateTimeString(), '2025-06-27 18:12:45');
+});


### PR DESCRIPTION
What
Adds two helper methods to the Moment.js prototype:

toDateString() — formats the date as YYYY-MM-DD
toDateTimeString() — formats the date and time as YYYY-MM-DD HH:mm:ss
These are inspired by Laravel's Carbon library and simplify backend date formatting use cases.

Why
Developers working with SQL or backend systems often need these formats. This avoids repetitive .format() calls and improves developer experience.

Tests
Added tests in src/test/moment/format.js
Verified that both methods return expected output
All existing tests pass
Closes https://github.com/moment/moment/issues/6236