### PR TITLE
[misc] run fossa scan manually

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,37 @@
+name: FOSSA
+
+on:
+  push:
+    branches: ['develop']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  license-scan:
+    name: License scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Use Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Analyze dependencies
+        uses: fossas/fossa-action@v2
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: Test license policy
+        uses: fossas/fossa-action@v2
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true


### PR DESCRIPTION
Fossa's GitHub App is marking dev dependencies as if they were actual dependencies.  Since the published package has no actual dependencies, we don't need to run FOSSA on PRs.  Instead, we can uninstall the app and just run the scans on develop after a merge, which will keep the report green.