### PR TITLE
[bugfix] weekday mismatch when the format only has part of a date

### DIFF
--- a/src/lib/create/from-array.js
+++ b/src/lib/create/from-array.js
@@ -42,7 +42,8 @@ export function configFromArray(config) {
         input = [],
         currentDate,
         expectedWeekday,
-        yearToUse;
+        yearToUse,
+        dateIsDefaulted;
 
     if (config._d) {
         return;
@@ -70,6 +71,11 @@ export function configFromArray(config) {
         config._a[MONTH] = date.getUTCMonth();
         config._a[DATE] = date.getUTCDate();
     }
+
+    dateIsDefaulted =
+        config._a[YEAR] == null ||
+        config._a[MONTH] == null ||
+        config._a[DATE] == null;
 
     // Default to current date.
     // * if no year, month, day of month are given, default to today
@@ -119,6 +125,7 @@ export function configFromArray(config) {
     if (
         config._w &&
         typeof config._w.d !== 'undefined' &&
+        !dateIsDefaulted &&
         config._w.d !== expectedWeekday
     ) {
         getParsingFlags(config).weekdayMismatch = true;

--- a/src/test/moment/parsing_flags.js
+++ b/src/test/moment/parsing_flags.js
@@ -432,3 +432,52 @@ test('weekday mismatch', function (assert) {
         'day of week matches date'
     );
 });
+
+test('weekday with partial date is not a mismatch', function (assert) {
+    var i,
+        weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        partialFormats = ['ddd DD', 'ddd MM', 'ddd MM-DD'],
+        j,
+        input;
+
+    for (i = 0; i < weekdays.length; i++) {
+        for (j = 0; j < partialFormats.length; j++) {
+            input = partialFormats[j]
+                .replace('ddd', weekdays[i])
+                .replace('MM', '01')
+                .replace('DD', '10');
+            assert.equal(
+                flags(input, partialFormats[j]).weekdayMismatch,
+                false,
+                input + ' with ' + partialFormats[j] + ' is not a mismatch'
+            );
+            assert.equal(
+                moment(input, partialFormats[j]).isValid(),
+                true,
+                input + ' with ' + partialFormats[j] + ' is valid'
+            );
+        }
+    }
+});
+
+test('weekday round trip through format', function (assert) {
+    var formats = [
+            'ddd',
+            'DD',
+            'ddd DD',
+            'ddd MM',
+            'ddd MM-DD',
+            'ddd MM-DD-YYYY',
+        ],
+        i,
+        formatted;
+
+    for (i = 0; i < formats.length; i++) {
+        formatted = moment.utc('2015-01-10T01:15Z').format(formats[i]);
+        assert.equal(
+            moment(formatted, formats[i]).isValid(),
+            true,
+            formats[i] + ' round trips to a valid moment'
+        );
+    }
+});


### PR DESCRIPTION
Fixes #6228

Parsing a weekday together with an incomplete date gives back an invalid moment:

    moment('Sat 10', 'ddd DD').isValid()  // false
    moment('Sat 01', 'ddd MM').isValid()  // false

while 'ddd', 'DD' and 'ddd YYYY' on their own all parse fine. That means
format() and then parse with the same format does not round trip, which is
how the issue was found.

The cause is in configFromArray. The parsed weekday is only used to build a
date when neither day of month nor month was parsed. With 'ddd DD' the day
of month is set, so the weekday never contributes anything, the year and
month quietly default to today, and then the weekday gets compared against
whatever date those defaults produced. Today is August, day 10 is a Monday,
so 'Sat 10' is reported as a mismatch. The result also depends on the day
you run it, which is why 'Mon 10' happens to work right now.

The fix records whether any of year, month or day of month had to be filled
in from the current date, and only runs the mismatch check when the whole
date actually came from the input. A weekday cannot contradict a value the
user never supplied.

Behavior that people rely on is unchanged. A full date with the wrong
weekday is still rejected:

    moment('Wed 08-10-2017', 'ddd MM-DD-YYYY').isValid()  // false
    moment('Thu 08-10-2017', 'ddd MM-DD-YYYY').isValid()  // true

The invalidWeekday flag is a separate thing and is untouched, so
moment('a', 'ddd') is still invalid. Week based formats such as
'gggg ww e' and 'GGGG [W]WW E' go through the day of year path before the
snapshot is taken, so they are unaffected.

To check for regressions beyond the suite I diffed the released build
against the patched source over 23 formats crossed with 25 inputs in both
strict and non strict mode, 1150 cases. There were 63 differences and every
one of them went from invalid to valid. Nothing went the other way, and no
moment that was already valid changed its parsed value. The only visible
change is that input which used to be rejected now parses.

Tests: added two cases to src/test/moment/parsing_flags.js. One walks all
seven weekdays across 'ddd DD', 'ddd MM' and 'ddd MM-DD' and asserts no
mismatch flag and a valid moment. The other is the round trip from the
issue report. Full suite passes, 3911 tests and 164038 assertions with no
failures. eslint and prettier are clean.