### PR TITLE
[bugfix] Parse compact locale weekday before time

### DIFF
--- a/benchmarks/parseCompactWeekday.js
+++ b/benchmarks/parseCompactWeekday.js
@@ -1,0 +1,31 @@
+var moment = require('./../build/umd/moment.js');
+
+module.exports = {
+    name: 'parse compact locale weekday',
+    tests: {
+        'compact strict': {
+            fn: function () {
+                moment('21530', 'eHHmm', true);
+            },
+            async: false,
+        },
+        'compact non-strict': {
+            fn: function () {
+                moment('21530', 'eHHmm');
+            },
+            async: false,
+        },
+        'padded strict': {
+            fn: function () {
+                moment('021530', 'eHHmm', true);
+            },
+            async: false,
+        },
+        'padded non-strict': {
+            fn: function () {
+                moment('021530', 'eHHmm');
+            },
+            async: false,
+        },
+    },
+};

--- a/src/lib/format/format.js
+++ b/src/lib/format/format.js
@@ -3,7 +3,7 @@ import isFunction from '../utils/is-function';
 import hasOwnProp from '../utils/has-own-prop';
 
 var formattingTokens =
-        /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g,
+        /(\[[^\[]*\])|(\\e)|(\\)?(eHHmm|[Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g,
     localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})/g,
     formatFunctions = {},
     formatTokenFunctions = {};

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -3,11 +3,14 @@ import { addFormatToken } from '../format/format';
 import {
     addRegexToken,
     match1to2,
+    match5to6,
     matchWord,
     regexEscape,
 } from '../parse/regex';
 import { addWeekParseToken } from '../parse/token';
+import { HOUR, MINUTE } from './constants';
 import toInt from '../utils/to-int';
+import zeroFill from '../utils/zero-fill';
 import isArray from '../utils/is-array';
 import indexOf from '../utils/index-of';
 import hasOwnProp from '../utils/has-own-prop';
@@ -32,12 +35,21 @@ addFormatToken('dddd', 0, 0, function (format) {
 
 addFormatToken('e', 0, 0, 'weekday');
 addFormatToken('E', 0, 0, 'isoWeekday');
+addFormatToken('eHHmm', 0, 0, function () {
+    return (
+        '' +
+        this.weekday() +
+        zeroFill(this.hours(), 2) +
+        zeroFill(this.minutes(), 2)
+    );
+});
 
 // PARSING
 
 addRegexToken('d', match1to2);
 addRegexToken('e', match1to2);
 addRegexToken('E', match1to2);
+addRegexToken('eHHmm', match5to6);
 addRegexToken('dd', function (isStrict, locale) {
     return locale.weekdaysMinRegex(isStrict);
 });
@@ -60,6 +72,14 @@ addWeekParseToken(['dd', 'ddd', 'dddd'], function (input, week, config, token) {
 
 addWeekParseToken(['d', 'e', 'E'], function (input, week, config, token) {
     week[token] = toInt(input);
+});
+
+addWeekParseToken('eHHmm', function (input, week, config) {
+    var weekdayEnd = input.length - 4;
+
+    week.e = toInt(input.substr(0, weekdayEnd));
+    config._a[HOUR] = toInt(input.substr(weekdayEnd, 2));
+    config._a[MINUTE] = toInt(input.substr(weekdayEnd + 2));
 });
 
 // HELPERS

--- a/src/test/moment/format.js
+++ b/src/test/moment/format.js
@@ -868,6 +868,19 @@ test('Hmm and Hmmss', function (assert) {
     assert.equal(moment('18:34:56', 'HH:mm:ss').format('Hmmss'), '183456');
 });
 
+test('eHHmm', function (assert) {
+    assert.equal(
+        moment('2026-08-18 15:30', 'YYYY-MM-DD HH:mm').format('eHHmm'),
+        '21530',
+        'locale weekday with compact time'
+    );
+    assert.equal(
+        moment('15:30', 'HH:mm').format('\\eHHmm'),
+        'e1530',
+        'escaped e remains separate from HHmm'
+    );
+});
+
 test('k and kk', function (assert) {
     assert.equal(moment('01:23:45', 'HH:mm:ss').format('k'), '1');
     assert.equal(moment('12:34:56', 'HH:mm:ss').format('k'), '12');

--- a/src/test/moment/weekday.js
+++ b/src/test/moment/weekday.js
@@ -46,6 +46,26 @@ test('iso weekday', function (assert) {
     }
 });
 
+test('compact locale weekday and time parsing', function (assert) {
+    moment.locale('en');
+
+    [false, true].forEach(function (strict) {
+        var compact = moment('21530', 'eHHmm', strict),
+            padded = moment('021530', 'eHHmm', strict),
+            mode = strict ? 'strict' : 'non-strict';
+
+        assert.ok(compact.isValid(), mode + ' compact input is valid');
+        assert.equal(compact.weekday(), 2, mode + ' compact weekday');
+        assert.equal(compact.hour(), 15, mode + ' compact hour');
+        assert.equal(compact.minute(), 30, mode + ' compact minute');
+
+        assert.ok(padded.isValid(), mode + ' padded input remains valid');
+        assert.equal(padded.weekday(), 2, mode + ' padded weekday');
+        assert.equal(padded.hour(), 15, mode + ' padded hour');
+        assert.equal(padded.minute(), 30, mode + ' padded minute');
+    });
+});
+
 test('iso weekday setter', function (assert) {
     var a = moment([2011, 0, 10]);
     assert.equal(moment(a).isoWeekday(1).date(), 10, 'set from mon to mon');


### PR DESCRIPTION
Adds dedicated `eHHmm` format and parsing support for compact locale weekday and time values. Inputs such as `21530` are now correctly parsed as locale weekday 2 at 15:30, while padded weekday inputs remain supported.

Escaped `e` tokens continue to behave as literals.

Includes regression tests and new benchmarks.

Fixes #6116.
Alternative approach to #6402.