### PR TITLE
[bugfix] Fix inherited lowercase long date formats

### DIFF
--- a/src/lib/locale/formats.js
+++ b/src/lib/locale/formats.js
@@ -11,13 +11,22 @@ export var defaultLongDateFormat = {
 
 export function longDateFormat(key) {
     var format = this._longDateFormat[key],
-        formatUpper = this._longDateFormat[key.toUpperCase()];
+        formatUpper = this._longDateFormat[key.toUpperCase()],
+        formatCache = this._longDateFormatCache;
 
     if (format || !formatUpper) {
         return format;
     }
 
-    this._longDateFormat[key] = formatUpper
+    if (
+        formatCache &&
+        formatCache[key] &&
+        formatCache[key].formatUpper === formatUpper
+    ) {
+        return formatCache[key].format;
+    }
+
+    format = formatUpper
         .match(formattingTokens)
         .map(function (tok) {
             if (
@@ -32,5 +41,12 @@ export function longDateFormat(key) {
         })
         .join('');
 
-    return this._longDateFormat[key];
+    if (!formatCache) {
+        formatCache = this._longDateFormatCache = {};
+    }
+    formatCache[key] = {
+        formatUpper: formatUpper,
+        format: format,
+    };
+    return format;
 }

--- a/src/test/moment/locale_inheritance.js
+++ b/src/test/moment/locale_inheritance.js
@@ -167,6 +167,46 @@ test('long date format', function (assert) {
     );
 });
 
+test('derived long date format', function (assert) {
+    moment.defineLocale('base-derived-ldf', {
+        longDateFormat: {
+            L: 'MM/DD/YYYY',
+            LL: 'MMMM D, YYYY',
+            LLL: 'MMMM D, YYYY h:mm A',
+            lll: '[parent] MMM D, YYYY h:mm A',
+        },
+    });
+
+    moment.localeData('base-derived-ldf').longDateFormat('l');
+    moment.localeData('base-derived-ldf').longDateFormat('ll');
+
+    moment.defineLocale('child-derived-ldf', {
+        parentLocale: 'base-derived-ldf',
+        longDateFormat: {
+            L: 'YYYY-MM-DD',
+            LL: 'D MMMM YYYY',
+            LLL: 'D MMMM YYYY HH:mm',
+        },
+    });
+
+    var anchor = moment.utc('2015-09-06T12:34:56', moment.ISO_8601);
+    assert.equal(
+        anchor.locale('child-derived-ldf').format('l'),
+        '2015-9-6',
+        'l is derived from the child format'
+    );
+    assert.equal(
+        anchor.locale('child-derived-ldf').format('ll'),
+        '6 Sep 2015',
+        'll is derived from the child format'
+    );
+    assert.equal(
+        anchor.locale('child-derived-ldf').format('lll'),
+        'parent Sep 6, 2015 12:34 PM',
+        'explicit parent lowercase format is inherited'
+    );
+});
+
 test('ordinal', function (assert) {
     moment.defineLocale('base-ordinal-1', {
         ordinal: '%dx',

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -166,6 +166,36 @@ test('long date format', function (assert) {
     );
 });
 
+test('update derived long date format', function (assert) {
+    moment.defineLocale('updated-derived-ldf', null);
+    moment.defineLocale('updated-derived-ldf', {
+        longDateFormat: {
+            L: 'MM/DD/YYYY',
+            LL: 'MMMM D, YYYY',
+        },
+    });
+
+    moment.localeData('updated-derived-ldf').longDateFormat('l');
+    moment.localeData('updated-derived-ldf').longDateFormat('ll');
+
+    moment.updateLocale('updated-derived-ldf', {
+        longDateFormat: {
+            L: 'YYYY-MM-DD',
+            LL: 'D MMMM YYYY',
+        },
+    });
+
+    var anchor = moment
+        .utc('2015-09-06T12:34:56', moment.ISO_8601)
+        .locale('updated-derived-ldf');
+    assert.equal(anchor.format('l'), '2015-9-6', 'l uses the updated format');
+    assert.equal(
+        anchor.format('ll'),
+        '6 Sep 2015',
+        'll uses the updated format'
+    );
+});
+
 test('ordinal', function (assert) {
     moment.defineLocale('ordinal-1', null);
     moment.defineLocale('ordinal-1', {


### PR DESCRIPTION
Derived lowercase long date formats were cached in the locale's configured
`longDateFormat` object. If a parent format had already been accessed, the
generated value could then be inherited by a child locale instead of being
derived from the child's uppercase format.

Store generated formats in a separate cache and validate them against their
uppercase source before reuse. Explicitly configured lowercase formats continue
to inherit normally.

Fixes #5381.