### PR TITLE
[bugfix] Parse compact locale weekday before time

### DIFF
--- a/benchmarks/parseCompactWeekday.js
+++ b/benchmarks/parseCompactWeekday.js
@@ -1,0 +1,31 @@
+var moment = require('./../build/umd/moment.js');
+
+module.exports = {
+    name: 'parse compact locale weekday',
+    tests: {
+        'compact strict': {
+            fn: function () {
+                moment('21530', 'eHHmm', true);
+            },
+            async: false,
+        },
+        'compact non-strict': {
+            fn: function () {
+                moment('21530', 'eHHmm');
+            },
+            async: false,
+        },
+        'padded strict': {
+            fn: function () {
+                moment('021530', 'eHHmm', true);
+            },
+            async: false,
+        },
+        'padded non-strict': {
+            fn: function () {
+                moment('021530', 'eHHmm');
+            },
+            async: false,
+        },
+    },
+};

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -36,7 +36,7 @@ addFormatToken('E', 0, 0, 'isoWeekday');
 // PARSING
 
 addRegexToken('d', match1to2);
-addRegexToken('e', match1to2);
+addRegexToken('e', match1to2LocaleWeekday);
 addRegexToken('E', match1to2);
 addRegexToken('dd', function (isStrict, locale) {
     return locale.weekdaysMinRegex(isStrict);
@@ -79,6 +79,12 @@ function parseWeekday(input, locale) {
     }
 
     return null;
+}
+
+function match1to2LocaleWeekday() {
+    // Prefer the single digit emitted by e before a compact HHmm value, while
+    // retaining the legacy two-digit parsing used by padded weekday inputs.
+    return /[0-6](?=\d{4}(?!\d))|\d\d?/;
 }
 
 function parseIsoWeekday(input, locale) {

--- a/src/test/moment/weekday.js
+++ b/src/test/moment/weekday.js
@@ -46,6 +46,26 @@ test('iso weekday', function (assert) {
     }
 });
 
+test('compact locale weekday and time parsing', function (assert) {
+    moment.locale('en');
+
+    [false, true].forEach(function (strict) {
+        var compact = moment('21530', 'eHHmm', strict),
+            padded = moment('021530', 'eHHmm', strict),
+            mode = strict ? 'strict' : 'non-strict';
+
+        assert.ok(compact.isValid(), mode + ' compact input is valid');
+        assert.equal(compact.weekday(), 2, mode + ' compact weekday');
+        assert.equal(compact.hour(), 15, mode + ' compact hour');
+        assert.equal(compact.minute(), 30, mode + ' compact minute');
+
+        assert.ok(padded.isValid(), mode + ' padded input remains valid');
+        assert.equal(padded.weekday(), 2, mode + ' padded weekday');
+        assert.equal(padded.hour(), 15, mode + ' padded hour');
+        assert.equal(padded.minute(), 30, mode + ' padded minute');
+    });
+});
+
 test('iso weekday setter', function (assert) {
     var a = moment([2011, 0, 10]);
     assert.equal(moment(a).isoWeekday(1).date(), 10, 'set from mon to mon');


### PR DESCRIPTION
Fixes #6116.

Formatting with `eHHmm` produces a five-digit value such as `21530`, but parsing that value previously allowed `e` to consume `21`. This left `530` for the time tokens and resulted in an invalid date.

A general rule that consumes one weekday digit whenever additional digits follow is insufficient because Moment has historically accepted padded weekday inputs. For example:

- `21530` means weekday 2 at 15:30
- `021530` means padded weekday 02 at 15:30

If the parser unconditionally consumes one digit from both inputs, the padded form is either rejected in strict mode or silently interpreted as weekday 0 at 21:53 in non-strict mode.

This change therefore uses a narrower rule: `e` consumes one digit when exactly four digits remain in the current numeric run, matching the output shape of `eHHmm`. Otherwise, the existing one-or-two-digit behavior is retained. This fixes the reported round trip without regressing padded weekday parsing.

Tests cover:

- Five-digit compact `eHHmm` input
- Six-digit padded weekday input
- Strict and non-strict parsing
- Weekday, hour, and minute values

Validation:

- `pnpm test -- --only=moment/weekday,moment/create,moment/week_year`
- `pnpm validate`