### PR TITLE
[bugfix] Normalize lazy-loaded locale names

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -63,34 +63,44 @@ function chooseLocale(names) {
 }
 
 function isLocaleNameSane(name) {
-    // Prevent names that look like filesystem paths, i.e contain '/' or '\'
-    // Ensure name is available and function returns boolean
-    return !!(name && name.match('^[^/\\\\]*$'));
+    // Only canonical locale module names are safe to append to the require path.
+    return typeof name === 'string' && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name);
 }
 
 function loadLocale(name) {
     var oldLocale = null,
-        aliasedRequire;
+        aliasedRequire,
+        normalizedName;
+
+    // Preserve exact custom locale names before trying the canonical built-in name.
+    if (locales[name] !== undefined) {
+        return locales[name];
+    }
+
+    normalizedName = normalizeLocale(name);
+    if (locales[normalizedName] !== undefined) {
+        return locales[normalizedName];
+    }
+
     // TODO: Find a better way to register and load all the locales in Node
     if (
-        locales[name] === undefined &&
         typeof module !== 'undefined' &&
         module &&
         module.exports &&
-        isLocaleNameSane(name)
+        isLocaleNameSane(normalizedName)
     ) {
         try {
             oldLocale = globalLocale._abbr;
             aliasedRequire = require;
-            aliasedRequire('./locale/' + name);
+            aliasedRequire('./locale/' + normalizedName);
             getSetGlobalLocale(oldLocale);
         } catch (e) {
             // mark as not found to avoid repeating expensive file require call causing high CPU
             // when trying to find en-US, en_US, en-us for every format call
-            locales[name] = null; // null means not found
+            locales[normalizedName] = null; // null means not found
         }
     }
-    return locales[name];
+    return locales[normalizedName];
 }
 
 // This function will load locale and then set the global locale.  If
@@ -176,17 +186,20 @@ export function defineLocale(name, config) {
 }
 
 export function updateLocale(name, config) {
-    if (config != null) {
-        var locale,
-            tmpLocale,
-            parentConfig = baseConfig;
+    var locale,
+        tmpLocale = loadLocale(name),
+        parentConfig = baseConfig;
 
+    if (tmpLocale != null) {
+        name = tmpLocale._abbr;
+    }
+
+    if (config != null) {
         if (locales[name] != null && locales[name].parentLocale != null) {
             // Update existing child locale in-place to avoid memory-leaks
             locales[name].set(mergeConfigs(locales[name]._config, config));
         } else {
             // MERGE
-            tmpLocale = loadLocale(name);
             if (tmpLocale != null) {
                 parentConfig = tmpLocale._config;
             }

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -91,6 +91,46 @@ test('library getters and setters', function (assert) {
 
     moment.locale('EN_gb');
     assert.equal(moment.locale(), 'en-gb', 'Normalize locale key underscore');
+    assert.equal(
+        indexOf.call(moment.locales(), 'EN_gb'),
+        -1,
+        'Do not cache the unnormalized locale key'
+    );
+    assert.equal(
+        indexOf.call(moment.locales(), 'en_gb'),
+        -1,
+        'Do not cache a partially normalized locale key'
+    );
+});
+
+test('preserve exact custom locale names', function (assert) {
+    moment.defineLocale('Mixed_Custom', { months: ['Movember'] });
+
+    assert.equal(
+        moment.localeData('Mixed_Custom')._abbr,
+        'Mixed_Custom',
+        'finds a custom locale before normalizing its name'
+    );
+    assert.equal(
+        moment.locale(),
+        'Mixed_Custom',
+        'sets a custom locale using its exact name'
+    );
+
+    moment.defineLocale('Mixed_Custom', null);
+});
+
+test('do not load invalid built-in locale names', function (assert) {
+    var invalidNames = ['.', '..', 'locale name', 'en@gb'];
+
+    each(invalidNames, function (name) {
+        moment.localeData(name);
+        assert.equal(
+            indexOf.call(moment.locales(), name),
+            -1,
+            'does not cache invalid locale name "' + name + '"'
+        );
+    });
 });
 
 test('library setter array of locales', function (assert) {

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -308,7 +308,7 @@ test('define child locale before parent', function (assert) {
 
 test('lazy load parentLocale', function (assert) {
     moment.defineLocale('de_test', {
-        parentLocale: 'de',
+        parentLocale: 'DE',
         monthsShort: [
             'M1',
             'M2',
@@ -327,6 +327,6 @@ test('lazy load parentLocale', function (assert) {
     assert.equal(
         moment.locale(),
         'de_test',
-        'failed to lazy load parentLocale'
+        'lazy loads a parentLocale with a normalized name'
     );
 });

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -286,6 +286,31 @@ test('update existing locale', function (assert) {
     moment.updateLocale('de', null);
 });
 
+test('lazy load locale with normalized name before update', function (assert) {
+    var locale = moment.updateLocale('DE', { monthsShort: ['JAN'] }),
+        january = locale.months(moment.utc([2017, 0]));
+
+    assert.equal(
+        january,
+        'Januar',
+        'inherits the lazy-loaded locale configuration'
+    );
+    assert.equal(locale._abbr, 'de', 'returns the normalized locale');
+    assert.equal(moment.locale(), 'de', 'sets the normalized locale globally');
+    assert.equal(
+        moment.locales().indexOf('DE'),
+        -1,
+        'does not create an unnormalized locale entry'
+    );
+
+    moment.updateLocale('DE', null);
+    assert.notEqual(
+        moment.localeData('de').monthsShort(moment.utc([2017, 0]), ''),
+        'JAN',
+        'resets the normalized locale using the original name'
+    );
+});
+
 test('update non-existing locale', function (assert) {
     moment.locale('en');
     moment.updateLocale('dude', { months: ['Movember'] });


### PR DESCRIPTION
Locale names passed to lazy-loading paths were used inconsistently. Mixed-case and underscore variants could trigger failed filesystem lookups, cache misses under noncanonical keys, or make `updateLocale` create a separate locale instead of updating the built-in one.

Resolve exact registered names first to preserve custom locales, then normalize and validate built-in module names before loading them. This keeps lazy loading, inheritance, updates, and resets on the same canonical locale while preventing invalid names from reaching `require`.