### PR TITLE
[locale] Add Ottoman Turkish (ota)

### DIFF
--- a/src/locale/ota.js
+++ b/src/locale/ota.js
@@ -1,0 +1,118 @@
+//! moment.js locale configuration
+//! locale : Ottoman Turkish [ota]
+//! authors : Ahmet Selim Çeleğen : https://github.com/as-celegen,
+//!           Bilal Harun : https://github.com/bilalharun
+
+import moment from '../moment';
+
+var symbolMap = {
+        1: '١',
+        2: '٢',
+        3: '٣',
+        4: '٤',
+        5: '٥',
+        6: '٦',
+        7: '٧',
+        8: '٨',
+        9: '٩',
+        0: '٠',
+    },
+    numberMap = {
+        '١': '1',
+        '٢': '2',
+        '٣': '3',
+        '٤': '4',
+        '٥': '5',
+        '٦': '6',
+        '٧': '7',
+        '٨': '8',
+        '٩': '9',
+        '٠': '0',
+    };
+
+export default moment.defineLocale('ota', {
+    months: 'اوجاق_شباط_مارت_نیسان_مایس_حزیران_تموز_آغستوس_ایلول_أكيم_قاسم_آرالق'.split(
+        '_'
+    ),
+    monthsShort: 'اوج_شب_مار_نیس_مای_حز_تم_آغس_ایل_أكي_قاس_آرا'.split('_'),
+    weekdays: 'پازار_پازارایرتسی_صالی_چهارشنبە_پرشنبە_جمعە_جمعەایرتسی'.split(
+        '_'
+    ),
+    weekdaysShort: 'پاز_پازت_صال_چهار_پرش_جم_جمت'.split('_'),
+    weekdaysMin: 'پز_پت_صا_چه_پر_جم_جت'.split('_'),
+    weekdaysParseExact: true,
+    meridiem: function (hours, minutes, isLower) {
+        if (hours < 12) {
+            return 'أوأو';
+        } else {
+            return 'أوص';
+        }
+    },
+    meridiemParse: /أوأو|أوص/,
+    isPM: function (input) {
+        return input === 'أوص';
+    },
+    longDateFormat: {
+        LT: 'HH:mm',
+        LTS: 'HH:mm:ss',
+        L: 'DD.MM.YYYY',
+        LL: 'D MMMM YYYY',
+        LLL: 'D MMMM YYYY HH:mm',
+        LLLL: 'dddd, D MMMM YYYY HH:mm',
+    },
+    calendar: {
+        sameDay: '[بوگون ساعت] LT',
+        nextDay: '[یارین ساعت] LT',
+        nextWeek: '[گلەجك] dddd [ساعت] LT',
+        lastDay: '[دون] LT',
+        lastWeek: '[گچن] dddd [ساعت] LT',
+        sameElse: 'L',
+    },
+    relativeTime: {
+        future: '%s صوڭرە',
+        past: '%s أوڭجە',
+        s: 'بر قاچ ثانیە',
+        ss: '%d ثانیە',
+        m: 'بر دقیقە',
+        mm: '%d دقیقە',
+        h: 'بر ساعت',
+        hh: '%d ساعت',
+        d: 'بر گون',
+        dd: '%d گون',
+        w: 'بر هفتە',
+        ww: '%d هفتە',
+        M: 'بر آی',
+        MM: '%d آی',
+        y: 'بر ییل',
+        yy: '%d ییل',
+    },
+    ordinal: function (number, period) {
+        switch (period) {
+            case 'd':
+            case 'D':
+            case 'Do':
+            case 'DD':
+                return number;
+            default:
+                return number + "'نجی";
+        }
+    },
+    preparse: function (string) {
+        return string
+            .replace(/[١٢٣٤٥٦٧٨٩٠]/g, function (match) {
+                return numberMap[match];
+            })
+            .replace(/،/g, ',');
+    },
+    postformat: function (string) {
+        return string
+            .replace(/\d/g, function (match) {
+                return symbolMap[match];
+            })
+            .replace(/,/g, '،');
+    },
+    week: {
+        dow: 1, // Monday is the first day of the week.
+        doy: 7, // The week that contains Jan 7th is the first week of the year.
+    },
+});

