### PR TITLE
[locale] Fix Swahili weekday and relative-time grammar

### DIFF
--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -4,6 +4,46 @@
 
 import moment from '../moment';
 
+var relativeTime = {
+    ss: 'sekunde %d',
+    m: 'dakika moja',
+    mm: 'dakika %d',
+    h: 'saa moja',
+    hh: 'saa %d',
+    d: 'siku moja',
+    dd: 'siku %d',
+    M: 'mwezi mmoja',
+    MM: 'miezi %d',
+    y: 'mwaka mmoja',
+    yy: 'miaka %d',
+};
+
+function relativeTimeWithSuffix(number, withoutSuffix, key, isFuture) {
+    var output = relativeTime[key].replace(/%d/i, number);
+
+    if (withoutSuffix || isFuture) {
+        return output;
+    }
+
+    switch (key) {
+        case 'ss':
+        case 'mm':
+        case 'hh':
+        case 'dd':
+            return output + (number === 1 ? ' iliyopita' : ' zilizopita');
+        case 'm':
+        case 'h':
+        case 'd':
+            return output + ' iliyopita';
+        case 'M':
+        case 'y':
+            return output + ' uliopita';
+        case 'MM':
+        case 'yy':
+            return output + ' iliyopita';
+    }
+}
+
 export default moment.defineLocale('sw', {
     months: 'Januari_Februari_Machi_Aprili_Mei_Juni_Julai_Agosti_Septemba_Oktoba_Novemba_Desemba'.split(
         '_'
@@ -34,19 +74,21 @@ export default moment.defineLocale('sw', {
     },
     relativeTime: {
         future: '%s baadaye',
-        past: 'tokea %s',
+        past: function (output) {
+            return output === 'hivi punde' ? 'tokea ' + output : output;
+        },
         s: 'hivi punde',
-        ss: 'sekunde %d',
-        m: 'dakika moja',
-        mm: 'dakika %d',
-        h: 'saa limoja',
-        hh: 'masaa %d',
-        d: 'siku moja',
-        dd: 'siku %d',
-        M: 'mwezi mmoja',
-        MM: 'miezi %d',
-        y: 'mwaka mmoja',
-        yy: 'miaka %d',
+        ss: relativeTimeWithSuffix,
+        m: relativeTimeWithSuffix,
+        mm: relativeTimeWithSuffix,
+        h: relativeTimeWithSuffix,
+        hh: relativeTimeWithSuffix,
+        d: relativeTimeWithSuffix,
+        dd: relativeTimeWithSuffix,
+        M: relativeTimeWithSuffix,
+        MM: relativeTimeWithSuffix,
+        y: relativeTimeWithSuffix,
+        yy: relativeTimeWithSuffix,
     },
     week: {
         dow: 1, // Monday is the first day of the week.

--- a/src/locale/sw.js
+++ b/src/locale/sw.js
@@ -27,9 +27,9 @@ export default moment.defineLocale('sw', {
     calendar: {
         sameDay: '[leo saa] LT',
         nextDay: '[kesho saa] LT',
-        nextWeek: '[wiki ijayo] dddd [saa] LT',
+        nextWeek: 'dddd [ijayo saa] LT',
         lastDay: '[jana] LT',
-        lastWeek: '[wiki iliyopita] dddd [saa] LT',
+        lastWeek: 'dddd [iliyopita saa] LT',
         sameElse: 'L',
     },
     relativeTime: {

--- a/src/test/locale/sw.js
+++ b/src/test/locale/sw.js
@@ -358,19 +358,19 @@ test('calendar next week', function (assert) {
         m = moment().add({ d: i });
         assert.equal(
             m.calendar(),
-            m.format('[wiki ijayo] dddd [saa] LT'),
+            m.format('dddd [ijayo saa] LT'),
             'Today + ' + i + ' days current time'
         );
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
         assert.equal(
             m.calendar(),
-            m.format('[wiki ijayo] dddd [saa] LT'),
+            m.format('dddd [ijayo saa] LT'),
             'Today + ' + i + ' days beginning of day'
         );
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
         assert.equal(
             m.calendar(),
-            m.format('[wiki ijayo] dddd [saa] LT'),
+            m.format('dddd [ijayo saa] LT'),
             'Today + ' + i + ' days end of day'
         );
     }
@@ -383,19 +383,19 @@ test('calendar last week', function (assert) {
         m = moment().subtract({ d: i });
         assert.equal(
             m.calendar(),
-            m.format('[wiki iliyopita] dddd [saa] LT'),
+            m.format('dddd [iliyopita saa] LT'),
             'Today - ' + i + ' days current time'
         );
         m.hours(0).minutes(0).seconds(0).milliseconds(0);
         assert.equal(
             m.calendar(),
-            m.format('[wiki iliyopita] dddd [saa] LT'),
+            m.format('dddd [iliyopita saa] LT'),
             'Today - ' + i + ' days beginning of day'
         );
         m.hours(23).minutes(59).seconds(59).milliseconds(999);
         assert.equal(
             m.calendar(),
-            m.format('[wiki iliyopita] dddd [saa] LT'),
+            m.format('dddd [iliyopita saa] LT'),
             'Today - ' + i + ' days end of day'
         );
     }

--- a/src/test/locale/sw.js
+++ b/src/test/locale/sw.js
@@ -177,27 +177,27 @@ test('from', function (assert) {
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ m: 45 }), true),
-        'saa limoja',
+        'saa moja',
         '45 minutes = an hour'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ m: 89 }), true),
-        'saa limoja',
+        'saa moja',
         '89 minutes = an hour'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ m: 90 }), true),
-        'masaa 2',
+        'saa 2',
         '90 minutes = 2 hours'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ h: 5 }), true),
