### PR TITLE
[misc] fix typo in transpile task description

### DIFF
--- a/tasks/transpile.js
+++ b/tasks/transpile.js
@@ -348,7 +348,7 @@ module.exports = function (grunt) {
 
     grunt.task.registerTask(
         'transpile',
-        'builds all es5 files, optinally creating custom locales',
+        'builds all es5 files, optionally creating custom locales',
         function (locales) {
             var tasks = ['clean:build', 'transpile-raw', 'concat:tests'];
 


### PR DESCRIPTION
Fix typo 'optinally' → 'optionally' in the grunt task description in tasks/transpile.js