### PR TITLE
Fix 6295 format prototype keys

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -4,7 +4,7 @@ import isFunction from '../utils/is-function';
 var formattingTokens =
         /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g,
     localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g,
-    formatFunctions = {},
+    formatFunctions = Object.create(null),
     formatTokenFunctions = {};
 
 export { formattingTokens, formatTokenFunctions };

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -949,3 +949,19 @@ test('does not modify original moment instance', function (assert) {
         'issue #5681 regression'
     );
 });
+
+test('format with Object prototype keys', function (assert) {
+    var m = moment([2025, 2, 16]);
+
+    assert.notEqual(
+        m.format('constructor'),
+        m.toString(),
+        '"constructor" should not resolve to Object.prototype.constructor'
+    );
+
+    assert.notEqual(
+        m.format('toString'),
+        '[object Object]',
+        '"toString" should not resolve to Object.prototype.toString'
+    );
+});


### PR DESCRIPTION
This PR fixes an issue where `moment().format()` incorrectly resolves Object prototype keys (`constructor, toString`) instead of treating them as regular format strings.

The problem is caused by `formatFunctions` being initialized as a plain JavaScript object (`{}`), which inherits properties from `Object.prototype`.

This PR changes `formatFunctions` to use `Object.create(null)`, preventing inherited properties from interfering with formatter lookup.

### Before
```
> moment().format('constructor')
Moment<2024-10-15T16:56:29+02:00>
> moment().format('toString')
'[object Object]'
```
### After
```
moment().format("constructor");
// => con14tructor
moment().format("toString");
// => toP6/22/2026ing
```

Both strings are now processed by Moment's normal formatting rules instead of resolving inherited `Object.prototype` properties.

Tests

Added a unit test covering formatting with Object prototype keys.

Fixes #6295.