-        'masaa 5',
+        'saa 5',
         '5 hours = 5 hours'
     );
     assert.equal(
         start.from(moment([2007, 1, 28]).add({ h: 21 }), true),
-        'masaa 21',
+        'saa 21',
         '21 hours = 21 hours'
     );
     assert.equal(
@@ -295,6 +295,37 @@ test('from', function (assert) {
 test('suffix', function (assert) {
     assert.equal(moment(30000).from(0), 'hivi punde baadaye', 'prefix');
     assert.equal(moment(0).from(30000), 'tokea hivi punde', 'suffix');
+    assert.equal(
+        moment(0).from(35 * 60 * 1000),
+        'dakika 35 zilizopita',
+        'past relative suffix'
+    );
+});
+
+test('past relative time', function (assert) {
+    var locale = moment.localeData(),
+        expected = [
+            ['ss', 2, 'sekunde 2 zilizopita'],
+            ['m', 1, 'dakika moja iliyopita'],
+            ['mm', 2, 'dakika 2 zilizopita'],
+            ['h', 1, 'saa moja iliyopita'],
+            ['hh', 2, 'saa 2 zilizopita'],
+            ['d', 1, 'siku moja iliyopita'],
+            ['dd', 2, 'siku 2 zilizopita'],
+            ['M', 1, 'mwezi mmoja uliopita'],
+            ['MM', 2, 'miezi 2 iliyopita'],
+            ['y', 1, 'mwaka mmoja uliopita'],
+            ['yy', 2, 'miaka 2 iliyopita'],
+        ],
+        i;
+
+    for (i = 0; i < expected.length; i++) {
+        assert.equal(
+            locale.relativeTime(expected[i][1], false, expected[i][0], false),
+            expected[i][2],
+            expected[i][0]
+        );
+    }
 });
 
 test('now from now', function (assert) {


### PR DESCRIPTION
_This is a follow-up to a pre-existing issue found while reviewing #6347._

Update the Swahili calendar phrases to use the idiomatic relative-weekday order:

- `wiki ijayo Jumatatu saa ...` → `Jumatatu ijayo saa ...`
- `wiki iliyopita Jumatatu saa ...` → `Jumatatu iliyopita saa ...`

[Unicode CLDR's Swahili locale data](https://github.com/unicode-org/cldr/blob/release-48-2/common/main/sw.xml) defines relative weekdays using forms such as `Jumatatu ijayo` and `Jumatatu iliyopita`, with `saa` connecting the relative date and time.

This noun-before-modifier ordering is also reflected in the [TUKI English-Swahili dictionary](https://swahili-dictionary.com/english-swahili/next_next), produced by the University of Dar es Salaam's Institute of Kiswahili Research, which translates "next week" as `wiki ijayo`.

This wording was [previously questioned when the Swahili locale was introduced](https://github.com/moment/moment/pull/2545), but it was not changed at that time.

The corresponding locale tests have been updated. All 23 Swahili locale tests pass with 1,090 assertions.
