### PR TITLE
[bugfix] add/subtract days across midnight DST transitions

### DIFF
--- a/src/lib/moment/add-subtract.js
+++ b/src/lib/moment/add-subtract.js
@@ -1,4 +1,4 @@
-import { get, set } from './get-set';
+import { get } from './get-set';
 import { setMonth } from '../units/month';
 import { createDuration } from '../duration/create';
 import { deprecateSimple } from '../utils/deprecate';
@@ -47,7 +47,7 @@ export function addSubtract(mom, duration, isAdding, updateOffset) {
         setMonth(mom, get(mom, 'Month') + months * isAdding);
     }
     if (days) {
-        set(mom, 'Date', get(mom, 'Date') + days * isAdding);
+        addDays(mom, days * isAdding);
     }
     if (milliseconds) {
         mom._d.setTime(mom._d.valueOf() + milliseconds * isAdding);
@@ -55,6 +55,31 @@ export function addSubtract(mom, duration, isAdding, updateOffset) {
     if (updateOffset) {
         hooks.updateOffset(mom, days || months);
     }
+}
+
+// Add `days` to `mom` while preserving the local time-of-day. Native
+// `Date#setDate` can leave the local hour shifted around midnight DST
+// transitions (e.g. America/Santiago, where DST kicks in at 00:00 and
+// `setDate(d+1)` from midnight lands on 23:00 of the previous day).
+// To handle that, advance the timestamp by `days * 86400000` ms and then
+// adjust by the difference between the source and destination timezone
+// offsets so the local wall-clock time stays the same. See #4743.
+function addDays(mom, days) {
+    var d = mom._d,
+        srcOffset,
+        target,
+        dstOffset;
+    if (mom._isUTC) {
+        d.setUTCDate(d.getUTCDate() + days);
+        return;
+    }
+    srcOffset = d.getTimezoneOffset();
+    target = d.valueOf() + days * 864e5;
+    dstOffset = new Date(target).getTimezoneOffset();
+    if (srcOffset !== dstOffset) {
+        target += (dstOffset - srcOffset) * 6e4;
+    }
+    d.setTime(target);
 }
 
 export var add = createAdder(1, 'add'),

--- a/src/test/moment/add_subtract.js
+++ b/src/test/moment/add_subtract.js
@@ -422,6 +422,49 @@ test('add across DST', function (assert) {
     );
 });
 
+test('issue 4743: add days across midnight DST transition', function (assert) {
+    // Simulate a timezone like America/Santiago whose DST starts at 00:00
+    // local time. Native Date#setDate is unreliable for the moment of the
+    // transition because the wall-clock midnight does not exist locally,
+    // and V8 may resolve the gap by stepping the local hour backward,
+    // producing a result on the previous calendar date. moment should
+    // still advance the date by one full day. See #4743.
+    // 2018-08-12 04:00 UTC == 2018-08-12 00:00 in -04:00, the last instant
+    // of standard time. From this UTC instant onward, the offset is -03:00.
+    var origGetTimezoneOffset = Date.prototype.getTimezoneOffset,
+        dstStartUTC = Date.UTC(2018, 7, 12, 4),
+        startUTC,
+        m,
+        m2;
+    Date.prototype.getTimezoneOffset = function () {
+        return this.valueOf() < dstStartUTC ? 240 : 180;
+    };
+    try {
+        // 2018-08-11 00:00 in -04:00 == 2018-08-11 04:00 UTC
+        startUTC = Date.UTC(2018, 7, 11, 4);
+        m = moment(startUTC).add(1, 'day');
+        // Expected: 2018-08-12 00:00 in -03:00 == 2018-08-12 03:00 UTC
+        assert.equal(
+            m.valueOf(),
+            Date.UTC(2018, 7, 12, 3),
+            'add 1 day at midnight DST should advance the local date by 1 day'
+        );
+
+        // Going the other way across the gap: 2018-08-13 00:00 in -03:00
+        // minus one day. Local 2018-08-12 00:00 does not exist, so the
+        // result will be the first valid local instant on Aug 12 (01:00),
+        // but the calendar date must still advance backward by one day.
+        m2 = moment(Date.UTC(2018, 7, 13, 3)).subtract(1, 'day');
+        assert.equal(
+            m2.valueOf(),
+            Date.UTC(2018, 7, 12, 4),
+            'subtract 1 day at midnight DST should retreat the local date by 1 day'
+        );
+    } finally {
+        Date.prototype.getTimezoneOffset = origGetTimezoneOffset;
+    }
+});
+
 test('add decimal values of days and months', function (assert) {
     assert.equal(
         moment([2016, 3, 3]).add(1.5, 'days').date(),


### PR DESCRIPTION
## Summary

Fixes #4743.

In timezones whose DST transition happens at 00:00 local time (e.g. **America/Santiago**), `moment(...).add(1, 'day')` could leave the local hour shifted backward, producing a result on the **previous calendar date**. The user-visible symptom is duplicated dates when iterating with `.add(1, 'day')`:

```js
// In America/Santiago:
moment('2018-08-11 00:00').add(1, 'day').format('YYYY-MM-DD')
// → '2018-08-11'  (expected '2018-08-12')
```

## Root cause

The current implementation calls `set(mom, 'Date', get(mom, 'Date') + days)` which delegates to native `Date#setDate`. `setDate` has to resolve a local wall-clock time, and when the resulting wall-clock time falls inside a DST gap (like Santiago's 00:00 → 01:00 jump), V8 picks the instant just before the transition, which silently lands on the previous day.

## Fix

Replace the `set('Date', ...)` call with a small `addDays` helper inside `add-subtract.js` that:

1. Advances the timestamp by `days * 86400000` ms.
2. Compares the source and destination `getTimezoneOffset()` values, and compensates for any DST offset delta so the local time-of-day is preserved across normal DST transitions.
3. Always advances (or retreats) the calendar date by the requested number of days, even when the target wall-clock midnight falls inside a DST gap.

UTC moments still go through `setUTCDate` directly (no DST concerns).

## Test

Adds a regression test that simulates Santiago by mocking `Date.prototype.getTimezoneOffset`, exercising both `add` and `subtract` across the midnight DST gap. The test fails on `develop` and passes with this fix.

The existing `add across DST` test (US Mar 12 2011 at 05:00) continues to pass on every supported timezone.

## Test plan

- [x] `npx grunt test:node` — all 3872 tests pass (162870 assertions)
- [x] New regression test fails on `develop` and passes with the fix
- [x] `prettier --check` and `eslint` clean