### PR TITLE
[bugfix] Avoid Object.assign in duration.humanize

### DIFF
--- a/src/lib/duration/humanize.js
+++ b/src/lib/duration/humanize.js
@@ -1,4 +1,5 @@
 import { createDuration } from './create';
+import extend from '../utils/extend';
 
 var round = Math.round,
     thresholds = {
@@ -97,7 +98,7 @@ export function humanize(argWithSuffix, argThresholds) {
         withSuffix = argWithSuffix;
     }
     if (typeof argThresholds === 'object') {
-        th = Object.assign({}, thresholds, argThresholds);
+        th = extend(extend({}, thresholds), argThresholds || {});
         if (argThresholds.s != null && argThresholds.ss == null) {
             th.ss = argThresholds.s - 1;
         }

--- a/src/test/moment/duration.js
+++ b/src/test/moment/duration.js
@@ -1180,6 +1180,21 @@ test('humanize duration with thresholds', function (assert) {
     );
 });
 
+test('humanize duration with thresholds without Object.assign', function (assert) {
+    var objectAssign = Object.assign;
+
+    try {
+        Object.assign = undefined;
+        assert.equal(
+            moment.duration({ weeks: 3 }).humanize({ d: 7, w: 4 }),
+            '3 weeks',
+            'custom thresholds work without Object.assign'
+        );
+    } finally {
+        Object.assign = objectAssign;
+    }
+});
+
 test('bubble value up', function (assert) {
     assert.equal(
         moment.duration({ milliseconds: 61001 }).milliseconds(),


### PR DESCRIPTION
Replace the Object.assign call used by duration.humanize with Moment's existing extend utility.

Object.assign is not available in legacy runtimes supported by Moment, including Internet Explorer. Since Moment source files are bundled but not polyfilled or transpiled for missing built-ins, duration.humanize({...}) could throw when custom thresholds were provided.
