### PR TITLE
[bugfix] Fix locale('__proto__') corrupting the global locale

### DIFF
--- a/src/lib/locale/locales.js
+++ b/src/lib/locale/locales.js
@@ -1,5 +1,6 @@
 import isArray from '../utils/is-array';
 import isUndefined from '../utils/is-undefined';
+import hasOwnProp from '../utils/has-own-prop';
 import { deprecateSimple } from '../utils/deprecate';
 import { mergeConfigs } from './set';
 import { Locale } from './constructor';
@@ -73,12 +74,15 @@ function loadLocale(name) {
         normalizedName;
 
     // Preserve exact custom locale names before trying the canonical built-in name.
-    if (locales[name] !== undefined) {
+    // Use hasOwnProp rather than a plain lookup so that names like "__proto__",
+    // "constructor", or "prototype" can't resolve to an inherited Object.prototype
+    // property instead of a real (or missing) locale entry.
+    if (hasOwnProp(locales, name)) {
         return locales[name];
     }
 
     normalizedName = normalizeLocale(name);
-    if (locales[normalizedName] !== undefined) {
+    if (hasOwnProp(locales, normalizedName)) {
         return locales[normalizedName];
     }
 

--- a/src/test/moment/locale.js
+++ b/src/test/moment/locale.js
@@ -1070,3 +1070,34 @@ test('when in strict mode with inexact parsing, treat periods in min-weekdays li
 //     assert.equal(moment('EE', 'MMMM').month(), 1, 'non-strict parse short month 1 with MMMM');
 //     assert.equal(moment('EEE', 'MMMM').month(), 2, 'non-strict parse short month 2 with MMMM');
 // });
+
+test('locale(name) with an Object.prototype property name does not corrupt the global locale', function (assert) {
+    var originalLocale = moment.locale();
+
+    each(
+        ['__proto__', 'constructor', 'prototype', 'toString'],
+        function (name) {
+            moment.locale('en');
+            moment.locale(name);
+            assert.equal(
+                moment.locale(),
+                'en',
+                'locale(' + name + ') should not change the current locale'
+            );
+            assert.equal(
+                typeof moment().format,
+                'function',
+                'formatting should still work after locale(' + name + ')'
+            );
+            assert.equal(
+                moment().format('LLLL'),
+                moment().locale('en').format('LLLL'),
+                'the global locale data should still behave like a real Locale after locale(' +
+                    name +
+                    ')'
+            );
+        }
+    );
+
+    moment.locale(originalLocale);
+});


### PR DESCRIPTION
Reported in #6440. `loadLocale()` checks whether a name is already loaded with `locales[name] !== undefined`, and since `locales` is a plain object, that lookup falls through to `Object.prototype` for names like `__proto__`, `constructor`, or `prototype`. The result then gets assigned as the global locale by `getSetGlobalLocale`, and every later call to `format`/`calendar`/`fromNow` throws because `Object.prototype` obviously isn't a real `Locale`.

Repro against current develop:

```js
const moment = require('moment');
moment.locale('__proto__');
moment().format('LLLL'); // TypeError: locale.longDateFormat is not a function
```

The fix swaps both lookups in `loadLocale` to use the existing `hasOwnProp` helper (already used elsewhere in this file) instead of a plain property check, so an own-property-only lookup treats these names the same as any other locale that was never registered: not found, warn, keep the current locale.

Added a regression test in `src/test/moment/locale.js` covering `__proto__`, `constructor`, `prototype`, and `toString`. Ran `pnpm validate` (lint + full suite, 3930 tests / 164926 assertions) clean.