### PR TITLE
[locale] Fix Polish month case for dotted day formats

### DIFF
--- a/src/locale/pl.js
+++ b/src/locale/pl.js
@@ -55,7 +55,7 @@ export default moment.defineLocale('pl', {
     months: function (momentToFormat, format) {
         if (!momentToFormat) {
             return monthsNominative;
-        } else if (/D MMMM/.test(format)) {
+        } else if (/D\.? MMMM/.test(format)) {
             return monthsSubjective[momentToFormat.month()];
         } else {
             return monthsNominative[momentToFormat.month()];

--- a/src/test/locale/pl.js
+++ b/src/test/locale/pl.js
@@ -109,6 +109,7 @@ test('format', function (assert) {
             ['M Mo MM MMMM MMM', '2 2. 02 luty lut'],
             ['YYYY YY', '2010 10'],
             ['D Do DD', '14 14. 14'],
+            ['D. MMMM', '14. lutego'],
             ['d do dddd ddd dd', '0 0. niedziela ndz Nd'],
             ['DDD DDDo DDDD', '45 45. 045'],
             ['w wo ww', '6 6. 06'],


### PR DESCRIPTION
## Summary

Use the Polish genitive month form when formatting `D. MMMM`, matching the existing behavior for `D MMMM`.

For example:

```js
moment([2010, 1, 14]).locale('pl').format('D. MMMM');
// Before: "14. luty"
// After:  "14. lutego"
```

This correction was originally proposed by @idoodler in #6101. This PR applies it to the authoritative source locale with regression coverage. Generated locale artifacts remain unchanged.

## Evidence

Unicode CLDR distinguishes between:

- [Format-context month names](https://github.com/unicode-org/cldr/blob/95f50133dc17b9d3e4cd355dbe4e30a1ccb1a185/common/main/pl.xml#L2018-L2031), which use genitive forms such as `lutego`.
- [Stand-alone month names](https://github.com/unicode-org/cldr/blob/95f50133dc17b9d3e4cd355dbe4e30a1ccb1a185/common/main/pl.xml#L2062-L2075), which use nominative forms such as `luty`.

CLDR's standard Polish long-date pattern is [`d MMMM y`](https://github.com/unicode-org/cldr/blob/95f50133dc17b9d3e4cd355dbe4e30a1ccb1a185/common/main/pl.xml#L2295-L2300).

The [Rada Języka Polskiego guidance on dates](https://rjp.pan.pl/zapis-dat/) supports written dates such as `24 kwietnia`. Its related [guidance about dots in written dates](https://rjp.pan.pl/zapis-dat-2/) indicates that a dot is normally unnecessary before a written month. Moment nevertheless permits custom formats, and adding the dot should not cause the month to change from genitive to nominative.

## Verification

- `pnpm test -- --only=locale/pl`
- `pnpm validate`