### PR TITLE
[bugfix] Correct locale and offset type declarations

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -35,7 +35,7 @@ declare namespace moment {
     relativeTime(n: number, withoutSuffix: boolean,
                  key: RelativeTimeKey, isFuture: boolean): string;
     pastFuture(diff: number, absRelTime: string): string;
-    set(config: Object): void;
+    set(config: LocaleSpecification): void;
 
     months(): string[];
     months(m: Moment, format?: string): string;
@@ -601,7 +601,7 @@ declare namespace moment {
     zone(): number;
     zone(b: number|string): Moment;
     utcOffset(): number;
-    utcOffset(b: number|string, keepLocalTime?: boolean): Moment;
+    utcOffset(b: number|string, keepLocalTime?: boolean, keepMinutes?: boolean): Moment;
     isUtcOffset(): boolean;
     daysInMonth(): number;
     isDST(): boolean;

--- a/ts3.1-typings/moment.d.ts
+++ b/ts3.1-typings/moment.d.ts
@@ -84,7 +84,7 @@ declare namespace moment {
       isFuture: boolean
     ): string;
     pastFuture(diff: number, absRelTime: string): string;
-    set(config: Object): void;
+    set(config: LocaleSpecification): void;
 
     months(): string[];
     months(m: Moment, format?: string): string;
@@ -693,7 +693,11 @@ declare namespace moment {
     zone(): number;
     zone(b: number | string): Moment;
     utcOffset(): number;
-    utcOffset(b: number | string, keepLocalTime?: boolean): Moment;
+    utcOffset(
+      b: number | string,
+      keepLocalTime?: boolean,
+      keepMinutes?: boolean
+    ): Moment;
     isUtcOffset(): boolean;
     daysInMonth(): number;
     isDST(): boolean;

--- a/typing-tests/legacy/moment-tests.ts
+++ b/typing-tests/legacy/moment-tests.ts
@@ -241,6 +241,7 @@ moment(1318874398806).unix();
 moment([2000]).isLeapYear();
 moment().zone();
 moment().utcOffset();
+moment().utcOffset(15, false, true);
 moment('2012-2', 'YYYY-MM').daysInMonth();
 moment([2011, 2, 12]).isDST();
 
@@ -649,3 +650,10 @@ moment.suppressDeprecationWarnings = true;
 moment.deprecationHandler = null;
 moment.deprecationHandler = undefined;
 moment.deprecationHandler = function (name: string | void, msg: string) {};
+
+var callableLocaleConfig: moment.LocaleSpecification = {
+  ordinal: function (number: number) {
+    return number + 'th';
+  },
+};
+moment.localeData().set(callableLocaleConfig);

--- a/typing-tests/modern/moment-tests.ts
+++ b/typing-tests/modern/moment-tests.ts
@@ -244,6 +244,7 @@ moment(1318874398806).unix();
 moment([2000]).isLeapYear();
 moment().zone();
 moment().utcOffset();
+moment().utcOffset(15, false, true);
 moment('2012-2', 'YYYY-MM').daysInMonth();
 moment([2011, 2, 12]).isDST();
 
@@ -643,3 +644,10 @@ moment.suppressDeprecationWarnings = true;
 moment.deprecationHandler = null;
 moment.deprecationHandler = undefined;
 moment.deprecationHandler = function (name: string | null, msg: string) {};
+
+var callableLocaleConfig: moment.LocaleSpecification = {
+  ordinal: function (number: number) {
+    return number + 'th';
+  },
+};
+moment.localeData().set(callableLocaleConfig);


### PR DESCRIPTION
Expose the runtime-supported `keepMinutes` argument on `utcOffset` and type `Locale#set` with `LocaleSpecification` so locale callback signatures are retained. Add coverage for both legacy and modern TypeScript declarations.

### ⚠️ Breaking Change

The `utcOffset` change is additive, but narrowing `Locale#set` from `Object` to `LocaleSpecification` can cause a compile-time error for callers whose config value is typed only as `Object`. Annotate or narrow that value to `moment.LocaleSpecification` before passing it; runtime behavior is unchanged.

This will be held until we're ready for a Moment `3.0.0` release.