### PR TITLE
[bugfix] Fix hu locale relative time ss ternary precedence

### DIFF
--- a/src/locale/hu.js
+++ b/src/locale/hu.js
@@ -15,9 +15,7 @@ function translate(number, withoutSuffix, key, isFuture) {
                 ? 'néhány másodperc'
                 : 'néhány másodperce';
         case 'ss':
-            return num + (isFuture || withoutSuffix)
-                ? ' másodperc'
-                : ' másodperce';
+            return num + (isFuture || withoutSuffix ? ' másodperc' : ' másodperce');
         case 'm':
             return 'egy' + (isFuture || withoutSuffix ? ' perc' : ' perce');
         case 'mm':

--- a/src/locale/hu.js
+++ b/src/locale/hu.js
@@ -15,7 +15,9 @@ function translate(number, withoutSuffix, key, isFuture) {
                 ? 'néhány másodperc'
                 : 'néhány másodperce';
         case 'ss':
-            return num + (isFuture || withoutSuffix ? ' másodperc' : ' másodperce');
+            return (
+                num + (isFuture || withoutSuffix ? ' másodperc' : ' másodperce')
+            );
         case 'm':
             return 'egy' + (isFuture || withoutSuffix ? ' perc' : ' perce');
         case 'mm':

--- a/src/test/locale/hu.js
+++ b/src/test/locale/hu.js
@@ -307,6 +307,25 @@ test('suffix', function (assert) {
     assert.equal(moment(0).from(30000), 'néhány másodperce', 'suffix');
 });
 
+test('from ss threshold set', function (assert) {
+    var start = moment([2007, 1, 28]),
+        s = moment.relativeTimeThreshold('s'),
+        ss = moment.relativeTimeThreshold('ss');
+    moment.relativeTimeThreshold('s', 45);
+    moment.relativeTimeThreshold('ss', 10);
+
+    assert.equal(
+        start.from(moment([2007, 1, 28]).add({ s: 11 }), true),
+        '11 másodperc',
+        '11 seconds = 11 seconds'
+    );
+    assert.equal(moment(0).from(11000), '11 másodperce', '11 seconds ago with suffix');
+    assert.equal(moment(11000).from(0), '11 másodperc múlva', '11 seconds future with suffix');
+
+    moment.relativeTimeThreshold('s', s);
+    moment.relativeTimeThreshold('ss', ss);
+});
+
 test('now from now', function (assert) {
     assert.equal(
         moment().fromNow(),

--- a/src/test/locale/hu.js
+++ b/src/test/locale/hu.js
@@ -319,8 +319,16 @@ test('from ss threshold set', function (assert) {
         '11 másodperc',
         '11 seconds = 11 seconds'
     );
-    assert.equal(moment(0).from(11000), '11 másodperce', '11 seconds ago with suffix');
-    assert.equal(moment(11000).from(0), '11 másodperc múlva', '11 seconds future with suffix');
+    assert.equal(
+        moment(0).from(11000),
+        '11 másodperce',
+        '11 seconds ago with suffix'
+    );
+    assert.equal(
+        moment(11000).from(0),
+        '11 másodperc múlva',
+        '11 seconds future with suffix'
+    );
 
     moment.relativeTimeThreshold('s', s);
     moment.relativeTimeThreshold('ss', ss);


### PR DESCRIPTION
## Summary

Fixes #6294

The `ss` branch in `translate()` in `src/locale/hu.js` parsed as `(num + (isFuture || withoutSuffix)) ? ...` because of ternary precedence, so the number was dropped for suffixed relative time strings.

Align the `ss` case with the other numeric units (`mm`, `hh`, etc.) by grouping the ternary with the suffix. Add locale tests that lower the `ss` threshold so the `ss` path is exercised with and without suffix.

## Test plan

- [x] `npx grunt test:single --grep="locale/hu"`