### PR TITLE
[misc] Clarify FAQ TypeScript section heading

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -23,6 +23,6 @@ If you don't have these config above, the default import won't work, and you'll 
 
 Note: It is recommended to use `import moment from 'moment'`.
 
-### Case and Program
+### Cases and problems
 
 Known cases so far: [#5444](https://github.com/moment/moment/issues/5444), [#5248](https://github.com/moment/moment/issues/5348) and [#5449](https://github.com/moment/moment/issues/5449).


### PR DESCRIPTION
## Problem

The TypeScript FAQ currently contains a section heading labeled `Case and Program`, which is confusing and does not accurately describe the content below it. The section simply links to several known GitHub issues, so the heading appears to be a typographical error and can be misleading to readers scanning the document.

## Solution

Rename the FAQ section heading from `Case and Program` to `Cases and problems` to better reflect that the section lists known issue cases and related problems.

This change is limited to a single Markdown heading in `FAQ.md`.

## Impact

- **Readability**: Makes the FAQ clearer for TypeScript users by using a more descriptive heading.
- **Maintainability**: Aligns documentation wording with the actual content, reducing potential confusion for future contributors and users.

## Notes

- This change only updates documentation and does **not** modify any runtime code or public APIs.
- Backward compatibility is fully preserved.
