### PR TITLE
[bugfix] Reset locale parsing caches after updates

### DIFF
--- a/src/lib/locale/set.js
+++ b/src/lib/locale/set.js
@@ -2,9 +2,13 @@ import isFunction from '../utils/is-function';
 import extend from '../utils/extend';
 import isObject from '../utils/is-object';
 import hasOwnProp from '../utils/has-own-prop';
+import { clearMonthsParseCache } from '../units/month';
+import { clearWeekdaysParseCache } from '../units/day-of-week';
 
 export function set(config) {
     var prop, i;
+    clearMonthsParseCache(this, config);
+    clearWeekdaysParseCache(this, config);
     for (i in config) {
         if (hasOwnProp(config, i)) {
             prop = config[i];

--- a/src/lib/units/day-of-week.js
+++ b/src/lib/units/day-of-week.js
@@ -119,13 +119,35 @@ var defaultLocaleWeekdays =
     defaultLocaleWeekdaysMin = 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
     defaultWeekdaysRegex = matchWord,
     defaultWeekdaysShortRegex = matchWord,
-    defaultWeekdaysMinRegex = matchWord;
+    defaultWeekdaysMinRegex = matchWord,
+    weekdaysParseProperties = [
+        'weekdaysParse',
+        'fullWeekdaysParse',
+        'shortWeekdaysParse',
+        'minWeekdaysParse',
+        'weekdaysRegex',
+        'weekdaysShortRegex',
+        'weekdaysMinRegex',
+        'weekdaysStrictRegex',
+        'weekdaysShortStrictRegex',
+        'weekdaysMinStrictRegex',
+    ];
 
 export {
     defaultLocaleWeekdays,
     defaultLocaleWeekdaysShort,
     defaultLocaleWeekdaysMin,
 };
+
+export function clearWeekdaysParseCache(locale, config) {
+    var i, prop;
+    for (i = 0; i < weekdaysParseProperties.length; i++) {
+        prop = weekdaysParseProperties[i];
+        if (!hasOwnProp(config, prop)) {
+            delete locale['_' + prop];
+        }
+    }
+}
 
 export function localeWeekdays(m, format) {
     var weekdays = isArray(this._weekdays)

--- a/src/lib/units/month.js
+++ b/src/lib/units/month.js
@@ -83,9 +83,28 @@ var defaultLocaleMonths =
         'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'.split('_'),
     MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s)+MMMM?/,
     defaultMonthsShortRegex = matchWord,
-    defaultMonthsRegex = matchWord;
+    defaultMonthsRegex = matchWord,
+    monthsParseProperties = [
+        'monthsParse',
+        'longMonthsParse',
+        'shortMonthsParse',
+        'monthsRegex',
+        'monthsShortRegex',
+        'monthsStrictRegex',
+        'monthsShortStrictRegex',
+    ];
 
 export { defaultLocaleMonths, defaultLocaleMonthsShort };
+
+export function clearMonthsParseCache(locale, config) {
+    var i, prop;
+    for (i = 0; i < monthsParseProperties.length; i++) {
+        prop = monthsParseProperties[i];
+        if (!hasOwnProp(config, prop)) {
+            delete locale['_' + prop];
+        }
+    }
+}
 
 export function localeMonths(m, format) {
     if (!m) {

--- a/src/test/moment/locale_update.js
+++ b/src/test/moment/locale_update.js
@@ -3,6 +3,15 @@ import moment from '../../moment';
 
 module('locale update');
 
+function makeNames(prefix, count) {
+    var i,
+        names = [];
+    for (i = 0; i < count; i++) {
+        names.push(prefix + String.fromCharCode(65 + i));
+    }
+    return names;
+}
+
 test('calendar', function (assert) {
     moment.defineLocale('cal', null);
     moment.defineLocale('cal', {
@@ -194,6 +203,145 @@ test('update derived long date format', function (assert) {
         '6 Sep 2015',
         'll uses the updated format'
     );
+});
+
+test('update generated exact locale parsing', function (assert) {
+    var localeName = 'updated-exact-parse',
+        oldMonths = makeNames('OldMonth', 12),
+        oldMonthsShort = makeNames('OldMon', 12),
+        oldWeekdays = makeNames('OldWeekday', 7),
+        oldWeekdaysShort = makeNames('OldDay', 7),
+        oldWeekdaysMin = makeNames('OldD', 7),
+        newMonths = makeNames('NewMonth', 12),
+        newMonthsShort = makeNames('NewMon', 12),
+        newWeekdays = makeNames('NewWeekday', 7),
+        newWeekdaysShort = makeNames('NewDay', 7),
+        newWeekdaysMin = makeNames('NewD', 7);
+
+    moment.defineLocale(localeName, null);
+    moment.defineLocale(localeName, {
+        months: oldMonths,
+        monthsShort: oldMonthsShort,
+        monthsParseExact: true,
+        weekdays: oldWeekdays,
+        weekdaysShort: oldWeekdaysShort,
+        weekdaysMin: oldWeekdaysMin,
+        weekdaysParseExact: true,
+    });
+    moment.updateLocale(localeName, { week: { dow: 1 } });
+
+    assert.ok(moment(oldMonths[0], 'MMMM', localeName, true).isValid());
+    assert.ok(moment(oldMonthsShort[0], 'MMM', localeName, true).isValid());
+    assert.ok(moment(oldWeekdays[0], 'dddd', localeName, true).isValid());
+    assert.ok(moment(oldWeekdaysShort[0], 'ddd', localeName, true).isValid());
+    assert.ok(moment(oldWeekdaysMin[0], 'dd', localeName, true).isValid());
+
+    moment.updateLocale(localeName, {
+        months: newMonths,
+        monthsShort: newMonthsShort,
+        weekdays: newWeekdays,
+        weekdaysShort: newWeekdaysShort,
+        weekdaysMin: newWeekdaysMin,
+    });
+
+    assert.ok(moment(newMonths[0], 'MMMM', localeName, true).isValid());
+    assert.ok(moment(newMonthsShort[0], 'MMM', localeName, true).isValid());
+    assert.ok(moment(newWeekdays[0], 'dddd', localeName, true).isValid());
+    assert.ok(moment(newWeekdaysShort[0], 'ddd', localeName, true).isValid());
+    assert.ok(moment(newWeekdaysMin[0], 'dd', localeName, true).isValid());
+    assert.notOk(moment(oldMonths[0], 'MMMM', localeName, true).isValid());
+    assert.notOk(moment(oldMonthsShort[0], 'MMM', localeName, true).isValid());
+    assert.notOk(moment(oldWeekdays[0], 'dddd', localeName, true).isValid());
+    assert.notOk(
+        moment(oldWeekdaysShort[0], 'ddd', localeName, true).isValid()
+    );
+    assert.notOk(moment(oldWeekdaysMin[0], 'dd', localeName, true).isValid());
+
+    moment.defineLocale(localeName, null);
+});
+
+test('update generated inexact locale parsing to exact', function (assert) {
+    var localeName = 'updated-inexact-parse',
+        oldMonths = makeNames('OldMonth', 12),
+        oldMonthsShort = makeNames('OldMon', 12),
+        oldWeekdays = makeNames('OldWeekday', 7),
+        oldWeekdaysShort = makeNames('OldDay', 7),
+        oldWeekdaysMin = makeNames('OldD', 7),
+        newMonths = makeNames('NewMonth', 12),
+        newMonthsShort = makeNames('NewMon', 12),
+        newWeekdays = makeNames('NewWeekday', 7),
+        newWeekdaysShort = makeNames('NewDay', 7),
+        newWeekdaysMin = makeNames('NewD', 7);
+
+    moment.defineLocale(localeName, null);
+    moment.defineLocale(localeName, {
+        months: oldMonths,
+        monthsShort: oldMonthsShort,
+        weekdays: oldWeekdays,
+        weekdaysShort: oldWeekdaysShort,
+        weekdaysMin: oldWeekdaysMin,
+    });
+    moment.updateLocale(localeName, { week: { dow: 1 } });
+
+    assert.ok(moment(oldMonths[0], 'MMMM', localeName, true).isValid());
+    assert.ok(moment(oldMonthsShort[0], 'MMM', localeName, true).isValid());
+    assert.ok(moment(oldWeekdays[0], 'dddd', localeName, true).isValid());
+    assert.ok(moment(oldWeekdaysShort[0], 'ddd', localeName, true).isValid());
+    assert.ok(moment(oldWeekdaysMin[0], 'dd', localeName, true).isValid());
+    assert.ok(moment(oldMonths[0], 'MMMM', localeName).isValid());
+    assert.ok(moment(oldWeekdays[0], 'dddd', localeName).isValid());
+
+    moment.updateLocale(localeName, {
+        months: newMonths,
+        monthsShort: newMonthsShort,
+        monthsParseExact: true,
+        weekdays: newWeekdays,
+        weekdaysShort: newWeekdaysShort,
+        weekdaysMin: newWeekdaysMin,
+        weekdaysParseExact: true,
+    });
+
+    assert.ok(moment(newMonths[0], 'MMMM', localeName, true).isValid());
+    assert.ok(moment(newMonthsShort[0], 'MMM', localeName, true).isValid());
+    assert.ok(moment(newWeekdays[0], 'dddd', localeName, true).isValid());
+    assert.ok(moment(newWeekdaysShort[0], 'ddd', localeName, true).isValid());
+    assert.ok(moment(newWeekdaysMin[0], 'dd', localeName, true).isValid());
+    assert.notOk(moment(oldMonths[0], 'MMMM', localeName, true).isValid());
+    assert.notOk(moment(oldMonthsShort[0], 'MMM', localeName, true).isValid());
+    assert.notOk(moment(oldWeekdays[0], 'dddd', localeName, true).isValid());
+    assert.notOk(
+        moment(oldWeekdaysShort[0], 'ddd', localeName, true).isValid()
+    );
+    assert.notOk(moment(oldWeekdaysMin[0], 'dd', localeName, true).isValid());
+
+    moment.defineLocale(localeName, null);
+});
+
+test('preserve configured locale parsing', function (assert) {
+    var localeName = 'configured-parse',
+        monthsParse = [/^month$/i],
+        monthsRegex = /^month/i,
+        weekdaysParse = [/^weekday$/i],
+        weekdaysRegex = /^weekday/i,
+        locale;
+
+    moment.defineLocale(localeName, null);
+    moment.defineLocale(localeName, {
+        monthsParse: monthsParse,
+        monthsRegex: monthsRegex,
+        weekdaysParse: weekdaysParse,
+        weekdaysRegex: weekdaysRegex,
+    });
+    moment.updateLocale(localeName, { week: { dow: 1 } });
+    moment.updateLocale(localeName, { week: { doy: 4 } });
+
+    locale = moment.localeData(localeName);
+    assert.strictEqual(locale._monthsParse, monthsParse);
+    assert.strictEqual(locale._monthsRegex, monthsRegex);
+    assert.strictEqual(locale._weekdaysParse, weekdaysParse);
+    assert.strictEqual(locale._weekdaysRegex, weekdaysRegex);
+
+    moment.defineLocale(localeName, null);
 });
 
 test('ordinal', function (assert) {


### PR DESCRIPTION
Month and weekday parsing data is generated lazily and retained on the locale.
When repeated `updateLocale` calls update that locale in place, the generated
data can continue recognizing previous names while rejecting the updated names.

Clear generated month and weekday parsing state when locale configuration is
reapplied. Explicitly configured parse arrays and regular expressions remain
unchanged.

Fixes #6435.