### PR TITLE
[bugfix] Ignore non-Moment arguments in min and max

### DIFF
--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -2,6 +2,7 @@ import { deprecate } from '../utils/deprecate';
 import isArray from '../utils/is-array';
 import { createLocal } from '../create/local';
 import { createInvalid } from '../create/valid';
+import { isMoment } from './constructor';
 
 export var prototypeMin = deprecate(
         'moment().min is deprecated, use moment.max instead. http://momentjs.com/guides/#/warnings/min-max/',
@@ -39,9 +40,20 @@ function pickBy(fn, moments) {
     if (!moments.length) {
         return createLocal();
     }
-    res = moments[0];
-    for (i = 1; i < moments.length; ++i) {
-        if (!moments[i].isValid() || moments[i][fn](res)) {
+    for (i = 0; i < moments.length; ++i) {
+        if (isMoment(moments[i])) {
+            res = moments[i];
+            break;
+        }
+    }
+    if (!res) {
+        return createInvalid();
+    }
+    for (++i; i < moments.length; ++i) {
+        if (
+            isMoment(moments[i]) &&
+            (!moments[i].isValid() || moments[i][fn](res))
+        ) {
             res = moments[i];
         }
     }

--- a/src/test/moment/min_max.js
+++ b/src/test/moment/min_max.js
@@ -70,3 +70,37 @@ test('max', function (assert) {
     assert.equal(moment.max([now, invalid]), invalid, 'max(now, invalid)');
     assert.equal(moment.max([invalid, now]), invalid, 'max(invalid, now)');
 });
+
+test('non-moment arguments', function (assert) {
+    var earlier = moment('2020-01-01'),
+        later = moment('2020-02-01'),
+        date = new Date(2020, 0, 15);
+
+    assert.equal(moment.min('no', later, null, earlier), earlier, 'min args');
+    assert.equal(moment.max(false, earlier, date, later), later, 'max args');
+    assert.equal(moment.min(later, date, earlier, 0), earlier, 'min positions');
+    assert.equal(moment.max(earlier, {}, later, 'no'), later, 'max positions');
+    assert.equal(moment.min([{}, later, earlier, date]), earlier, 'min array');
+    assert.equal(moment.max([date, earlier, later, 0]), later, 'max array');
+});
+
+test('only non-moment arguments', function (assert) {
+    assert.ok(moment.min().isValid(), 'min empty args');
+    assert.ok(moment.max().isValid(), 'max empty args');
+    assert.ok(moment.min([]).isValid(), 'min empty array');
+    assert.ok(moment.max([]).isValid(), 'max empty array');
+    assert.ok(!moment.min('no').isValid(), 'min one non-moment');
+    assert.ok(!moment.max(new Date()).isValid(), 'max one non-moment');
+    assert.ok(!moment.min('no', 0, null).isValid(), 'min non-moment args');
+    assert.ok(!moment.max([false, undefined, {}]).isValid(), 'max array');
+});
+
+test('non-moment arguments with invalid moments', function (assert) {
+    var valid = moment('2020-01-01'),
+        invalid = moment.invalid();
+
+    assert.equal(moment.min('no', valid, null, invalid), invalid, 'min');
+    assert.equal(moment.max(invalid, false, valid, {}), invalid, 'max');
+    assert.equal(moment.min([0, invalid, valid, 'no']), invalid, 'min array');
+    assert.equal(moment.max([valid, {}, invalid, null]), invalid, 'max array');
+});


### PR DESCRIPTION
`moment.min` and `moment.max` assumed every argument after the first was a Moment instance. Passing another date-like value, such as a native `Date`, caused an exception instead of selecting from the supplied Moments:

```js
var june = moment("2024-06-01");

moment.min(june, new Date(2024, 4, 1));
// TypeError: moments[i].isValid is not a function
```

The selection logic now finds the first actual Moment and compares only subsequent Moment instances, ignoring other values regardless of their position. Explicitly invalid Moments continue to propagate, while empty calls retain their existing behavior. Regression tests cover variadic and array inputs, ignored values in multiple positions, all-non-Moment inputs, and combinations containing invalid Moments.

```js
moment.min(june, new Date(2024, 4, 1), moment("2024-04-01"));
// moment("2024-04-01")
```

This is an in-scope maintenance fix for an existing API, not a new feature. It intentionally changes behavior only for unsupported non-Moment arguments: rather than returning a raw value or throwing depending on its position, those arguments are ignored. As a project maintainer, I approve this compatibility tradeoff because it replaces inconsistent accidental behavior with a predictable Moment result.

Fixes #6143.