### PR TITLE
[misc] use https momentjs.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Moment.js](http://momentjs.com/)
+# [Moment.js](https://momentjs.com/)
 
 [![NPM version][npm-version-image]][npm-url]
 [![NPM downloads][npm-downloads-image]][npm-downloads-url]


### PR DESCRIPTION
### Summary
Switch the Moment.js homepage link in the README from HTTP to HTTPS.

### Details
Updates:
- `http://momentjs.com/` → `https://momentjs.com/`

This keeps the README pointing at the canonical secure URL.