### PR TITLE
[bugfix] Fix develop CI failures from recent locale changes

### DIFF
--- a/src/locale/am-et.js
+++ b/src/locale/am-et.js
@@ -2,67 +2,61 @@
 //! locale : Amharic (Ethiopia) [am-et]
 //! author : Tekle Ayele : https://github.com/tekleayele
 
-;(function (global, factory) {
-   typeof exports === 'object' && typeof module !== 'undefined'
-       && typeof require === 'function' ? factory(require('../moment')) :
-   typeof define === 'function' && define.amd ? define(['../moment'], factory) :
-   factory(global.moment)
-}(this, (function (moment) { 'use strict';
+import moment from '../moment';
 
-    //! moment.js locale configuration
-
-    var amEt = moment.defineLocale('am-et', {
-        months: 'ጃንዩወሪ_ፌብሩወሪ_ማርች_ኤፕሪል_ሜይ_ጁን_ጁላይ_ኦገስት_ሴፕቴምበር_ኦክቶበር_ኖቬምበር_ዲሴምበር'.split(
-            '_'
-        ),
-        monthsShort: 'ጃን_ፌብ_ማር_ኤፕር_ሜይ_ጁን_ጁላይ_ኦገ_ሴፕ_ኦክቶ_ኖቬ_ዲሴ'.split('_'),
-        weekdays: 'እሑድ_ሰኞ_ማክሰኞ_እሮብ_ሀሙስ_ዓርብ_ቅዳሜ'.split(
-            '_'
-        ),
-        weekdaysShort: 'እሑ_ሰኞ_ማክ_እሮ_ሀሙ_ዓር_ቅዳ'.split('_'),
-        weekdaysMin: 'እሁ_ሰ_ማ_እ_ሀ_ዓ_ቅ'.split('_'),
-        longDateFormat: {
-            LT: 'h:mm A',
-            LTS: 'h:mm:ss A',
-            L: 'DD/MM/YYYY',
-            LL: 'D MMMM YYYY',
-            LLL: 'D MMMM YYYY h:mm A',
-            LLLL: 'dddd, D MMMM YYYY h:mm A',
-        },
-        calendar: {
-            sameDay: '[ዛሬ በ] LT',
-            nextDay: '[ነገ በ] LT',
-            nextWeek: 'dddd [በ] LT',
-            lastDay: '[ትናንትና በ] LT',
-            lastWeek: '[ያለፈው ሳምንት] dddd [በ] LT',
-            sameElse: 'L',
-        },
-        relativeTime: {
-            future: '%s ውስጥ',
-            past: '%s በፊት',
-            s: 'ጥቂት ሰከንዶች',
-            ss: '%d ሰከንዶች',
-            m: 'አንድ ደቂቃ',
-            mm: '%d ደቂቃዎች',
-            h: 'አንድ ሰአት',
-            hh: '%d ሰአታት',
-            d: 'አንድ ቀን',
-            dd: '%d ቀናት',
-            M: 'አንድ ወር',
-            MM: '%d ወራት',
-            y: 'አንድ ዓመት',
-            yy: '%d ዓመታት',
-        },
-        dayOfMonthOrdinalParse: /\d{1,2}(ኛ)/,
-        ordinal: function (number) {
-            return number + 'ኛ';
-        },
-        week: {
-            dow: 1, // Monday is the first day of the week.
-            doy: 7, // The week that contains Jan 7th is the first week of the year.
-        },
-    });
-
-    return amEt;
-
-})));
+export default moment.defineLocale('am-et', {
+    months: 'ጃንዩወሪ_ፌብሩወሪ_ማርች_ኤፕሪል_ሜይ_ጁን_ጁላይ_ኦገስት_ሴፕቴምበር_ኦክቶበር_ኖቬምበር_ዲሴምበር'.split(
+        '_'
+    ),
+    monthsShort: 'ጃን_ፌብ_ማር_ኤፕር_ሜይ_ጁን_ጁላይ_ኦገ_ሴፕ_ኦክቶ_ኖቬ_ዲሴ'.split('_'),
+    weekdays: 'እሑድ_ሰኞ_ማክሰኞ_እሮብ_ሀሙስ_ዓርብ_ቅዳሜ'.split('_'),
+    weekdaysShort: 'እሑ_ሰኞ_ማክ_እሮ_ሀሙ_ዓር_ቅዳ'.split('_'),
+    weekdaysMin: 'እሁ_ሰ_ማ_እ_ሀ_ዓ_ቅ'.split('_'),
+    meridiemParse: /ጥዋት|ከሰዓት/,
+    isPM: function (input) {
+        return input === 'ከሰዓት';
+    },
+    meridiem: function (hours) {
+        return hours < 12 ? 'ጥዋት' : 'ከሰዓት';
+    },
+    longDateFormat: {
+        LT: 'h:mm A',
+        LTS: 'h:mm:ss A',
+        L: 'DD/MM/YYYY',
+        LL: 'D MMMM YYYY',
+        LLL: 'D MMMM YYYY h:mm A',
+        LLLL: 'dddd, D MMMM YYYY h:mm A',
+    },
+    calendar: {
+        sameDay: '[ዛሬ በ] LT',
+        nextDay: '[ነገ በ] LT',
+        nextWeek: 'dddd [በ] LT',
+        lastDay: '[ትናንትና በ] LT',
+        lastWeek: '[ያለፈው ሳምንት] dddd [በ] LT',
+        sameElse: 'L',
+    },
+    relativeTime: {
+        future: '%s ውስጥ',
+        past: '%s በፊት',
+        s: 'ጥቂት ሰከንዶች',
+        ss: '%d ሰከንዶች',
+        m: 'አንድ ደቂቃ',
+        mm: '%d ደቂቃዎች',
+        h: 'አንድ ሰአት',
+        hh: '%d ሰአታት',
+        d: 'አንድ ቀን',
+        dd: '%d ቀናት',
+        M: 'አንድ ወር',
+        MM: '%d ወራት',
+        y: 'አንድ ዓመት',
+        yy: '%d ዓመታት',
+    },
+    dayOfMonthOrdinalParse: /\d{1,2}(ኛ)/,
+    ordinal: function (number) {
+        return number + 'ኛ';
+    },
+    week: {
+        dow: 0, // Sunday is the first day of the week.
+        doy: 6, // The week that contains Jan 1st is the first week of the year.
+    },
+});

