### PR TITLE
[codex] Fix array item checks for moment input

### DIFF
--- a/src/lib/utils/is-moment-input.js
+++ b/src/lib/utils/is-moment-input.js
@@ -68,7 +68,7 @@ function isNumberOrStringArray(input) {
     if (arrayTest) {
         dataTypeTest =
             input.filter(function (item) {
-                return !isNumber(item) && isString(input);
+                return !isNumber(item) && !isString(item);
             }).length === 0;
     }
     return arrayTest && dataTypeTest;

--- a/src/test/moment/is_moment_input.js
+++ b/src/test/moment/is_moment_input.js
@@ -1,0 +1,18 @@
+import { module, test } from '../qunit';
+import { isMomentInput } from '../../lib/utils/is-moment-input';
+
+module('is moment input');
+
+test('isMomentInput recognizes arrays of numbers and strings', function (assert) {
+    assert.ok(isMomentInput([]), 'empty array');
+    assert.ok(isMomentInput([2010, 0, 1]), 'number array');
+    assert.ok(isMomentInput(['2010', '0', '1']), 'string array');
+    assert.ok(isMomentInput([2010, '0']), 'mixed number and string array');
+});
+
+test('isMomentInput rejects arrays with other item types', function (assert) {
+    assert.ok(!isMomentInput([2010, {}]), 'object item');
+    assert.ok(!isMomentInput([2010, null]), 'null item');
+    assert.ok(!isMomentInput([2010, undefined]), 'undefined item');
+    assert.ok(!isMomentInput([2010, new Date()]), 'date item');
+});


### PR DESCRIPTION
## Summary
- Check each array item with isString instead of checking the whole input array while validating moment inputs.

## Validation
- targeted grunt tests, eslint, prettier check, and full npm test passed.

## Notes
- Opened as a draft PR for maintainer review.
