### PR TITLE
[locale] de, de-at, de-ch: parse short months without trailing dot

### DIFF
--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -7,6 +7,23 @@
 
 import moment from '../moment';
 
+var monthsParse = [
+        /^jän/i,
+        /^feb/i,
+        /^mär/i,
+        /^apr/i,
+        /^mai/i,
+        /^jun/i,
+        /^jul/i,
+        /^aug/i,
+        /^sep/i,
+        /^okt/i,
+        /^nov/i,
+        /^dez/i,
+    ],
+    monthsRegex =
+        /^(Jänner|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember|Jän\.?|Feb\.?|Mär\.?|Apr\.?|Jun\.?|Jul\.?|Aug\.?|Sep\.?|Okt\.?|Nov\.?|Dez\.?)/i;
+
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {
         m: ['eine Minute', 'einer Minute'],
@@ -28,7 +45,18 @@ export default moment.defineLocale('de-at', {
     ),
     monthsShort:
         'Jän._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
-    monthsParseExact: true,
+
+    monthsRegex: monthsRegex,
+    monthsShortRegex: monthsRegex,
+    monthsStrictRegex:
+        /^(Jänner|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)/i,
+    monthsShortStrictRegex:
+        /^(Jän\.?|Feb\.?|März|Mär\.?|Apr\.?|Mai|Juni|Jun\.?|Juli|Jul\.?|Aug\.?|Sep\.?|Okt\.?|Nov\.?|Dez\.?)/i,
+
+    monthsParse: monthsParse,
+    longMonthsParse: monthsParse,
+    shortMonthsParse: monthsParse,
+
     weekdays:
         'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split(
             '_'

--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -6,6 +6,23 @@
 
 import moment from '../moment';
 
+var monthsParse = [
+        /^jan/i,
+        /^feb/i,
+        /^mär/i,
+        /^apr/i,
+        /^mai/i,
+        /^jun/i,
+        /^jul/i,
+        /^aug/i,
+        /^sep/i,
+        /^okt/i,
+        /^nov/i,
+        /^dez/i,
+    ],
+    monthsRegex =
+        /^(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember|Jan\.?|Feb\.?|Mär\.?|Apr\.?|Jun\.?|Jul\.?|Aug\.?|Sep\.?|Okt\.?|Nov\.?|Dez\.?)/i;
+
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {
         m: ['eine Minute', 'einer Minute'],
@@ -27,7 +44,18 @@ export default moment.defineLocale('de-ch', {
     ),
     monthsShort:
         'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
-    monthsParseExact: true,
+
+    monthsRegex: monthsRegex,
+    monthsShortRegex: monthsRegex,
+    monthsStrictRegex:
+        /^(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)/i,
+    monthsShortStrictRegex:
+        /^(Jan\.?|Feb\.?|März|Mär\.?|Apr\.?|Mai|Juni|Jun\.?|Juli|Jul\.?|Aug\.?|Sep\.?|Okt\.?|Nov\.?|Dez\.?)/i,
+
+    monthsParse: monthsParse,
+    longMonthsParse: monthsParse,
+    shortMonthsParse: monthsParse,
+
     weekdays:
         'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split(
             '_'

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -6,6 +6,23 @@
 
 import moment from '../moment';
 
+var monthsParse = [
+        /^jan/i,
+        /^feb/i,
+        /^mär/i,
+        /^apr/i,
+        /^mai/i,
+        /^jun/i,
+        /^jul/i,
+        /^aug/i,
+        /^sep/i,
+        /^okt/i,
+        /^nov/i,
+        /^dez/i,
+    ],
+    monthsRegex =
+        /^(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember|Jan\.?|Feb\.?|Mär\.?|Apr\.?|Jun\.?|Jul\.?|Aug\.?|Sep\.?|Okt\.?|Nov\.?|Dez\.?)/i;
+
 function processRelativeTime(number, withoutSuffix, key, isFuture) {
     var format = {
         m: ['eine Minute', 'einer Minute'],
@@ -27,7 +44,18 @@ export default moment.defineLocale('de', {
     ),
     monthsShort:
         'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
-    monthsParseExact: true,
+
+    monthsRegex: monthsRegex,
+    monthsShortRegex: monthsRegex,
+    monthsStrictRegex:
+        /^(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)/i,
+    monthsShortStrictRegex:
+        /^(Jan\.?|Feb\.?|März|Mär\.?|Apr\.?|Mai|Juni|Jun\.?|Juli|Jul\.?|Aug\.?|Sep\.?|Okt\.?|Nov\.?|Dez\.?)/i,
+
+    monthsParse: monthsParse,
+    longMonthsParse: monthsParse,
+    shortMonthsParse: monthsParse,
+
     weekdays:
         'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split(
             '_'

--- a/src/test/locale/de-at.js
+++ b/src/test/locale/de-at.js
@@ -46,6 +46,79 @@ test('parse', function (assert) {
     }
 });
 
+test('parse short months without trailing dot (issue #6300)', function (assert) {
+    // Feb.toLocaleString('de-AT', {month: 'short'}) yields "Feb" without a
+    // trailing dot, which used to fail to parse and silently default to
+    // month index 0 (January). Both the dotted and undotted spellings must
+    // parse to the correct month for every month name, short and long.
+    var longNames =
+            'Jänner_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split(
+                '_'
+            ),
+        shortNamesWithDot =
+            'Jän._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split(
+                '_'
+            ),
+        shortNamesWithoutDot =
+            'Jän_Feb_März_Apr_Mai_Juni_Juli_Aug_Sep_Okt_Nov_Dez'.split('_'),
+        i;
+
+    for (i = 0; i < 12; i++) {
+        assert.equal(
+            moment(shortNamesWithDot[i], 'MMM').month(),
+            i,
+            shortNamesWithDot[i] + ' (MMM, with dot) should be month ' + (i + 1)
+        );
+        assert.equal(
+            moment(shortNamesWithoutDot[i], 'MMM').month(),
+            i,
+            shortNamesWithoutDot[i] +
+                ' (MMM, without dot) should be month ' +
+                (i + 1)
+        );
+        assert.equal(
+            moment(longNames[i], 'MMMM').month(),
+            i,
+            longNames[i] + ' (MMMM) should be month ' + (i + 1)
+        );
+
+        assert.equal(
+            moment('15.' + (i + 1) + '.2000', 'DD.MM.YYYY').format('MMM'),
+            shortNamesWithDot[i],
+            'MMM output for month ' + (i + 1) + ' should be unchanged'
+        );
+        assert.equal(
+            moment('15.' + (i + 1) + '.2000', 'DD.MM.YYYY').format('MMMM'),
+            longNames[i],
+            'MMMM output for month ' + (i + 1) + ' should be unchanged'
+        );
+    }
+
+    // The exact repro from the issue, adapted to de-at.
+    assert.equal(
+        moment('Feb 15, 2000', 'MMM DD, YYYY').month(),
+        1,
+        'Feb 15, 2000 should parse as February, not January'
+    );
+});
+
+test('parse ICU short month names', function (assert) {
+    // new Date(2000, m, 15).toLocaleString('de-AT', {month: 'short'})
+    // truncates März/Juni/Juli to Mär/Jun/Jul (no dot) and Jänner to Jän
+    // (no dot), unlike moment's own monthsShort output. These must parse too.
+    var icuShortNames =
+            'Jän_Feb_Mär_Apr_Mai_Jun_Jul_Aug_Sep_Okt_Nov_Dez'.split('_'),
+        i;
+
+    for (i = 0; i < 12; i++) {
+        assert.equal(
+            moment(icuShortNames[i], 'MMM').month(),
+            i,
+            icuShortNames[i] + ' (ICU short) should be month ' + (i + 1)
+        );
+    }
+});
+
 test('format', function (assert) {
     var a = [
             [

--- a/src/test/locale/de-ch.js
+++ b/src/test/locale/de-ch.js
@@ -45,6 +45,79 @@ test('parse', function (assert) {
     }
 });
 
+test('parse short months without trailing dot (issue #6300)', function (assert) {
+    // Feb.toLocaleString('de-CH', {month: 'short'}) yields "Feb" without a
+    // trailing dot, which used to fail to parse and silently default to
+    // month index 0 (January). Both the dotted and undotted spellings must
+    // parse to the correct month for every month name, short and long.
+    var longNames =
+            'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split(
+                '_'
+            ),
+        shortNamesWithDot =
+            'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split(
+                '_'
+            ),
+        shortNamesWithoutDot =
+            'Jan_Feb_März_Apr_Mai_Juni_Juli_Aug_Sep_Okt_Nov_Dez'.split('_'),
+        i;
+
+    for (i = 0; i < 12; i++) {
+        assert.equal(
+            moment(shortNamesWithDot[i], 'MMM').month(),
+            i,
+            shortNamesWithDot[i] + ' (MMM, with dot) should be month ' + (i + 1)
+        );
+        assert.equal(
+            moment(shortNamesWithoutDot[i], 'MMM').month(),
+            i,
+            shortNamesWithoutDot[i] +
+                ' (MMM, without dot) should be month ' +
+                (i + 1)
+        );
+        assert.equal(
+            moment(longNames[i], 'MMMM').month(),
+            i,
+            longNames[i] + ' (MMMM) should be month ' + (i + 1)
+        );
+
+        assert.equal(
+            moment('15.' + (i + 1) + '.2000', 'DD.MM.YYYY').format('MMM'),
+            shortNamesWithDot[i],
+            'MMM output for month ' + (i + 1) + ' should be unchanged'
+        );
+        assert.equal(
+            moment('15.' + (i + 1) + '.2000', 'DD.MM.YYYY').format('MMMM'),
+            longNames[i],
+            'MMMM output for month ' + (i + 1) + ' should be unchanged'
+        );
+    }
+
+    // The exact repro from the issue, adapted to de-ch.
+    assert.equal(
+        moment('Feb 15, 2000', 'MMM DD, YYYY').month(),
+        1,
+        'Feb 15, 2000 should parse as February, not January'
+    );
+});
+
+test('parse ICU short month names', function (assert) {
+    // new Date(2000, m, 15).toLocaleString('de-CH', {month: 'short'})
+    // truncates März/Juni/Juli to Mär/Jun/Jul (no dot), unlike moment's own
+    // monthsShort output. These must parse too.
+    var icuShortNames =
+            'Jan_Feb_Mär_Apr_Mai_Jun_Jul_Aug_Sep_Okt_Nov_Dez'.split('_'),
+        i;
+
+    for (i = 0; i < 12; i++) {
+        assert.equal(
+            moment(icuShortNames[i], 'MMM').month(),
+            i,
+            icuShortNames[i] + ' (ICU short) should be month ' + (i + 1)
+        );
+    }
+});
+
 test('format', function (assert) {
     var a = [
             [

--- a/src/test/locale/de.js
+++ b/src/test/locale/de.js
@@ -45,6 +45,79 @@ test('parse', function (assert) {
     }
 });
 
+test('parse short months without trailing dot (issue #6300)', function (assert) {
+    // Feb.toLocaleString('de-DE', {month: 'short'}) yields "Feb" without a
+    // trailing dot, which used to fail to parse and silently default to
+    // month index 0 (January). Both the dotted and undotted spellings must
+    // parse to the correct month for every month name, short and long.
+    var longNames =
+            'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split(
+                '_'
+            ),
+        shortNamesWithDot =
+            'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split(
+                '_'
+            ),
+        shortNamesWithoutDot =
+            'Jan_Feb_März_Apr_Mai_Juni_Juli_Aug_Sep_Okt_Nov_Dez'.split('_'),
+        i;
+
+    for (i = 0; i < 12; i++) {
+        assert.equal(
+            moment(shortNamesWithDot[i], 'MMM').month(),
+            i,
+            shortNamesWithDot[i] + ' (MMM, with dot) should be month ' + (i + 1)
+        );
+        assert.equal(
+            moment(shortNamesWithoutDot[i], 'MMM').month(),
+            i,
+            shortNamesWithoutDot[i] +
+                ' (MMM, without dot) should be month ' +
+                (i + 1)
+        );
+        assert.equal(
+            moment(longNames[i], 'MMMM').month(),
+            i,
+            longNames[i] + ' (MMMM) should be month ' + (i + 1)
+        );
+
+        assert.equal(
+            moment('15.' + (i + 1) + '.2000', 'DD.MM.YYYY').format('MMM'),
+            shortNamesWithDot[i],
+            'MMM output for month ' + (i + 1) + ' should be unchanged'
+        );
+        assert.equal(
+            moment('15.' + (i + 1) + '.2000', 'DD.MM.YYYY').format('MMMM'),
+            longNames[i],
+            'MMMM output for month ' + (i + 1) + ' should be unchanged'
+        );
+    }
+
+    // The exact repro from the issue.
+    assert.equal(
+        moment('Feb 15, 2000', 'MMM DD, YYYY').month(),
+        1,
+        'Feb 15, 2000 should parse as February, not January'
+    );
+});
+
+test('parse ICU short month names', function (assert) {
+    // new Date(2000, m, 15).toLocaleString('de-DE', {month: 'short'})
+    // truncates März/Juni/Juli to Mär/Jun/Jul (no dot), unlike moment's own
+    // monthsShort output. These must parse too.
+    var icuShortNames =
+            'Jan_Feb_Mär_Apr_Mai_Jun_Jul_Aug_Sep_Okt_Nov_Dez'.split('_'),
+        i;
+
+    for (i = 0; i < 12; i++) {
+        assert.equal(
+            moment(icuShortNames[i], 'MMM').month(),
+            i,
+            icuShortNames[i] + ' (ICU short) should be month ' + (i + 1)
+        );
+    }
+});
+
 test('format', function (assert) {
     var a = [
             [


### PR DESCRIPTION
Fixes #6300.

German locales store `monthsShort` with a trailing dot ("Feb.") and set
`monthsParseExact: true`, which forces the parser to match the dot literally.
`Feb` matches nothing, so the month slot is never filled and falls back to
index 0 — parsing silently returns January instead of failing.

Beyond the reported case, ICU truncates `März`/`Juni`/`Juli` to
`Mär`/`Jun`/`Jul`, so `toLocaleString('de-DE', { month: 'short' })` output
could not be parsed back by moment for four of twelve months. The same defect
is present in `de-at` (which additionally has `Jänner`/`Jän`) and `de-ch`.

Follows the approach already used in `nl.js` for the same problem:
`monthsShort` is left unchanged so formatted output is byte identical,
`monthsParseExact` is removed, and explicit `monthsParse`/`monthsRegex`/
`monthsStrictRegex` entries accept both dotted and undotted forms. Full month
names precede their truncated forms in every alternation, so nothing
truncates during extraction.

Tests added for all three locales covering both short forms, the full names,
and the exact twelve strings ICU emits. Full suite passes.