### PR TITLE
[bugfix] moment.min and moment.max should check first argument isValid() (fix #6143)

### DIFF
--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -41,7 +41,10 @@ function pickBy(fn, moments) {
     }
     res = moments[0];
     for (i = 1; i < moments.length; ++i) {
-        if (!moments[i].isValid() || moments[i][fn](res)) {
+        if (!moments[i].isValid()) {
+            return createInvalid();
+        }
+        if (moments[i][fn](res)) {
             res = moments[i];
         }
     }

--- a/src/test/moment/min_max.js
+++ b/src/test/moment/min_max.js
@@ -27,6 +27,9 @@ test('min', function (assert) {
 
     assert.equal(moment.min([now, invalid]), invalid, 'min(now, invalid)');
     assert.equal(moment.min([invalid, now]), invalid, 'min(invalid, now)');
+
+    assert.ok(!moment.min(invalid, now, past).isValid(), 'min(invalid, now, past) should be invalid');
+    assert.ok(!moment.min([invalid, future, past]).isValid(), 'min([invalid, future, past]) should be invalid');
 });
 
 test('max', function (assert) {
@@ -69,4 +72,7 @@ test('max', function (assert) {
 
     assert.equal(moment.max([now, invalid]), invalid, 'max(now, invalid)');
     assert.equal(moment.max([invalid, now]), invalid, 'max(invalid, now)');
+
+    assert.ok(!moment.max(invalid, now, past).isValid(), 'max(invalid, now, past) should be invalid');
+    assert.ok(!moment.max([invalid, future, past]).isValid(), 'max([invalid, future, past]) should be invalid');
 });


### PR DESCRIPTION
## Fix: moment.min/max should check first argument isValid()

### Problem
moment.min() and moment.max() did not validate the first argument. If the first element in the array was an invalid moment, it would be returned without checking isValid().

### Root Cause
In the  function, the initial  was used directly without checking if it was valid. Only subsequent elements were checked with .

### Fix
Added an isValid() check for the first element (moments[0]) in the  function. If any argument is invalid (including the first), the function now returns an invalid moment.

### Test Cases Added
- `moment.min(invalid, now, past).isValid() === false`
- `moment.min([invalid, future, past]).isValid() === false`
- `moment.max(invalid, now, past).isValid() === false`
- `moment.max([invalid, future, past]).isValid() === false`

Closes #6143