### PR TITLE
[bugfix] Fix compact e weekday parsing before time

### DIFF
--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -36,7 +36,7 @@ addFormatToken('E', 0, 0, 'isoWeekday');
 // PARSING
 
 addRegexToken('d', match1to2);
-addRegexToken('e', match1to2);
+addRegexToken('e', match1to2Weekday);
 addRegexToken('E', match1to2);
 addRegexToken('dd', function (isStrict, locale) {
     return locale.weekdaysMinRegex(isStrict);
@@ -79,6 +79,12 @@ function parseWeekday(input, locale) {
     }
 
     return null;
+}
+
+// In compact numeric formats like eHHmm, e must leave digits for the following
+// token while keeping wider separated inputs like "04" working.
+function match1to2Weekday() {
+    return /[0-6](?=\d{2})|\d\d?/;
 }
 
 function parseIsoWeekday(input, locale) {

--- a/src/test/moment/weekday.js
+++ b/src/test/moment/weekday.js
@@ -46,6 +46,17 @@ test('iso weekday', function (assert) {
     }
 });
 
+test('weekday parsing reads exactly one digit before time', function (assert) {
+    moment.locale('en');
+
+    var localeWeekday = moment('21530', 'eHHmm');
+
+    assert.equal(localeWeekday.isValid(), true, 'eHHmm is valid');
+    assert.equal(localeWeekday.weekday(), 2, 'e parses one digit');
+    assert.equal(localeWeekday.hour(), 15, 'e leaves hours intact');
+    assert.equal(localeWeekday.minute(), 30, 'e leaves minutes intact');
+});
+
 test('iso weekday setter', function (assert) {
     var a = moment([2011, 0, 10]);
     assert.equal(moment(a).isoWeekday(1).date(), 10, 'set from mon to mon');


### PR DESCRIPTION
Fixes #6116.

This updates the `e` weekday parser so compact numeric formats like `eHHmm` leave the following digits for the time tokens. It still preserves existing wider separated weekday parsing such as `04` in week-date formats.

Tests:
- `npx grunt test:node --only=moment/weekday`
- `npx grunt test:node --only=moment/weekday,moment/create`
- `npm run eslint`
- `npm run prettier-check`
- `npx grunt`
- `git diff --check`