### PR TITLE
[tests] Fix strict flag assertion message

### DIFF
--- a/src/test/moment/creation-data.js
+++ b/src/test/moment/creation-data.js
@@ -35,6 +35,6 @@ test('strict', function (assert) {
     );
     assert.ok(
         !moment('2015-01-02', 'YYYY-MM-DD').creationData().strict,
-        'strict is true'
+        'strict is false'
     );
 });


### PR DESCRIPTION
## Problem

In the `creation-data` test suite (`src/test/moment/creation-data.js`), the second assertion in the `strict` test verifies that `creationData().strict` is **false** when `moment` is called without the strict flag. However, the assertion message currently reads `strict is true`, which contradicts the actual expectation and can be misleading when the test fails.

## Solution

Update the assertion message for the non-strict case from `strict is true` to `strict is false` so that the human-readable message correctly reflects the expected value of the `strict` flag.

This change affects only the test description string and does not alter the test logic or runtime behavior.

## Impact

- **Clarity**: Makes the `strict` test easier to understand by aligning the assertion message with the actual condition being tested.
- **Debugging**: Reduces confusion when reading test failures, since the failure message will now accurately describe the expected behavior.

## Backward Compatibility

- No production code, public APIs, or typings are modified.
- The change is limited to a single test assertion message and is fully backward compatible.
