### PR TITLE
[locale] Fix Uzbek past relative time

### DIFF
--- a/src/locale/uz-latn.js
+++ b/src/locale/uz-latn.js
@@ -33,7 +33,7 @@ export default moment.defineLocale('uz-latn', {
     },
     relativeTime: {
         future: 'Yaqin %s ichida',
-        past: 'Bir necha %s oldin',
+        past: '%s oldin',
         s: 'soniya',
         ss: '%d soniya',
         m: 'bir daqiqa',

--- a/src/locale/uz.js
+++ b/src/locale/uz.js
@@ -30,7 +30,7 @@ export default moment.defineLocale('uz', {
     },
     relativeTime: {
         future: 'Якин %s ичида',
-        past: 'Бир неча %s олдин',
+        past: '%s олдин',
         s: 'фурсат',
         ss: '%d фурсат',
         m: 'бир дакика',

--- a/src/test/locale/uz-latn.js
+++ b/src/test/locale/uz-latn.js
@@ -294,13 +294,14 @@ test('from', function (assert) {
 
 test('suffix', function (assert) {
     assert.equal(moment(30000).from(0), 'Yaqin soniya ichida', 'prefix');
-    assert.equal(moment(0).from(30000), 'Bir necha soniya oldin', 'suffix');
+    assert.equal(moment(0).from(30000), 'soniya oldin', 'suffix');
+    assert.equal(moment(0).from(5 * 864e5), '5 kun oldin', 'suffix with count');
 });
 
 test('now from now', function (assert) {
     assert.equal(
         moment().fromNow(),
-        'Bir necha soniya oldin',
+        'soniya oldin',
         'now from now should display as in the past'
     );
 });

--- a/src/test/locale/uz.js
+++ b/src/test/locale/uz.js
@@ -291,13 +291,14 @@ test('from', function (assert) {
 
 test('suffix', function (assert) {
     assert.equal(moment(30000).from(0), 'Якин фурсат ичида', 'prefix');
-    assert.equal(moment(0).from(30000), 'Бир неча фурсат олдин', 'suffix');
+    assert.equal(moment(0).from(30000), 'фурсат олдин', 'suffix');
+    assert.equal(moment(0).from(5 * 864e5), '5 кун олдин', 'suffix with count');
 });
 
 test('now from now', function (assert) {
     assert.equal(
         moment().fromNow(),
-        'Бир неча фурсат олдин',
+        'фурсат олдин',
         'now from now should display as in the past'
     );
 });


### PR DESCRIPTION
## Summary

Fix past relative-time formatting in the Uzbek Latin and Cyrillic locales.

The existing `Bir necha %s oldin` / `Бир неча %s олдин` wrappers add an indefinite quantity before every relative-time value. This produces incorrect counted phrases such as `Bir necha 5 kun oldin`. The equivalent mistake in English would be “a few 5 days ago.”

Remove that prefix so past values are formatted as `%s oldin` / `%s олдин`.

This incorporates the correction proposed by @Zukhrik in #6094, applying it to the authoritative source files with regression tests.

## Evidence

Current CLDR Uzbek data consistently formats past relative times as `{0} <unit> oldin`, without `bir necha`:

- [Years](https://github.com/unicode-org/cldr/blob/95f50133dc17b9d3e4cd355dbe4e30a1ccb1a185/common/main/uz.xml#L2437-L2446)
- [Days](https://github.com/unicode-org/cldr/blob/95f50133dc17b9d3e4cd355dbe4e30a1ccb1a185/common/main/uz.xml#L2611-L2620)
- [Hours](https://github.com/unicode-org/cldr/blob/95f50133dc17b9d3e4cd355dbe4e30a1ccb1a185/common/main/uz.xml#L2960-L2969)
- [Seconds](https://github.com/unicode-org/cldr/blob/95f50133dc17b9d3e4cd355dbe4e30a1ccb1a185/common/main/uz.xml#L3028-L3037)

The Uzbek explanatory dictionary also defines [`oldin`](https://izoh.uz/word/oldin) for prior time, while [`bir necha`](https://izoh.uz/word/necha) expresses an indefinite quantity.

## Testing

- `pnpm test -- --only=locale/uz`
- `pnpm test -- --only=locale/uz-latn`
- `pnpm validate`