--- a/src/test/locale/ota.js
+++ b/src/test/locale/ota.js
@@ -1,0 +1,199 @@
+import { test } from '../qunit';
+import { localeModule } from '../qunit-locale';
+import moment from '../../moment';
+localeModule('ota');
+
+var months =
+    'اوجاق_شباط_مارت_نیسان_مایس_حزیران_تموز_آغستوس_ایلول_أكيم_قاسم_آرالق'.split(
+        '_'
+    );
+
+test('parse', function (assert) {
+    var tests = months,
+        i;
+    function equalTest(input, mmm, i) {
+        assert.equal(
+            moment(input, mmm).month(),
+            i,
+            input + ' should be month ' + (i + 1)
+        );
+    }
+
+    for (i = 0; i < 12; i++) {
+        equalTest(tests[i], 'MMMM', i);
+        equalTest(tests[i].toLocaleLowerCase(), 'MMMM', i);
+        equalTest(tests[i].toLocaleUpperCase(), 'MMMM', i);
+    }
+});
+
+test('format', function (assert) {
+    var a = [
+            [
+                'dddd, MMMM Do YYYY, h:mm:ss a',
+                'پازار، شباط ١٤ ٢٠١٠، ٣:٢٥:٥٠ أوص',
+            ],
+            ['ddd, hA', 'پاز، ٣أوص'],
+            ['M Mo MM MMMM MMM', "٢ ٢'نجی ٠٢ شباط شب"],
+            ['YYYY YY', '٢٠١٠ ١٠'],
+            ['D Do DD', '١٤ ١٤ ١٤'],
+            ['d do dddd ddd dd', '٠ ٠ پازار پاز پز'],
+            ['DDD DDDo DDDD', "٤٥ ٤٥'نجی ٠٤٥"],
+            ['w wo ww', "٧ ٧'نجی ٠٧"],
+            ['h hh', '٣ ٠٣'],
+            ['H HH', '١٥ ١٥'],
+            ['m mm', '٢٥ ٢٥'],
+            ['s ss', '٥٠ ٥٠'],
+            ['a A', 'أوص أوص'],
+            ['LTS', '١٥:٢٥:٥٠'],
+            ['L', '١٤.٠٢.٢٠١٠'],
+            ['LL', '١٤ شباط ٢٠١٠'],
+            ['LLL', '١٤ شباط ٢٠١٠ ١٥:٢٥'],
+            ['LLLL', 'پازار، ١٤ شباط ٢٠١٠ ١٥:٢٥'],
+            ['l', '١٤.٢.٢٠١٠'],
+            ['ll', '١٤ شب ٢٠١٠'],
+            ['lll', '١٤ شب ٢٠١٠ ١٥:٢٥'],
+            ['llll', 'پاز، ١٤ شب ٢٠١٠ ١٥:٢٥'],
+        ],
+        b = moment(new Date(2010, 1, 14, 15, 25, 50, 125)),
+        i;
+    for (i = 0; i < a.length; i++) {
+        assert.equal(b.format(a[i][0]), a[i][1], a[i][0] + ' ---> ' + a[i][1]);
+    }
+});
+
+test('format ordinal', function (assert) {
+    assert.equal(moment([2011, 0, 1]).format('DDDo'), "١'نجی", '1');
+    assert.equal(moment([2011, 0, 2]).format('DDDo'), "٢'نجی", '2');
+    assert.equal(moment([2011, 0, 3]).format('DDDo'), "٣'نجی", '3');
+    assert.equal(moment([2011, 0, 4]).format('DDDo'), "٤'نجی", '4');
+    assert.equal(moment([2011, 0, 5]).format('DDDo'), "٥'نجی", '5');
+    assert.equal(moment([2011, 0, 10]).format('DDDo'), "١٠'نجی", '10');
+    assert.equal(moment([2011, 0, 20]).format('DDDo'), "٢٠'نجی", '20');
+    assert.equal(moment([2011, 0, 31]).format('DDDo'), "٣١'نجی", '31');
+});
+
+test('format month', function (assert) {
+    var expected = months,
+        i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(
+            moment([2011, i, 1]).format('MMMM'),
+            expected[i],
+            expected[i]
+        );
+    }
+});
+
+test('format week', function (assert) {
+    var expected =
+            'پازار پاز پز_پازارایرتسی پازت پت_صالی صال صا_چهارشنبە چهار چه_پرشنبە پرش پر_جمعە جم جم_جمعەایرتسی جمت جت'.split(
+                '_'
+            ),
+        i;
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(
+            moment([2011, 0, 2 + i]).format('dddd ddd dd'),
+            expected[i],
+            expected[i]
+        );
+    }
+});
+
+test('from', function (assert) {
+    var start = moment([2007, 1, 28]);
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ s: 44 }), true),
+        'بر قاچ ثانیە',
+        '44 seconds = a few seconds'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ s: 45 }), true),
+        'بر دقیقە',
+        '45 seconds = a minute'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ m: 45 }), true),
+        'بر ساعت',
+        '45 minutes = an hour'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ h: 22 }), true),
+        'بر گون',
+        '22 hours = a day'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 26 }), true),
+        'بر آی',
+        '26 days = a month'
+    );
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ d: 345 }), true),
+        'بر ییل',
+        '345 days = a year'
+    );
+});
+
+test('suffix', function (assert) {
+    assert.equal(moment(30000).from(0), 'بر قاچ ثانیە صوڭرە', 'prefix');
+    assert.equal(moment(0).from(30000), 'بر قاچ ثانیە أوڭجە', 'suffix');
+});
+
+test('now from now', function (assert) {
+    assert.equal(
+        moment().fromNow(),
+        'بر قاچ ثانیە أوڭجە',
+        'now from now should display as in the past'
+    );
+});
+
+test('fromNow', function (assert) {
+    assert.equal(
+        moment().add({ s: 30 }).fromNow(),
+        'بر قاچ ثانیە صوڭرە',
+        'in a few seconds'
+    );
+    assert.equal(moment().add({ d: 5 }).fromNow(), '٥ گون صوڭرە', 'in 5 days');
+});
+
+test('calendar day', function (assert) {
+    var a = moment().hours(12).minutes(0).seconds(0);
+
+    assert.equal(
+        moment(a).calendar(),
+        'بوگون ساعت ١٢:٠٠',
+        'today at the same time'
+    );
+    assert.equal(
+        moment(a).add({ m: 25 }).calendar(),
+        'بوگون ساعت ١٢:٢٥',
+        'Now plus 25 min'
+    );
+    assert.equal(
+        moment(a).add({ h: 1 }).calendar(),
+        'بوگون ساعت ١٣:٠٠',
+        'Now plus 1 hour'
+    );
+    assert.equal(
+        moment(a).add({ d: 1 }).calendar(),
+        'یارین ساعت ١٢:٠٠',
+        'tomorrow at the same time'
+    );
+    assert.equal(
+        moment(a).subtract({ h: 1 }).calendar(),
+        'بوگون ساعت ١١:٠٠',
+        'Now minus 1 hour'
+    );
+    assert.equal(
+        moment(a).subtract({ d: 1 }).calendar(),
+        'دون ١٢:٠٠',
+        'yesterday at the same time'
+    );
+});
+
+test('weeks year starting sunday formatted', function (assert) {
+    assert.equal(
+        moment([2012, 0, 1]).format('w ww wo'),
+        "١ ٠١ ١'نجی",
+        'Jan 1 2012 should be week 1'
+    );
+});


### PR DESCRIPTION
## Summary

Adds a new locale for **Ottoman Turkish** using ISO 639-3 code `ota` (https://iso639-3.sil.org/code/ota).

The locale uses Ottoman script (Perso-Arabic) for month/weekday names and Arabic-Indic digits (٠-٩) for number postformatting, matching how Modern Turkish is written in Ottoman script.

### Why `ota` and not `os`

`os` (ISO 639-1) is Ossetic, not Ottoman. The correct ISO code for Ottoman Turkish is `ota` (ISO 639-3).

### Files

- `src/locale/ota.js` — locale definition
- `src/test/locale/ota.js` — QUnit tests covering parse, format, ordinal, weekdays, calendar, relative time

### Tests

- Lint passes (`grunt lint`).
- All locale-specific tests pass. Pre-existing failures in other locales on `develop` (yo, hr, lt, lv, vi, ss, ga, gd) are unrelated.

### CLA

I will sign the JS Foundation CLA before merge.