### PR TITLE
[bugfix] Fix uk locale week calculation according to ДСТУ ISO 8601:2010 

### DIFF
--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -2,6 +2,7 @@
 //! locale : Ukrainian [uk]
 //! author : zemlanin : https://github.com/zemlanin
 //! Author : Menelion Elensúle : https://github.com/Oire
+//! Author : Oleksandr Trukhnii : https://github.com/JohnJunior
 
 import moment from '../moment';
 
@@ -162,6 +163,6 @@ export default moment.defineLocale('uk', {
     },
     week: {
         dow: 1, // Monday is the first day of the week.
-        doy: 7, // The week that contains Jan 7th is the first week of the year.
+        doy: 4, // The week that contains Jan 4th is the first week of the year.
     },
 });

--- a/src/test/locale/uk.js
+++ b/src/test/locale/uk.js
@@ -57,7 +57,7 @@ test('format', function (assert) {
             ['D Do DD', '14 14-го 14'],
             ['d do dddd ddd dd', '0 0-й неділя нд нд'],
             ['DDD DDDo DDDD', '45 45-й 045'],
-            ['w wo ww', '7 7-й 07'],
+            ['w wo ww', '6 6-й 06'],
             ['h hh', '3 03'],
             ['H HH', '15 15'],
             ['m mm', '25 25'],
@@ -500,27 +500,27 @@ test('calendar all else', function (assert) {
 test('weeks year starting sunday formatted', function (assert) {
     assert.equal(
         moment([2011, 11, 26]).format('w ww wo'),
-        '1 01 1-й',
-        'Dec 26 2011 should be week 1'
+        '52 52 52-й',
+        'Dec 26 2011 should be week 52 of 2011'
     );
     assert.equal(
         moment([2012, 0, 1]).format('w ww wo'),
-        '1 01 1-й',
-        'Jan  1 2012 should be week 1'
+        '52 52 52-й',
+        'Jan  1 2012 should be week 52 of 2011'
     );
     assert.equal(
         moment([2012, 0, 2]).format('w ww wo'),
-        '2 02 2-й',
-        'Jan  2 2012 should be week 2'
+        '1 01 1-й',
+        'Jan  2 2012 should be week 1'
     );
     assert.equal(
         moment([2012, 0, 8]).format('w ww wo'),
-        '2 02 2-й',
-        'Jan  8 2012 should be week 2'
+        '1 01 1-й',
+        'Jan  8 2012 should be week 1'
     );
     assert.equal(
         moment([2012, 0, 9]).format('w ww wo'),
-        '3 03 3-й',
-        'Jan  9 2012 should be week 3'
+        '2 02 2-й',
+        'Jan  9 2012 should be week 2'
     );
 });


### PR DESCRIPTION
Hi, and thank you for moment.js — we rely on it heavily across our
projects, so first of all, thanks for all the work on it. 🙏 This is a
small fix for the Ukrainian locale.

### Summary

The Ukrainian locale currently computes week numbers incorrectly. It uses
`doy: 7`, which does not match the standard adopted in Ukraine.

Ukraine has a national standard for date and time representation,
**ДСТУ ISO 8601:2010**, which is identical to **ISO 8601:2004 (IDT)**.
Per that standard, the first week of the year is the week containing the
first Thursday (equivalently, the week containing January 4th), and the
week starts on Monday.

### Change

```diff
 week: {
     dow: 1, // Monday is the first day of the week.
-    doy: 7, // The week that contains Jan 7th is the first week of the year.
+    doy: 4, // The week that contains Jan 4th is the first week of the year.
 },
```

### Tests
Updated the expected values in src/test/locale/uk.js accordingly.
npx grunt passes fully — eslint, prettier-check, and the full test
suite (0 failed).

### Review
cc @zemlanin @Oire — you are listed as the authors of the uk locale,
so flagging this for your review as native speakers. If I should be
tagging someone else for locale/standards sign-off instead, please let
me know who to ping.

<img width="1023" height="520" alt="Screenshot at Jun 10 21-01-25" src="https://github.com/user-attachments/assets/3b968476-deac-4347-b9da-e6bd01a0af5d" />
<img width="969" height="519" alt="Screenshot at Jun 10 21-01-58" src="https://github.com/user-attachments/assets/890e46b0-08a7-4550-8f4e-17fb86f9dadc" />
