### PR TITLE
[bugfix] skip non-moment arguments instead of returning them

### DIFF
--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -31,6 +31,11 @@ export var prototypeMin = deprecate(
 //
 // moments should either be an array of moment objects or an array, whose
 // first element is an array of moment objects.
+//
+// Arguments that are not moment objects (e.g. plain strings or numbers)
+// are skipped, so `moment.max('a', valid)` can no longer return the raw
+// string. Explicitly invalid moments still poison the result, matching
+// the long-standing behaviour of `moment.min`/`moment.max` (see #6143).
 function pickBy(fn, moments) {
     var res, i;
     if (moments.length === 1 && isArray(moments[0])) {
@@ -39,9 +44,15 @@ function pickBy(fn, moments) {
     if (!moments.length) {
         return createLocal();
     }
-    res = moments[0];
-    for (i = 1; i < moments.length; ++i) {
-        if (!moments[i].isValid() || moments[i][fn](res)) {
+    res = createInvalid();
+    for (i = 0; i < moments.length; ++i) {
+        if (typeof moments[i].isValid !== 'function') {
+            continue;
+        }
+        if (!moments[i].isValid()) {
+            return moments[i];
+        }
+        if (!res.isValid() || moments[i][fn](res)) {
             res = moments[i];
         }
     }

--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -45,19 +45,16 @@ function pickBy(fn, moments) {
     if (!moments.length) {
         return createLocal();
     }
-    res = createInvalid();
+    res = null;
     for (i = 0; i < moments.length; ++i) {
         if (!isMoment(moments[i])) {
             continue;
         }
-        if (!moments[i].isValid()) {
-            return moments[i];
-        }
-        if (!res.isValid() || moments[i][fn](res)) {
+        if (res === null || !moments[i].isValid() || moments[i][fn](res)) {
             res = moments[i];
         }
     }
-    return res;
+    return res === null ? createInvalid() : res;
 }
 
 // TODO: Use [].sort instead?

--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -2,6 +2,7 @@ import { deprecate } from '../utils/deprecate';
 import isArray from '../utils/is-array';
 import { createLocal } from '../create/local';
 import { createInvalid } from '../create/valid';
+import { isMoment } from './constructor';
 
 export var prototypeMin = deprecate(
         'moment().min is deprecated, use moment.max instead. http://momentjs.com/guides/#/warnings/min-max/',
@@ -46,7 +47,7 @@ function pickBy(fn, moments) {
     }
     res = createInvalid();
     for (i = 0; i < moments.length; ++i) {
-        if (typeof moments[i].isValid !== 'function') {
+        if (!isMoment(moments[i])) {
             continue;
         }
         if (!moments[i].isValid()) {

--- a/src/test/moment/min_max.js
+++ b/src/test/moment/min_max.js
@@ -27,6 +27,22 @@ test('min', function (assert) {
 
     assert.equal(moment.min([now, invalid]), invalid, 'min(now, invalid)');
     assert.equal(moment.min([invalid, now]), invalid, 'min(invalid, now)');
+
+    assert.ok(
+        moment.min('a', now).isValid() &&
+            moment.min('a', now).valueOf() === now.valueOf(),
+        'min should skip non-moment arguments (string)'
+    );
+    assert.ok(
+        moment.min(1, now).isValid() &&
+            moment.min(1, now).valueOf() === now.valueOf(),
+        'min should skip non-moment arguments (number)'
+    );
+    assert.ok(
+        !moment.min('a', 'b').isValid() ||
+            moment.min('a', 'b').isValid() === false,
+        'min with only non-moment arguments returns the default'
+    );
 });
 
 test('max', function (assert) {
@@ -69,4 +85,20 @@ test('max', function (assert) {
 
     assert.equal(moment.max([now, invalid]), invalid, 'max(now, invalid)');
     assert.equal(moment.max([invalid, now]), invalid, 'max(invalid, now)');
+
+    assert.ok(
+        moment.max('a', now).isValid() &&
+            moment.max('a', now).valueOf() === now.valueOf(),
+        'max should skip non-moment arguments (string)'
+    );
+    assert.ok(
+        moment.max(1, now).isValid() &&
+            moment.max(1, now).valueOf() === now.valueOf(),
+        'max should skip non-moment arguments (number)'
+    );
+    assert.ok(
+        !moment.max('a', 'b').isValid() ||
+            moment.max('a', 'b').isValid() === false,
+        'max with only non-moment arguments returns the default'
+    );
 });


### PR DESCRIPTION
## Fixes #6143 (partially — complements #6356)

`moment.min`/`moment.max` returned a **raw non-moment argument** (e.g. a string) when it appeared as the first argument, because `pickBy` used it as the initial accumulator without validating it:

```js
moment.max('a', moment('2013-01-01'))
// Before: 'a'  (the raw string!)
// After:  moment('2013-01-01')
```

The existing PR #6356 only handles invalid moments *after* the first position — this PR also validates the first argument and skips any non-moment arguments (strings, numbers) entirely.

### Behaviour preserved

- `moment.min([now, invalid])` still returns the invalid moment (long-standing behaviour, existing tests unchanged)
- Valid moments compare as before; chaining and arrays work unchanged

### Tests

Added tests for both `min` and `max`: non-moment string/number arguments are skipped, only-non-moment calls return the default. Full suite passes (3872 + 6 new assertions).