### PR TITLE
Suppress Webpack/Vite "Can't resolve './locale'" warning (#6092)

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -69,8 +69,7 @@ function isLocaleNameSane(name) {
 }
 
 function loadLocale(name) {
-    var oldLocale = null,
-        aliasedRequire;
+    var oldLocale = null;
     // TODO: Find a better way to register and load all the locales in Node
     if (
         locales[name] === undefined &&
@@ -81,8 +80,16 @@ function loadLocale(name) {
     ) {
         try {
             oldLocale = globalLocale._abbr;
-            aliasedRequire = require;
-            aliasedRequire('./locale/' + name);
+            // The webpackIgnore / @vite-ignore magic comments instruct
+            // Webpack and Vite to leave this `require` alone, so they no
+            // longer emit a "Can't resolve './locale'" warning when moment
+            // is bundled. In bundled environments the call will simply
+            // throw at runtime (caught below), and consumers should
+            // import the locales they need explicitly. In Node.js the
+            // call still works as before. See #6092.
+            require(
+                /* webpackIgnore: true */ /* @vite-ignore */ './locale/' + name
+            );
             getSetGlobalLocale(oldLocale);
         } catch (e) {
             // mark as not found to avoid repeating expensive file require call causing high CPU


### PR DESCRIPTION
## Summary

Fixes #6092.

The dynamic `require('./locale/' + name)` inside `loadLocale` causes Webpack 5 (and Vite) to emit a `Module not found: Can't resolve './locale'` warning whenever moment is bundled, because bundlers try to statically resolve the dynamic require path. The existing `aliasedRequire = require` workaround no longer hides the call from modern bundlers when moment is inlined into another package (see the issue thread).

## Fix

Drop the `aliasedRequire` indirection and call `require` directly with both the **`webpackIgnore: true`** and **`@vite-ignore`** magic comments. Both bundlers honour these comments and leave the require call alone, so the warning disappears.

```js
require(
    /* webpackIgnore: true */ /* @vite-ignore */ './locale/' + name
);
```

## Behavior

- **Node.js**: unchanged — the dynamic require resolves and the locale file is loaded exactly as before. Verified with `moment.locale('fr')` / `moment.locale('de')` against the built UMD bundle.
- **Bundled (Webpack/Vite)**: the require call is preserved as-is in the output. At runtime in a browser there is no `require`, so the call throws and is caught by the existing `try`/`catch`, marking the locale as not found. This matches the recommended pattern for bundled environments (import locales explicitly, or use `IgnorePlugin` / `moment-locales-webpack-plugin`), and removes the long-standing build warning.
- **Older bundlers** that don't recognise the magic comments: the comments are simply ignored — no regression.

## Test plan

- [x] `npx grunt test:node` — all 3872 tests pass
- [x] Manual verification: `moment.locale('fr')` and `moment.locale('de')` still load correctly in Node from the built `build/umd/moment.js`
- [x] `prettier --check` and `eslint` clean