### PR TITLE
[bugfix] Validate first argument in moment.min and moment.max

### DIFF
--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -2,6 +2,7 @@ import { deprecate } from '../utils/deprecate';
 import isArray from '../utils/is-array';
 import { createLocal } from '../create/local';
 import { createInvalid } from '../create/valid';
+import { isMoment } from './constructor';
 
 export var prototypeMin = deprecate(
         'moment().min is deprecated, use moment.max instead. http://momentjs.com/guides/#/warnings/min-max/',
@@ -39,8 +40,11 @@ function pickBy(fn, moments) {
     if (!moments.length) {
         return createLocal();
     }
-    res = moments[0];
+    res = isMoment(moments[0]) ? moments[0] : createLocal(moments[0]);
     for (i = 1; i < moments.length; ++i) {
+        if (!isMoment(moments[i])) {
+            moments[i] = createLocal(moments[i]);
+        }
         if (!moments[i].isValid() || moments[i][fn](res)) {
             res = moments[i];
         }

--- a/src/test/moment/min_max.js
+++ b/src/test/moment/min_max.js
@@ -27,6 +27,11 @@ test('min', function (assert) {
 
     assert.equal(moment.min([now, invalid]), invalid, 'min(now, invalid)');
     assert.equal(moment.min([invalid, now]), invalid, 'min(invalid, now)');
+
+    assert.ok(
+        !moment.min('invalid', now).isValid(),
+        'min(invalid string, now)'
+    );
 });
 
 test('max', function (assert) {
@@ -69,4 +74,9 @@ test('max', function (assert) {
 
     assert.equal(moment.max([now, invalid]), invalid, 'max(now, invalid)');
     assert.equal(moment.max([invalid, now]), invalid, 'max(invalid, now)');
+
+    assert.ok(
+        !moment.max('invalid', now).isValid(),
+        'max(invalid string, now)'
+    );
 });


### PR DESCRIPTION
## Problem
`moment.min` and `moment.max` validate later arguments during comparison, but the first argument is used as the initial result without being normalized first. If the first value is an invalid non-Moment input, it can be returned directly instead of producing an invalid Moment.

## Root cause
`pickBy` assigns `moments[0]` directly to `res`, while subsequent values are expected to be Moment instances and are checked with `.isValid()`.

## Fix
Normalize the first candidate with `createLocal` when it is not already a Moment, and do the same for subsequent non-Moment candidates before validity checks/comparisons.

## Testing
- Added regression coverage for `moment.min('invalid', now)`.
- Added regression coverage for `moment.max('invalid', now)`.
- Ran `git diff --check` successfully.

Fixes #6143