### PR TITLE
[bugfix] prevent object prototypes in format strings

### DIFF
--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -1,5 +1,6 @@
 import zeroFill from '../utils/zero-fill';
 import isFunction from '../utils/is-function';
+import hasOwnProp from '../utils/has-own-prop';
 
 var formattingTokens =
         /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g,
@@ -77,10 +78,12 @@ export function formatMoment(m, format) {
     }
 
     format = expandFormat(format, m.localeData());
-    formatFunctions[format] =
-        formatFunctions[format] || makeFormatFunction(format);
+    var cacheKey = '$' + format;
+    if (!hasOwnProp(formatFunctions, cacheKey)) {
+        formatFunctions[cacheKey] = makeFormatFunction(format);
+    }
 
-    return formatFunctions[format](m);
+    return formatFunctions[cacheKey](m);
 }
 
 export function expandFormat(format, locale) {

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -949,3 +949,23 @@ test('does not modify original moment instance', function (assert) {
         'issue #5681 regression'
     );
 });
+
+test('format strings matching Object prototype keys', function (assert) {
+    var m = moment([2025, 2, 16, 12, 34, 56, 789]);
+
+    assert.equal(
+        m.format('constructor'),
+        'con56tructor',
+        'constructor is treated as a format string'
+    );
+    assert.equal(
+        m.format('toString'),
+        'to7tring',
+        'toString is treated as a format string'
+    );
+    assert.equal(
+        m.format('__proto__'),
+        '__proto__',
+        '__proto__ is treated as a format string'
+    );
+});


### PR DESCRIPTION
Fixes #6295 