### PR TITLE
[locale] Fix Swahili spelling of hour from saat to saa

### DIFF
--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -27,9 +27,9 @@ export default moment.defineLocale('sw', {
     calendar: {
         sameDay: '[leo saa] LT',
         nextDay: '[kesho saa] LT',
-        nextWeek: '[wiki ijayo] dddd [saat] LT',
+        nextWeek: '[wiki ijayo] dddd [saa] LT',
         lastDay: '[jana] LT',
-        lastWeek: '[wiki iliyopita] dddd [saat] LT',
+        lastWeek: '[wiki iliyopita] dddd [saa] LT',
         sameElse: 'L',
     },
     relativeTime: {

--- a/src/test/locale/sw.js
+++ b/src/test/locale/sw.js
@@ -358,19 +358,19 @@ test('calendar next week', function (assert) {
         m = moment().add({ d: i });
         assert.equal(
             m.calendar(),
-            m.format('[wiki ijayo] dddd [saat] LT'),
+            m.format('[wiki ijayo] dddd [saa] LT'),
             'Today + ' + i + ' days current time'
         );
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
         assert.equal(
             m.calendar(),
-            m.format('[wiki ijayo] dddd [saat] LT'),
+            m.format('[wiki ijayo] dddd [saa] LT'),
             'Today + ' + i + ' days beginning of day'
         );
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
         assert.equal(
             m.calendar(),
-            m.format('[wiki ijayo] dddd [saat] LT'),
+            m.format('[wiki ijayo] dddd [saa] LT'),
             'Today + ' + i + ' days end of day'
         );
     }
@@ -383,19 +383,19 @@ test('calendar last week', function (assert) {
         m = moment().subtract({ d: i });
         assert.equal(
             m.calendar(),
-            m.format('[wiki iliyopita] dddd [saat] LT'),
+            m.format('[wiki iliyopita] dddd [saa] LT'),
             'Today - ' + i + ' days current time'
         );
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
         assert.equal(
             m.calendar(),
-            m.format('[wiki iliyopita] dddd [saat] LT'),
+            m.format('[wiki iliyopita] dddd [saa] LT'),
             'Today - ' + i + ' days beginning of day'
         );
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
         assert.equal(
             m.calendar(),
-            m.format('[wiki iliyopita] dddd [saat] LT'),
+            m.format('[wiki iliyopita] dddd [saa] LT'),
             'Today - ' + i + ' days end of day'
         );
     }


### PR DESCRIPTION
- In Swahili "hour" does not have letter "t" at the end

`moment\src\locale\sw.js`
```diff
 calendar: {
     sameDay: '[leo saa] LT',
     nextDay: '[kesho saa] LT',
-    nextWeek: '[wiki ijayo] dddd [saat] LT',
+    nextWeek: '[wiki ijayo] dddd [saa] LT',
     lastDay: '[jana] LT',
-    lastWeek: '[wiki iliyopita] dddd [saat] LT',
+    lastWeek: '[wiki iliyopita] dddd [saa] LT',
     sameElse: 'L',
 },