--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -10,7 +10,7 @@ export default moment.defineLocale('ca', {
             'gener_febrer_març_abril_maig_juny_juliol_agost_setembre_octubre_novembre_desembre'.split(
                 '_'
             ),
-        format: "de gener_de febrer_de març_d’abril_de maig_de juny_de juliol_d’agost_de setembre_d’octubre_de novembre_de desembre".split(
+        format: 'de gener_de febrer_de març_d’abril_de maig_de juny_de juliol_d’agost_de setembre_d’octubre_de novembre_de desembre'.split(
             '_'
         ),
         isFormat: /D[oD]?(\s)+MMMM/,

--- a/src/test/locale/am-et.test.js
+++ b/src/test/locale/am-et.test.js
@@ -5,9 +5,10 @@ import moment from '../../moment';
 localeModule('am-et');
 
 test('parse', function (assert) {
-    var tests = 'ጃንዩወሪ ጃን_ፌብሩወሪ ፌብ_ማርች ማር_ኤፕሪል ኤፕር_ሜይ ሜይ_ጁን ጁን_ጁላይ ጁላይ_ኦገስት ኦገ_ሴፕቴምበር ሴፕ_ኦክቶበር ኦክቶ_ኖቬምበር ኖቬ_ዲሴምበር ዲሴ'.split(
-            '_'
-        ),
+    var tests =
+            'ጃንዩወሪ ጃን_ፌብሩወሪ ፌብ_ማርች ማር_ኤፕሪል ኤፕር_ሜይ ሜይ_ጁን ጁን_ጁላይ ጁላይ_ኦገስት ኦገ_ሴፕቴምበር ሴፕ_ኦክቶበር ኦክቶ_ኖቬምበር ኖቬ_ዲሴምበር ዲሴ'.split(
+                '_'
+            ),
         i;
 
     function equalTest(input, mmm, i) {
@@ -29,25 +30,28 @@ test('parse', function (assert) {
 
 test('format', function (assert) {
     var a = [
-            ['dddd, MMMM Do YYYY, h:mm:ss a', 'እሁድ, ጃንዩወሪ 14ኛ 2010, 3:25:50 ከሰዓት'],
-            ['ddd, hA', 'እሁ, 3ከሰዓት'],
+            [
+                'dddd, MMMM Do YYYY, h:mm:ss a',
+                'ሀሙስ, ጃንዩወሪ 14ኛ 2010, 3:25:50 ከሰዓት',
+            ],
+            ['ddd, hA', 'ሀሙ, 3ከሰዓት'],
             ['M Mo MM MMMM MMM', '1 1ኛ 01 ጃንዩወሪ ጃን'],
             ['YYYY YY', '2010 10'],
             ['D Do DD', '14 14ኛ 14'],
-            ['d do dddd ddd dd', '0 0ኛ እሁድ እሁ እሁ'],
+            ['d do dddd ddd dd', '4 4ኛ ሀሙስ ሀሙ ሀ'],
             ['DDD DDDo DDDD', '14 14ኛ 014'],
-            ['w wo ww', '2 2ኛ 02'],
+            ['w wo ww', '3 3ኛ 03'],
             ['h hh', '3 03'],
             ['H HH', '15 15'],
             ['m mm', '25 25'],
             ['s ss', '50 50'],
             ['a A', 'ከሰዓት ከሰዓት'],
             ['[ዓመተ] DDDD', 'ዓመተ 014'],
-            ['LTS', '15:25:50'],
+            ['LTS', '3:25:50 ከሰዓት'],
             ['L', '14/01/2010'],
             ['LL', '14 ጃንዩወሪ 2010'],
-            ['LLL', '14 ጃንዩወሪ 2010 15:25'],
-            ['LLLL', 'እሁድ, 14 ጃንዩወሪ 2010 15:25'],
+            ['LLL', '14 ጃንዩወሪ 2010 3:25 ከሰዓት'],
+            ['LLLL', 'ሀሙስ, 14 ጃንዩወሪ 2010 3:25 ከሰዓት'],
         ],
         b = moment(new Date(2010, 0, 14, 15, 25, 50, 125)),
         i;
@@ -62,17 +66,17 @@ test('calendar', function (assert) {
 
     assert.equal(
         moment(a).calendar(),
-        'ዛሬ በ 12:00',
+        'ዛሬ በ 12:00 ከሰዓት',
         'today at the same time'
     );
     assert.equal(
         moment(a).add({ d: 1 }).calendar(),
-        'ነገ በ 12:00',
+        'ነገ በ 12:00 ከሰዓት',
         'tomorrow at the same time'
     );
     assert.equal(
         moment(a).subtract({ d: 1 }).calendar(),
-        'ትናንትና በ 12:00',
+        'ትናንትና በ 12:00 ከሰዓት',
         'yesterday at the same time'
     );
 });

--- a/src/test/locale/ca.js
+++ b/src/test/locale/ca.js
@@ -97,13 +97,13 @@ test('format apostrophed prepositions', function (assert) {
             date: [2025, 9, 10],
             format: 'LL',
             want: '10 d’octubre de 2025',
-        }
-    ]
+        },
+    ];
 
     examples.forEach(({ date, format, want }) => {
         const got = moment(date).format(format);
         assert.equal(got, want, `${date}, ${format}: got ${got}, want ${want}`);
-    })
+    });
 });
 
 test('format ordinal', function (assert) {
@@ -495,6 +495,6 @@ test('weeks year starting sunday formatted', function (assert) {
 
 test('day and month', function (assert) {
     assert.equal(moment([2012, 1, 15]).format('D MMMM'), '15 de febrer');
-    assert.equal(moment([2012, 9, 15]).format('D MMMM'), "15 d’octubre");
+    assert.equal(moment([2012, 9, 15]).format('D MMMM'), '15 d’octubre');
     assert.equal(moment([2012, 9, 15]).format('MMMM, D'), 'octubre, 15');
 });


### PR DESCRIPTION
- Fix the Amharic locale introduced by #6278 by converting it to the expected module format.
- Align Amharic meridiems, 12-hour time formats, and Sunday-first week settings with CLDR data.
- Correct stale Amharic test fixtures and expectations.
- Apply Prettier formatting to the Catalan changes introduced by #6306.
